### PR TITLE
chore(deploy): Support locally-built images and add audit/sdp inventory groups

### DIFF
--- a/private-channel-deploy/.gitignore
+++ b/private-channel-deploy/.gitignore
@@ -10,6 +10,9 @@ ansible.log
 # improvements" for the SOPS upgrade path that lets this go in git encrypted.
 secrets.yml
 
+# Per-stack secret overrides (e.g. the auditor stack). Same rule as secrets.yml.
+*secrets.yml
+
 # Reserved for the SOPS upgrade. Keys must never live in the repo.
 age.key
 keys.txt

--- a/private-channel-deploy/.gitignore
+++ b/private-channel-deploy/.gitignore
@@ -10,7 +10,7 @@ ansible.log
 # improvements" for the SOPS upgrade path that lets this go in git encrypted.
 secrets.yml
 
-# Per-stack secret overrides (e.g. the auditor stack). Same rule as secrets.yml.
+# Per-stack secret overrides (e.g. sdp-secrets.yml). Same rule as secrets.yml.
 *secrets.yml
 
 # Reserved for the SOPS upgrade. Keys must never live in the repo.

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -335,6 +335,8 @@
           Fix: edit secrets.yml and add `jwt_secret: <random-32+-byte-string>`  (e.g. `openssl rand -hex 32`).
       when: gateway_enforce_jwt | default(true) | bool
 
+    # When skip_pull is set the stack runs a locally-built image (no registry),
+    # so GHCR creds aren't needed.
     - name: Assert GHCR creds present
       ansible.builtin.assert:
         that:
@@ -343,6 +345,7 @@
         fail_msg: |
           `ghcr_user`/`ghcr_token` empty in secrets.yml. Deploy needs them to docker-login to GHCR before pulling images.
           Fix: edit secrets.yml — `ghcr_user: <github-username>`, `ghcr_token: <PAT with read:packages>`.
+      when: not (skip_pull | default(false) | bool)
 
     # Yellowstone gRPC required for indexer-solana on public clusters
     # (localnet uses the bundled validator's Yellowstone, no external endpoint).
@@ -429,6 +432,7 @@
         executable: /bin/bash
       changed_when: true
       no_log: true
+      when: not (skip_pull | default(false) | bool)
 
     # Drop the marker last so a partial bootstrap re-runs cleanly.
     - name: Drop bootstrap marker
@@ -839,12 +843,14 @@
         docker compose -p private-channel --env-file {{ target_versions_env_file }} --env-file {{ target_config_dir }}/.env -f {{ target_compose_file }} -f {{ target_override_file }}
     block:
     # Pull pinned tag. Runs from the target's config dir so the host doesn't
-    # need the repo.
+    # need the repo. Skipped when skip_pull is set (image was built locally on
+    # this host and isn't in any registry).
     - name: Pull images from registry
       ansible.builtin.shell: "{{ compose_cmd }} pull {{ compose_services }}"
       args:
         chdir: "{{ target_config_dir }}"
       changed_when: true
+      when: not (skip_pull | default(false) | bool)
 
     # Postgres runs as uid 70, but Docker creates named volumes root-owned, so the
     # archive_command (`cp %p /wal_archive/...`) fails with "Permission denied" and

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -423,6 +423,9 @@
   # Runs every deploy (not gated by the bootstrap marker) so a host first stood
   # up with skip_pull=true still gets logged in the day it switches to
   # skip_pull=false, instead of silently reusing a bootstrap that skipped auth.
+  # Tagged deploy (not just bootstrap) so a tag-scoped `--tags deploy` run — the
+  # normal way to redeploy an already-bootstrapped host — still authenticates
+  # before PHASE 4's `Pull images from registry` (also tagged deploy) runs.
   # Forced to /bin/bash because `set -o pipefail` is bash-only and Debian/Ubuntu
   # ship dash as /bin/sh.
   - name: Write GHCR credentials to docker config
@@ -442,7 +445,7 @@
       executable: /bin/bash
     changed_when: true
     no_log: true
-    tags: [ bootstrap ]
+    tags: [ bootstrap, deploy ]
     when: not (skip_pull | default(false) | bool)
 
   # =========================================================================

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -412,34 +412,38 @@
         mode: "0755"
       loop: [ "", data, logs, config ]
 
-    # GHCR creds → ~/.docker/config.json so `docker compose pull` can fetch images.
-    # Forced to /bin/bash because `set -o pipefail` is bash-only and Debian/Ubuntu
-    # ship dash as /bin/sh.
-    - name: Write GHCR credentials to docker config
-      ansible.builtin.shell: |
-        set -euo pipefail
-        mkdir -p ~/.docker
-        echo -n '{{ ghcr_user }}:{{ ghcr_token }}' | base64 -w0 > /tmp/.ghcr_b64
-        python3 -c "
-        import json, os, pathlib
-        p = pathlib.Path(os.path.expanduser('~/.docker/config.json'))
-        cfg = json.loads(p.read_text()) if p.exists() else {}
-        cfg.setdefault('auths', {})['ghcr.io'] = {'auth': open('/tmp/.ghcr_b64').read()}
-        p.write_text(json.dumps(cfg, indent=2))
-        "
-        rm -f /tmp/.ghcr_b64
-      args:
-        executable: /bin/bash
-      changed_when: true
-      no_log: true
-      when: not (skip_pull | default(false) | bool)
-
     # Drop the marker last so a partial bootstrap re-runs cleanly.
     - name: Drop bootstrap marker
       ansible.builtin.copy:
         dest: "{{ bootstrap_marker }}"
         content: "bootstrapped {{ ansible_date_time.iso8601 }}\n"
         mode: "0644"
