### PR TITLE
fix(indexer): seed live datasource from durable backfill frontier (SO…

### DIFF
--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -47,6 +47,8 @@ pub struct YellowstoneSource {
     batch_size: usize,
     #[cfg(feature = "datasource-rpc")]
     storage: Option<Arc<Storage>>,
+    #[cfg(feature = "datasource-rpc")]
+    initial_gap_floor: Option<u64>,
     health: Option<Arc<private_channel_metrics::HealthState>>,
 }
 
@@ -72,12 +74,23 @@ impl YellowstoneSource {
             batch_size: 0,
             #[cfg(feature = "datasource-rpc")]
             storage: None,
+            #[cfg(feature = "datasource-rpc")]
+            initial_gap_floor: None,
             health: None,
         }
     }
 
     pub fn with_health(mut self, health: Arc<private_channel_metrics::HealthState>) -> Self {
         self.health = Some(health);
+        self
+    }
+
+    /// Durable frontier to backfill up to once at startup, before the first
+    /// subscription, so the live tip can't leapfrog the backfill->live handoff.
+    /// `None` (a fresh node) runs no initial fill.
+    #[cfg(feature = "datasource-rpc")]
+    pub fn with_initial_gap_floor(mut self, floor: Option<u64>) -> Self {
+        self.initial_gap_floor = floor;
         self
     }
 
