### PR TITLE
fix(rpc): return parsed JSON for token accounts in getAccountInfo jsonParsed encoding

### DIFF
--- a/core/src/rpc/get_account_info_impl.rs
+++ b/core/src/rpc/get_account_info_impl.rs
@@ -6,13 +6,18 @@ use crate::{
     },
 };
 use jsonrpsee::core::RpcResult;
-use solana_account_decoder::encode_ui_account;
+use solana_account_decoder::{
+    encode_ui_account,
+    parse_account_data::{AccountAdditionalDataV3, SplTokenAdditionalDataV2},
+};
 use solana_account_decoder_client_types::{UiAccount, UiAccountEncoding};
 use solana_client::{
     rpc_config::RpcAccountInfoConfig,
     rpc_response::{Response, RpcResponseContext},
 };
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{account::AccountSharedData, account::ReadableAccount, pubkey::Pubkey};
+use spl_token::solana_program::program_pack::Pack;
+use spl_token::state::{Account as TokenAccount, Mint};
 use std::str::FromStr;
 use tracing::debug;
 
@@ -40,13 +45,49 @@ pub async fn get_account_info_impl(
     };
 
     let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base64);
-    let value = account_data
-        .map(|account| encode_ui_account(&pubkey, &account, encoding, None, config.data_slice));
+
+    let additional_data = if encoding == UiAccountEncoding::JsonParsed {
+        build_token_additional_data(read_deps, account_data.as_ref()).await
+    } else {
+        None
+    };
+
+    let value = account_data.map(|account| {
+        encode_ui_account(
+            &pubkey,
+            &account,
+            encoding,
+            additional_data,
+            config.data_slice,
+        )
+    });
 
     debug!("get_account_info pubkey={} hit={}", pubkey, value.is_some());
 
     Ok(Response {
         context: RpcResponseContext::new(slot),
         value,
+    })
+}
+
+async fn build_token_additional_data(
+    read_deps: &ReadDeps,
+    account: Option<&AccountSharedData>,
+) -> Option<AccountAdditionalDataV3> {
+    let account = account?;
+    if *account.owner() != spl_token::id() {
+        return None;
+    }
+    let token_account = TokenAccount::unpack(account.data()).ok()?;
+    let mint_account = read_deps
+        .accounts_db
+        .get_account_shared_data(&token_account.mint)
+        .await?;
+    let mint = Mint::unpack(mint_account.data()).ok()?;
+    Some(AccountAdditionalDataV3 {
+        spl_token_additional_data: Some(SplTokenAdditionalDataV2 {
+            decimals: mint.decimals,
+            ..Default::default()
+        }),
     })
 }