+
+  # GHCR creds → ~/.docker/config.json so `docker compose pull` can fetch images.
+  # Runs every deploy (not gated by the bootstrap marker) so a host first stood
+  # up with skip_pull=true still gets logged in the day it switches to
+  # skip_pull=false, instead of silently reusing a bootstrap that skipped auth.
+  # Forced to /bin/bash because `set -o pipefail` is bash-only and Debian/Ubuntu
+  # ship dash as /bin/sh.
+  - name: Write GHCR credentials to docker config
+    ansible.builtin.shell: |
+      set -euo pipefail
+      mkdir -p ~/.docker
+      echo -n '{{ ghcr_user }}:{{ ghcr_token }}' | base64 -w0 > /tmp/.ghcr_b64
+      python3 -c "
+      import json, os, pathlib
+      p = pathlib.Path(os.path.expanduser('~/.docker/config.json'))
+      cfg = json.loads(p.read_text()) if p.exists() else {}
+      cfg.setdefault('auths', {})['ghcr.io'] = {'auth': open('/tmp/.ghcr_b64').read()}
+      p.write_text(json.dumps(cfg, indent=2))
+      "
+      rm -f /tmp/.ghcr_b64
+    args:
+      executable: /bin/bash
+    changed_when: true
+    no_log: true
+    tags: [ bootstrap ]
+    when: not (skip_pull | default(false) | bool)
 
   # =========================================================================
   # PHASE 2.5: RESET_STATE — wipe data volumes in lockstep with the validator.

--- a/private-channel-deploy/inventory.ini
+++ b/private-channel-deploy/inventory.ini
@@ -8,3 +8,14 @@
 # Pre-trust with: `ssh-keyscan -H <host> >> ~/.ssh/known_hosts`.
 [dev]
 private-channel ansible_host=<IP_ADDRESS> ansible_user=<USER> ansible_ssh_private_key_file=~/.ssh/id_ed25519 ansible_host_key_checking=False
+
+# Isolated devnet stack for the external security auditor (spc-audit-vm, GCP
+# project spc-devnet-7473). Reuses the deployed escrow/withdraw programs; its
+# own static IP + escrow instance. Vars come from vars/audit.yml.
+[audit]
+private-channel-audit ansible_host=34.69.108.194 ansible_user=spcadmin ansible_ssh_private_key_file=~/.ssh/spc_gce ansible_host_key_checking=False
+
+# SDP integration stack (spc-sdp-vm). Reuses the deployed programs; own instance.
+# Gateway open (JWT enforcement off). Vars: vars/sdp.yml.
+[sdp]
+private-channel-sdp ansible_host=34.71.147.163 ansible_user=spcadmin ansible_ssh_private_key_file=~/.ssh/spc_gce ansible_host_key_checking=False

--- a/private-channel-deploy/inventory.ini
+++ b/private-channel-deploy/inventory.ini
@@ -9,12 +9,6 @@
 [dev]
 private-channel ansible_host=<IP_ADDRESS> ansible_user=<USER> ansible_ssh_private_key_file=~/.ssh/id_ed25519 ansible_host_key_checking=False
 
-# Isolated devnet stack for the external security auditor (spc-audit-vm, GCP
-# project spc-devnet-7473). Reuses the deployed escrow/withdraw programs; its
-# own static IP + escrow instance. Vars come from vars/audit.yml.
-[audit]
-private-channel-audit ansible_host=34.69.108.194 ansible_user=spcadmin ansible_ssh_private_key_file=~/.ssh/spc_gce ansible_host_key_checking=False
-
 # SDP integration stack (spc-sdp-vm). Reuses the deployed programs; own instance.
 # Gateway open (JWT enforcement off). Vars: vars/sdp.yml.
 [sdp]

--- a/private-channel-deploy/templates/compose.yml.j2
+++ b/private-channel-deploy/templates/compose.yml.j2
@@ -11,6 +11,12 @@
 
 # Prepend image_registry so `compose pull` resolves to GHCR (or whatever registry).
 {% set img_prefix = image_registry ~ '/' %}
+# skip_pull stacks build the image locally under this same img_prefix tag, but
+# without pull_policy: never, `compose up`'s default "missing" policy would
+# still reach for the registry if that exact tag isn't found locally for any
+# reason (rebuild skipped, tag typo, etc.) — an unauthenticated pull attempt
+# instead of a clear local-image-missing failure.
+{% set no_pull = skip_pull | default(false) | bool %}
 
 services:
 {% for svc in ['write-node', 'read-node', 'gateway', 'streamer', 'auth',
@@ -18,8 +24,14 @@ services:
   {{ svc }}:
     # Pin every Solana Private Channels-app service to the deployed image tag.
     image: {{ img_prefix }}private-channel-app:{{ image_tag }}
+{% if no_pull %}
+    pull_policy: never
+{% endif %}
 {% endfor %}
 
   # Stamp the deployed tag onto the validator image too (built from validator.Dockerfile).
   validator:
     image: {{ img_prefix }}private-channel-validator:{{ image_tag }}
+{% if no_pull %}
+    pull_policy: never
+{% endif %}


### PR DESCRIPTION
## Summary
- skip_pull lets a stack run a locally-built image with no registry, by skipping the GHCR creds assertion, docker login, and compose pull. Needed for stacks that build the retargeted 9tgHa1 escrow program locally instead of pulling from GHCR.
- Adds [audit] and [sdp] inventory groups for the two isolated devnet stacks: the external security auditor and the SDP dev shop integration.
- .gitignore now excludes any *secrets.yml so per-stack secret overrides (audit-secrets.yml, sdp-secrets.yml) never get committed.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...