@@ -191,8 +204,51 @@ impl DataSource for YellowstoneSource {
         let batch_size = self.batch_size;
         #[cfg(feature = "datasource-rpc")]
         let storage = self.storage.clone();
+        #[cfg(feature = "datasource-rpc")]
+        let initial_gap_floor = self.initial_gap_floor;
 
         let handle = tokio::spawn(async move {
+            // One-shot startup gap-fill before the first subscription: the gRPC
+            // stream begins at the live tip, so without this the slots between
+            // the backfill target and the first streamed slot are covered by
+            // neither path (SOLA6-10). Reuses the reconnect machinery; the floor
+            // already carries the durable checkpoint, so storage is only a
+            // presence guard (gap detection wired) and isn't re-read. A fill
+            // failure must degrade to streaming, never skip it, so no `?`.
+            #[cfg(feature = "datasource-rpc")]
+            if let Some(floor) = initial_gap_floor {
+                if let (Some(ref poller), Some(_)) = (&rpc_poller, &storage) {
+                    match try_fill_reconnect_gap(
+                        floor,
+                        poller,
+                        max_gap_slots,
+                        batch_size,
+                        program_type,
+                        escrow_instance_id,
+                        &tx,
+                    )
+                    .await
+                    {
+                        Ok(filled) => {
+                            if filled > 0 {
+                                info!(
+                                    "Startup gap-fill complete: {} slots backfilled \
+                                     (from frontier {})",
+                                    filled, floor
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Startup gap-fill failed (frontier: {}): {}. \
+                                 Proceeding to stream.",
+                                floor, e
+                            );
+                        }
+                    }
+                }
+            }
+
             loop {
                 if cancellation_token.is_cancelled() {
                     info!("Yellowstone source received cancellation signal, stopping...");

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -14,6 +14,9 @@ use crate::{
 use crate::indexer::backfill::BackfillService;
 
 #[cfg(feature = "datasource-rpc")]
+use crate::indexer::checkpoint::get_last_checkpoint;
+
+#[cfg(feature = "datasource-rpc")]
 use crate::indexer::datasource::rpc_polling::{rpc::RpcPoller, RpcPollingSource};
 
 #[cfg(feature = "datasource-yellowstone")]
@@ -24,6 +27,37 @@ use tokio::signal;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
+
+/// The durable frontier the live datasource must resume from: a resolved
+/// backfill gap target dominates, else the committed checkpoint, else `None`
+/// for a genuinely fresh node (checkpoint 0, no gap) so we never replay genesis.
+#[cfg(feature = "datasource-rpc")]
+fn durable_frontier(resolved_gap_target: Option<u64>, committed_checkpoint: u64) -> Option<u64> {
+    match resolved_gap_target {
+        Some(target) => Some(target),
+        None if committed_checkpoint > 0 => Some(committed_checkpoint),
+        None => None,
+    }
+}
+
+/// Slot the live RPC poller seeds at, one past the durable frontier so the
+/// backfill->live handoff is contiguous and cannot leapfrog an unfilled slot.
+/// A resolved gap dominates a stale `from_slot` (the bug); an explicit
+/// `from_slot` is honored only when no gap was resolved; a fresh node returns
+/// `None` so the poller seeds at the live tip rather than from genesis.
+#[cfg(feature = "datasource-rpc")]
+fn rpc_live_from_slot(
+    resolved_gap_target: Option<u64>,
+    config_from_slot: Option<u64>,
+    committed_checkpoint: u64,
+) -> Option<u64> {
+    match (resolved_gap_target, config_from_slot, committed_checkpoint) {
+        (Some(target), _, _) => Some(target + 1),
+        (None, Some(configured), _) => Some(configured),
+        (None, None, cp) if cp > 0 => Some(cp + 1),
+        (None, None, _) => None,
+    }
+}
 
 pub async fn run(
     common_config: PrivateChannelIndexerConfig,
@@ -97,6 +131,11 @@ pub async fn run(
     //    no live-tip slot can slip past it and push the checkpoint over the gap.
     let mut checkpoint_writer = CheckpointWriter::new(storage.clone());
 
+    // The inclusive backfill target when a gap is resolved; seeds the live
+    // datasource so it resumes contiguously instead of from an independent tip.
+    #[cfg(feature = "datasource-rpc")]
+    let mut resolved_gap_target: Option<u64> = None;
+
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -156,6 +195,7 @@ pub async fn run(
                 match backfill_service.resolve_range().await {
                     Ok(Some((from_slot, target))) => {
                         checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
+                        resolved_gap_target = Some(target);
                         let instruction_tx_clone = instruction_tx.clone();
                         tokio::spawn(async move {
                             if let Err(e) = backfill_service
@@ -187,6 +227,14 @@ pub async fn run(
     let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
     info!("CheckpointWriter service started");
 
+    // Resolve the durable frontier that seeds the live datasource. Read the
+    // committed checkpoint once (the processor, its only producer, starts last,
+    // so no update has flowed yet); fail closed via `?` rather than mis-seed.
+    #[cfg(feature = "datasource-rpc")]
+    let committed_checkpoint = get_last_checkpoint(&storage, common_config.program_type).await?;
+    #[cfg(feature = "datasource-rpc")]
+    let frontier = durable_frontier(resolved_gap_target, committed_checkpoint);
+
     // 6. Start datasource
     let mut datasource: Box<dyn DataSource> = match indexer_config.datasource_type {
         #[cfg(feature = "datasource-rpc")]
@@ -199,7 +247,11 @@ pub async fn run(
 
             let mut source = RpcPollingSource::new(
                 common_config.rpc_url.clone(),
-                rpc_config.from_slot,
+                rpc_live_from_slot(
+                    resolved_gap_target,
+                    rpc_config.from_slot,
+                    committed_checkpoint,
+                ),
                 rpc_config.poll_interval_ms,
                 rpc_config.error_retry_interval_ms,
                 rpc_config.batch_size,
@@ -270,6 +322,7 @@ pub async fn run(
                         indexer_config.backfill.batch_size,
                     )
                     .with_storage(storage.clone())
+                    .with_initial_gap_floor(frontier)
             };
 
             let source = if let Some(h) = health.clone() {
@@ -344,4 +397,43 @@ pub async fn run(
 
     info!("Indexer shutdown complete");
     Ok(())
+}
+
+#[cfg(all(test, feature = "datasource-rpc"))]
+mod tests {
+    use super::{durable_frontier, rpc_live_from_slot};
+
+    // T0 inclusive backfill target; CP a prior durable checkpoint; CFG a stale
+    // operator-set from_slot. Distinct values so a regressed branch can't alias.
+    const T0: u64 = 110;
+    const CP: u64 = 90;
+    const CFG: u64 = 500;
+
+    #[test]
+    fn rpc_live_from_slot_covers_every_case() {
+        let cases = [
+            // (resolved_gap_target, config_from_slot, checkpoint, expected)
+            (Some(T0), None, 0, Some(T0 + 1)),
+            (Some(T0), Some(CFG), CP, Some(T0 + 1)),
+            (None, Some(CFG), CP, Some(CFG)),
+            (None, None, CP, Some(CP + 1)),
+            (None, None, 0, None),
+            (None, Some(CFG), 0, Some(CFG)),
+        ];
+        for (gap, cfg, cp, expected) in cases {
+            assert_eq!(
+                rpc_live_from_slot(gap, cfg, cp),
+                expected,
+                "gap={gap:?} cfg={cfg:?} cp={cp}"
+            );
+        }
+    }
+
+    #[test]
+    fn durable_frontier_covers_every_case() {
+        assert_eq!(durable_frontier(Some(T0), 0), Some(T0));
+        assert_eq!(durable_frontier(Some(T0), CP), Some(T0));
+        assert_eq!(durable_frontier(None, CP), Some(CP));
+        assert_eq!(durable_frontier(None, 0), None);
+    }
 }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -107,6 +107,14 @@ path = "tests/indexer/malformed_yellowstone_update.rs"
 name = "yellowstone_reconnect_gap"
 path = "tests/indexer/yellowstone_reconnect_gap.rs"
 
+[[test]]
+name = "yellowstone_startup_gap"
+path = "tests/indexer/yellowstone_startup_gap.rs"
+
+[[test]]
+name = "rpc_startup_handoff"
+path = "tests/indexer/rpc_startup_handoff.rs"
+
 # Yellowstone inner_instructions + unknown-discriminator arms.
 [[test]]
 name = "yellowstone_inner_and_unknown"

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -61,6 +61,8 @@ integration-test:
 	@cargo test --test yellowstone_wiring -- --nocapture
 	@cargo test --test malformed_yellowstone_update -- --nocapture
 	@cargo test --test yellowstone_reconnect_gap -- --nocapture
+	@cargo test --test yellowstone_startup_gap -- --nocapture
+	@cargo test --test rpc_startup_handoff -- --nocapture
 	@cargo test --test yellowstone_inner_and_unknown -- --nocapture
 	@cargo test --test harness_sanity -- --nocapture
 	@cargo test --test sender_mint_idempotency -- --nocapture

--- a/integration/tests/indexer/rpc_startup_handoff.rs
+++ b/integration/tests/indexer/rpc_startup_handoff.rs
@@ -1,0 +1,194 @@
+//! RPC polling backfill->live handoff.
+//!
+//! `rpc_live_from_slot` seeds the live poller at `T0 + 1` (one past the
+//! inclusive backfill target) so the poller covers the seam slots instead of
+//! jumping to an independently-sampled chain tip. This drives a real
+//! `RpcPollingSource` seeded at `T0 + 1` against a mockito RPC backend and
+//! asserts the seam slots (and an instruction landing inside the seam) reach
+//! the processor channel. Reuses the mockito getSlot/getBlock pattern from the
+//! `rpc_polling/source.rs` unit tests.
+
+use mockito::{Matcher, Server as MockitoServer};
+use private_channel_indexer::config::ProgramType;
+use private_channel_indexer::indexer::datasource::common::datasource::DataSource;
+use private_channel_indexer::indexer::datasource::common::types::ProcessorMessage;
+use private_channel_indexer::indexer::datasource::rpc_polling::RpcPollingSource;
+use serde_json::json;
+use solana_sdk::commitment_config::CommitmentLevel;
+use solana_transaction_status::UiTransactionEncoding;
+use std::collections::HashSet;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+// Inclusive backfill target; the live poller is seeded at SEED = T0 + 1.
+const T0: u64 = 110;
+const SEED: u64 = T0 + 1;
+// Chain tip (exclusive upper bound of get_slots_to_process), so the seam the
+// poller must cover before reaching the tip is SEED..=TIP-1 (111..=114).
+const TIP: u64 = T0 + 5;
+// A withdraw instruction lands inside the seam, proving real data is captured.
+const INSTR_SLOT: u64 = T0 + 3;
+
+const WITHDRAW_PROGRAM_ID: &str = "J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi";
+
+fn mock_get_slot(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": slot, "id": 1}).to_string())
+        .expect_at_least(1)
+        .create()
+}
+
+fn mock_empty_block(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [slot]}),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "blockhash": "TestBlockHash11111111111111111111111111111",
+                    "parentSlot": slot - 1,
+                    "transactions": []
+                },
+                "id": 1
+            })
+            .to_string(),
+        )
+        .expect_at_least(1)
+        .create()
+}
+
+/// base58-encoded WithdrawFunds payload: discriminator 0, amount, None destination.
+fn withdraw_funds_data() -> String {
+    let mut data = vec![0u8];
+    data.extend_from_slice(&1000u64.to_le_bytes());
+    data.push(0);
+    bs58::encode(data).into_string()
+}
+
+fn mock_withdraw_block(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    // accountKeys 0..4 are the WithdrawFunds accounts; index 5 is the program.
+    let account_keys = json!([
+        "11111111111111111111111111111111",
+        "11111111111111111111111111111111",
+        "11111111111111111111111111111111",
+        "11111111111111111111111111111111",
+        "11111111111111111111111111111111",
+        WITHDRAW_PROGRAM_ID
+    ]);
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [slot]}),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "blockhash": "TestBlockHash11111111111111111111111111111",
+                    "parentSlot": slot - 1,
+                    "transactions": [{
+                        "transaction": {
+                            "signatures": ["5".repeat(64)],
+                            "message": {
+                                "accountKeys": account_keys,
+                                "instructions": [{
+                                    "programIdIndex": 5,
+                                    "accounts": [0, 1, 2, 3, 4],
+                                    "data": withdraw_funds_data()
+                                }]
+                            }
+                        },
+                        "meta": null
+                    }]
+                },
+                "id": 1
+            })
+            .to_string(),
+        )
+        .expect_at_least(1)
+        .create()
+}
+
+/// Seeded at T0+1, the poller emits SlotComplete for the seam slots
+/// (T0+1..=TIP-1) and the withdraw instruction in the seam block - it covers
+/// the handoff window instead of jumping to the chain tip.
+#[tokio::test]
+async fn live_poller_seeded_at_t0_plus_1_emits_seam_slots() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    let mut server = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut server, TIP);
+    let _b111 = mock_empty_block(&mut server, SEED);
+    let _b112 = mock_empty_block(&mut server, T0 + 2);
+    let _b113 = mock_withdraw_block(&mut server, INSTR_SLOT);
+    let _b114 = mock_empty_block(&mut server, T0 + 4);
+
+    let mut source = RpcPollingSource::new(
+        server.url(),
+        Some(SEED),
+        10,
+        10,
+        16,
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Finalized,
+        ProgramType::Withdraw,
+        None,
+    );
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(64);
+    let cancel = CancellationToken::new();
+    let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+    let wanted: HashSet<u64> = (SEED..TIP).collect(); // 111..=114, exclusive of tip
+    let mut seen_slots: HashSet<u64> = HashSet::new();
+    let mut saw_instruction = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !(wanted.is_subset(&seen_slots) && saw_instruction) {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            panic!(
+                "timed out; slots seen: {:?}, instruction: {}",
+                seen_slots, saw_instruction
+            );
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) => {
+                seen_slots.insert(slot);
+            }
+            Ok(Some(ProcessorMessage::Instruction(meta))) if meta.slot == INSTR_SLOT => {
+                saw_instruction = true;
+            }
+            _ => {}
+        }
+    }
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+
+    assert!(
+        wanted.is_subset(&seen_slots),
+        "poller must cover the seam {:?}; saw {:?}",
+        wanted,
+        seen_slots
+    );
+    assert!(
+        saw_instruction,
+        "the withdraw instruction in the seam block must be emitted"
+    );
+    assert!(
+        !seen_slots.contains(&TIP),
+        "the tip slot is above the seam and must not be fetched in this window"
+    );
+}

--- a/integration/tests/indexer/yellowstone_startup_gap.rs
+++ b/integration/tests/indexer/yellowstone_startup_gap.rs
@@ -1,0 +1,241 @@
+//! Startup gap-fill for `YellowstoneSource`.
+//!
+//! The gRPC stream begins at the live tip, so on the very first connection the
+//! slots between the backfill target (the durable frontier) and the first
+//! streamed slot are covered by neither backfill nor the live stream. With an
+//! initial gap floor set, the source runs the RPC gap-fill once before the
+//! first subscription to close that window. A fresh node (floor `None`) runs no
+//! initial fill. Mirrors the harness of `yellowstone_reconnect_gap.rs`.
+
+use mockito::{Matcher, Server as MockitoServer};
+use private_channel_indexer::config::ProgramType;
+use private_channel_indexer::indexer::datasource::common::datasource::DataSource;
+use private_channel_indexer::indexer::datasource::common::types::ProcessorMessage;
+use private_channel_indexer::indexer::datasource::rpc_polling::rpc::RpcPoller;
+use private_channel_indexer::indexer::datasource::yellowstone::YellowstoneSource;
+use private_channel_indexer::storage::common::storage::mock::MockStorage;
+use private_channel_indexer::storage::Storage;
+use serde_json::json;
+use solana_sdk::commitment_config::CommitmentLevel;
+use solana_transaction_status::UiTransactionEncoding;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+use test_utils::mock_yellowstone::{MockYellowstoneServer, Update, UpdateMatcher};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use yellowstone_grpc_proto::geyser::{
+    subscribe_update::UpdateOneof, SubscribeUpdate, SubscribeUpdateBlockMeta,
+};
+
+// Durable frontier the startup path established (inclusive backfill target).
+const FLOOR: u64 = 110;
+// RPC chain tip at startup. Gap-fill replays FLOOR..=TIP (anchor = FLOOR-1).
+const TIP: u64 = 116;
+// First live slot streamed after the fill.
+const LIVE_SLOT: u64 = 117;
+
+fn block_meta(slot: u64) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: vec!["all_blocks_meta".to_string()],
+        update_oneof: Some(UpdateOneof::BlockMeta(SubscribeUpdateBlockMeta {
+            slot,
+            blockhash: format!("hash-{slot}"),
+            ..Default::default()
+        })),
+        created_at: None,
+    }
+}
+
+fn empty_block_json() -> serde_json::Value {
+    json!({
+        "blockhash": "TestBlockHash11111111111111111111111111111",
+        "parentSlot": 0,
+        "transactions": []
+    })
+}
+
+/// With an initial gap floor, the source backfills FLOOR..=TIP via RPC before
+/// the first subscription and then streams the live slot - no stream drop, so
+/// the gap slots can only have come from the startup fill.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_gap_fill_runs_before_first_stream() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    let mut rpc_mock = MockitoServer::new_async().await;
+
+    let _slot_mock = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": TIP, "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    // Fill replays the boundary slot FLOOR (anchor = FLOOR-1) through TIP.
+    let mut block_mocks = Vec::new();
+    for slot in FLOOR..=TIP {
+        let m = rpc_mock
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "getBlock", "params": [slot]}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "result": empty_block_json(), "id": 1}).to_string())
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        block_mocks.push(m);
+    }
+
+    let server = MockYellowstoneServer::start().await;
+
+    let rpc_poller = Arc::new(RpcPoller::new(
+        rpc_mock.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ));
+
+    // Frontier carries the checkpoint; storage is only the presence guard.
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(rpc_poller, 1_000, 16)
+    .with_storage(storage)
+    .with_initial_gap_floor(Some(FLOOR));
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // Live slot after the fill - buffered by the mock until subscribe consumes it.
+    server.enqueue(UpdateMatcher, Update::ok(block_meta(LIVE_SLOT)));
+
+    // The gap (FLOOR+1..=TIP) plus the live slot must all reach the channel.
+    let wanted: HashSet<u64> = ((FLOOR + 1)..=TIP)
+        .chain(std::iter::once(LIVE_SLOT))
+        .collect();
+    let mut seen: HashSet<u64> = HashSet::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while !wanted.is_subset(&seen) {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            panic!(
+                "timed out; seen: {:?}, missing: {:?}",
+                seen,
+                wanted.difference(&seen).collect::<Vec<_>>()
+            );
+        }
+        if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+            tokio::time::timeout(remaining, rx.recv()).await
+        {
+            seen.insert(slot);
+        }
+    }
+
+    assert!(
+        wanted.is_subset(&seen),
+        "startup fill (no drop) must deliver gap + live slots; seen: {:?}",
+        seen
+    );
+    assert!(
+        server.call_count("subscribe") >= 1,
+        "expected at least one subscribe handshake; got {}",
+        server.call_count("subscribe")
+    );
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    server.shutdown().await;
+}
+
+/// A fresh node (floor `None`) runs no startup fill: only the streamed slot
+/// appears, never a backfill SlotComplete - the Yellowstone-path Downside A
+/// guard (no genesis replay on a fresh node).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fresh_startup_no_initial_fill() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    let mut rpc_mock = MockitoServer::new_async().await;
+
+    // No getBlock mocks; getSlot tolerated but must not be needed for a fresh node.
+    let _slot_mock = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": 200, "id": 1}).to_string())
+        .expect_at_most(0)
+        .create_async()
+        .await;
+
+    let server = MockYellowstoneServer::start().await;
+
+    let rpc_poller = Arc::new(RpcPoller::new(
+        rpc_mock.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ));
+
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(64);
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(rpc_poller, 1_000, 16)
+    .with_storage(storage)
+    .with_initial_gap_floor(None);
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    server.enqueue(UpdateMatcher, Update::ok(block_meta(100)));
+    let _ = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
+    // Settle any spurious fill activity (there should be none).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut all_slots = vec![];
+    while let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+        tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
+    {
+        all_slots.push(slot);
+    }
+
+    let unexpected: Vec<_> = all_slots.iter().filter(|&&s| s != 100).collect();
+    assert!(
+        unexpected.is_empty(),
+        "fresh node must NOT run a startup fill; unexpected slots: {:?}",
+        unexpected
+    );
+    // No RPC at all: the floor-None guard skips the fill before any getSlot probe.
+    _slot_mock.assert_async().await;
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary

- Fixes **SOLA6-10 (High)**: with startup backfill enabled, the indexer resolved a historical range `(from_slot, T0]`, gated the checkpoint to it, and spawned backfill - then started the **live** datasource from an **independently sampled** later slot `T1` (a fresh `get_latest_slot()` for RPC polling; the live gRPC tip for Yellowstone). Slots in `(T0, T1)` were fetched by neither path. Once backfill released the gate at `T0`, the next live `SlotComplete` advanced the durable checkpoint past the hole (SOLA3-17's plain-max handoff), so it was **never replayed**: skipped deposits never minted, skipped withdrawals never received a `withdrawal_nonce`.
- Fix: seed the live datasource from the **durable frontier the startup path already established**, for both datasources. RPC polling now seeds the poller at `frontier + 1` (contiguous, disjoint handoff). Yellowstone runs a **one-shot startup gap-fill** to `frontier..=tip` (via the existing reconnect RPC machinery) before the first subscription.
- No checkpoint-writer, processor, provenance, or schema change. SOLA3-17 already made the checkpoint gap-safe; this closes the handoff seam SOLA3-17 explicitly deferred.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,149 | 12,761 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28363173900) |
| Indexer | 22,898 | 26,023 | 88.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28363173900) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28363173900) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28363173900) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,177 | 15,176 | 80.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28363173900) |
| **Total** | **48,044** | **56,058** | **85.7%** | |

> Last updated: 2026-06-29 10:15:40 UTC by E2E Integration