--- a/core/src/rpc/simulate_transaction_impl.rs
+++ b/core/src/rpc/simulate_transaction_impl.rs
@@ -11,7 +11,10 @@ use crate::{
 use base64::{engine::general_purpose::STANDARD, Engine};
 use bincode::Options;
 use jsonrpsee::core::RpcResult;
-use solana_account_decoder::encode_ui_account;
+use solana_account_decoder::{
+    encode_ui_account,
+    parse_account_data::{AccountAdditionalDataV3, SplTokenAdditionalDataV2},
+};
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_rpc_client_types::{
     config::RpcSimulateTransactionConfig,
@@ -19,6 +22,7 @@ use solana_rpc_client_types::{
 };
 use solana_runtime_transaction::runtime_transaction::RuntimeTransaction;
 use solana_sdk::{
+    account::ReadableAccount,
     message::{v0::LoadedAddresses, SimpleAddressLoader},
     pubkey::Pubkey,
     transaction::{MessageHash, VersionedTransaction},
@@ -29,6 +33,8 @@ use solana_transaction_status::{
     UiCompiledInstruction, UiInnerInstructions, UiInstruction, UiReturnDataEncoding,
     UiTransactionEncoding, UiTransactionReturnData,
 };
+use spl_token::solana_program::program_pack::Pack;
+use spl_token::state::{Account as TokenAccount, Mint};
 use std::{collections::HashSet, str::FromStr, sync::Arc};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
@@ -188,11 +194,20 @@ pub async fn simulate_transaction(
                                             .bob
                                             .get_account_shared_data(&pubkey)
                                             .map(|account_shared_data| {
+                                                let additional_data =
+                                                    if encoding == UiAccountEncoding::JsonParsed {
+                                                        build_token_additional_data(
+                                                            Some(&account_shared_data),
+                                                            &execution_deps.bob,
+                                                        )
+                                                    } else {
+                                                        None
+                                                    };
                                                 encode_ui_account(
                                                     &pubkey,
                                                     &account_shared_data,
                                                     encoding,
-                                                    None,
+                                                    additional_data,
                                                     None,
                                                 )
                                             }),
@@ -293,5 +308,32 @@ pub async fn simulate_transaction(
     Ok(Response {
         context: RpcResponseContext::new(slot),
         value,
+    })
+}
+
+fn build_token_additional_data(
+    account: Option<&solana_sdk::account::AccountSharedData>,
+    bob: &impl TransactionProcessingCallback,
+) -> Option<AccountAdditionalDataV3> {
+    let account = account?;
+    if *account.owner() != spl_token::id() {
+        return None;
+    }
+    let token_account = TokenAccount::unpack(account.data()).ok()?;
+    let mint_account = bob
+        .get_account_shared_data(&token_account.mint)
+        .or_else(|| {
+            warn!(
+                "mint account {} not found for jsonParsed encoding, falling back to base64",
+                token_account.mint
+            );
+            None
+        })?;
+    let mint = Mint::unpack(mint_account.data()).ok()?;
+    Some(AccountAdditionalDataV3 {
+        spl_token_additional_data: Some(SplTokenAdditionalDataV2 {
+            decimals: mint.decimals,
+            ..Default::default()
+        }),
     })
 }

--- a/core/src/rpc/simulate_transaction_impl.rs
+++ b/core/src/rpc/simulate_transaction_impl.rs
@@ -320,15 +320,7 @@ fn build_token_additional_data(
         return None;
     }
     let token_account = TokenAccount::unpack(account.data()).ok()?;
-    let mint_account = bob
-        .get_account_shared_data(&token_account.mint)
-        .or_else(|| {
-            warn!(
-                "mint account {} not found for jsonParsed encoding, falling back to base64",
-                token_account.mint
-            );
-            None
-        })?;
+    let mint_account = bob.get_account_shared_data(&token_account.mint)?;
     let mint = Mint::unpack(mint_account.data()).ok()?;
     Some(AccountAdditionalDataV3 {
         spl_token_additional_data: Some(SplTokenAdditionalDataV2 {


### PR DESCRIPTION
## Summary
- `getAccountInfo` and `simulateTransaction` with `encoding: "jsonParsed"` silently return base64 for SPL token accounts instead of parsed JSON
- Root cause: `encode_ui_account` receives `None` for `additional_data`, but the upstream parser (`parse_token_v3`) requires mint decimals to parse token accounts — on failure it falls back to base64
- Fix: when `jsonParsed` is requested and the account is owned by SPL Token, fetch the mint account to obtain decimals and pass them via `AccountAdditionalDataV3`

## Reproduction
```
curl -X POST http://localhost:8899 -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"getAccountInfo",
       "params":["<any-token-ATA>",{"encoding":"jsonParsed"}]}'
```

Before fix: `["aDOoHy...", "base64"]`
After fix: `{"parsed": {"info": {"mint": "...", "owner": "...", "tokenAmount": {...}}, "type": "account"}, "program": "spl-token"}`

Note: mint accounts already parse correctly (no decimals needed for that path).

## Scope
This fix covers classic SPL Token accounts only. Token-2022 is not registered in Contra's SVM (`processor.rs`) and `spl-token-2022` is not a dependency of `contra-core`, so Token-2022 accounts cannot exist on L2. Token-2022 support can be added when the program is registered in the SVM.

## Test plan
- [x] `cargo check -p contra-core` passes
- [x] `getAccountInfo` with `jsonParsed` on token account returns parsed JSON
- [x] `getAccountInfo` with `jsonParsed` on mint account still works
- [x] `getAccountInfo` with `base64` encoding unchanged
- [x] Non-token accounts (system) unaffected