### PR TITLE
fix: Recover the Yellowstone stream from silent stalls

### DIFF
--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -54,6 +54,9 @@ pub struct YellowstoneSource {
     #[cfg(feature = "datasource-rpc")]
     storage: Option<Arc<Storage>>,
     health: Option<Arc<private_channel_metrics::HealthState>>,
+    /// Silent-stream watchdog window. Defaults to STREAM_STALL_TIMEOUT; overridable
+    /// (mainly so tests can drive the reconnect path without a 60s wait).
+    stall_timeout: std::time::Duration,
 }
 
 impl YellowstoneSource {
@@ -79,11 +82,18 @@ impl YellowstoneSource {
             #[cfg(feature = "datasource-rpc")]
             storage: None,
             health: None,
+            stall_timeout: STREAM_STALL_TIMEOUT,
         }
     }
 
     pub fn with_health(mut self, health: Arc<private_channel_metrics::HealthState>) -> Self {
         self.health = Some(health);
+        self
+    }
+
+    /// Override the silent-stream watchdog window (mainly for tests).
+    pub fn with_stall_timeout(mut self, stall_timeout: std::time::Duration) -> Self {
+        self.stall_timeout = stall_timeout;
         self
     }
 
@@ -111,6 +121,25 @@ impl YellowstoneSource {
 
 #[cfg(feature = "datasource-rpc")]
 const RECONNECT_GAP_RETRY_BACKOFF: Duration = Duration::from_secs(5);
+
+// Stall recovery: a half-open stream (peer stops sending, no FIN/error) hangs
+// stream.next() forever. Two independent backstops force a reconnect.
+
+/// HTTP/2 keepalive interval: send a PING to the peer this often so a dead transport
+/// surfaces as a stream error instead of hanging. Paired with keep_alive_while_idle so
+/// pings fire even when no blocks stream (escrow blocks are sparse on quiet clusters).
+const GRPC_KEEPALIVE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Tear the connection down if a keepalive PING goes unanswered this long.
+const GRPC_KEEPALIVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Application-level watchdog: force a reconnect if no message of ANY kind (a block or
+/// a server ping) arrives within this window. Backstops the h2 keepalive for a server
+/// that keeps the socket up but wedges mid-stream. When escrow is idle, server pings are
+/// the only regular signal, so this sits well above any reasonable ping cadence to avoid
+/// tearing down a healthy but quiet stream. If idle false-reconnects ever show up in the
+/// reconnect metric, subscribe to slots for a per-slot heartbeat instead of widening this.
+const STREAM_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 /// Terminal states of the reconnect gap repair; there is no error variant because
 /// failures retry inside the loop instead of falling through to a resubscribe.
@@ -381,6 +410,7 @@ impl DataSource for YellowstoneSource {
         #[cfg(feature = "datasource-rpc")]
         let escrow_instance_id = self.escrow_instance_id;
         let health = self.health.clone();
+        let stall_timeout = self.stall_timeout;
 
         #[cfg(feature = "datasource-rpc")]
         let rpc_poller = self.rpc_poller.clone();
@@ -437,6 +467,7 @@ impl DataSource for YellowstoneSource {
                     tx.clone(),
                     cancellation_token.clone(),
                     health.as_ref(),
+                    stall_timeout,
                     #[cfg(feature = "datasource-rpc")]
                     gap_ctx,
                     #[cfg(feature = "datasource-rpc")]
@@ -499,6 +530,7 @@ async fn connect_and_stream(
     tx: InstructionSender,
     cancellation_token: CancellationToken,
     health: Option<&Arc<private_channel_metrics::HealthState>>,
+    stall_timeout: std::time::Duration,
     // Present only on reconnects (after the first connection). When set, the first
     // live block arms the gate + backfill so the residual window cannot be leapfrogged.
     #[cfg(feature = "datasource-rpc")] gap_ctx: Option<&ReconnectGapCtx>,
@@ -519,6 +551,9 @@ async fn connect_and_stream(
         .map_err(|e| DataSourceRpcError::Protocol {
             reason: e.to_string(),
         })?
+        .http2_keep_alive_interval(GRPC_KEEPALIVE_INTERVAL)
+        .keep_alive_timeout(GRPC_KEEPALIVE_TIMEOUT)
+        .keep_alive_while_idle(true)
         .connect()
         .await
         .map_err(|e| DataSourceRpcError::Protocol {
@@ -586,6 +621,22 @@ async fn connect_and_stream(
                 drop(subscribe_tx);
                 info!("Yellowstone gRPC connection closed");
                 break;
+            }
+            // Fresh timer each iteration, so any inbound message resets it. Fires only
+            // when the stream goes fully silent; returns Err to take the reconnect +
+            // gap-fill path (which replays whatever slots were missed while wedged).
+            _ = tokio::time::sleep(stall_timeout) => {
+                warn!(
+                    "Yellowstone stream stalled: no message in {:?}, forcing reconnect",
+                    stall_timeout
+                );
+                metrics::INDEXER_RPC_ERRORS
+                    .with_label_values(&[program_type.as_label(), "stall"])
+                    .inc();
+                return Err(DataSourceRpcError::Protocol {
+                    reason: format!("stream stalled: no message in {stall_timeout:?}"),
+                }
+                .into());
             }
             message = stream.next() => {
                 match message {

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -55,7 +55,7 @@ pub struct YellowstoneSource {
     storage: Option<Arc<Storage>>,
     health: Option<Arc<private_channel_metrics::HealthState>>,
     /// Silent-stream watchdog window. Defaults to STREAM_STALL_TIMEOUT; overridable
-    /// (mainly so tests can drive the reconnect path without a 60s wait).
+    /// (mainly so tests can drive the reconnect path without a 120s wait).
     stall_timeout: std::time::Duration,
 }
 

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -266,3 +266,72 @@ async fn fresh_system_reconnect_does_not_gap_fill() {
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
     server.shutdown().await;
 }
+
+/// Silent-stall watchdog: a stream that stays open but stops emitting (no FIN, no
+/// error, no server ping) must be force-reconnected. This is the prod failure that
+/// wedged the escrow indexer for ~12h: `stream.next()` blocked forever because
+/// nothing tripped the reconnect path. The mock holds the stream open once its
+/// queue drains, so an empty queue past the stall window reproduces it exactly.
+/// No gap detection here — this isolates the watchdog from the backfill path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stall_watchdog_forces_reconnect_on_silent_stream() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    let server = MockYellowstoneServer::start().await;
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(64);
+    let cancel = CancellationToken::new();
+
+    // Short watchdog so the test drives the reconnect without the 60s prod wait.
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_stall_timeout(Duration::from_millis(300));
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // Deliver one slot so the first connection is streaming, then stop: the mock
+    // holds the stream open and silent, arming the watchdog.
+    server.enqueue(UpdateMatcher, Update::ok(empty_block(100)));
+    let first = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+    assert!(
+        matches!(
+            first,
+            Ok(Some(ProcessorMessage::SlotComplete { slot: 100, .. }))
+        ),
+        "expected slot 100 before the stall; got {first:?}"
+    );
+
+    // Watchdog (300ms) fires, then the Err path backs off 5s before resubscribing,
+    // so allow generous headroom for the second handshake.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while server.call_count("subscribe") < 2 {
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "silent stream must force a reconnect; subscribe count stuck at {}",
+                server.call_count("subscribe")
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        server.call_count("subscribe") >= 2,
+        "watchdog should resubscribe after a silent stall; got {}",
+        server.call_count("subscribe")
+    );
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    server.shutdown().await;
+}


### PR DESCRIPTION
The escrow indexer wedged on devnet for ~12h. The Yellowstone gRPC stream went silent with no FIN, no error, and no server ping, so stream.next() blocked forever and nothing tripped the existing reconnect path. The health endpoint correctly reported degraded/stalled, but Docker does not auto-restart on an unhealthy check, so it just sat there until a manual restart (which reconnects and gap-fills the backlog on its own).

cantina-audit already had the improved detection (require_continuous_progress makes /health report stalled even at pending=0) but no recovery. This adds the recovery.

Two independent backstops in connect_and_stream:

HTTP/2 keepalive on the gRPC client (15s interval, 10s timeout, while-idle) so a dead transport surfaces as a stream error and takes the existing reconnect path.

An application-level watchdog: a select arm that forces a reconnect if no message of any kind (a block or a server ping) arrives within a window. Fresh timer each loop iteration so any inbound message resets it. It fires only on a fully silent stream and returns Err into the existing reconnect + gap-fill path, which replays whatever slots were missed while wedged. Default is 60s, comfortably above the server ping cadence so a healthy idle stream is never torn down (escrow blocks are sparse since we subscribe to blocks filtered by account_include, not every-slot blocks_meta).

The stall window is injectable via with_stall_timeout so the regression test drives the reconnect without a 60s wait. New test stall_watchdog_forces_reconnect_on_silent_stream reproduces the exact failure: the mock holds the stream open and silent, and we assert a resubscribe happens. New metric label INDEXER_RPC_ERRORS{error_type="stall"}.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 14,008 | 15,713 | 89.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32067696247) |
| Indexer | 35,493 | 39,103 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32067696247) |
| Gateway | 1,476 | 1,698 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32067696247) |
| Auth | 908 | 1,059 | 85.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32067696247) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,334 | 18,237 | 78.6% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32067696247) |
| **Total** | **66,219** | **75,810** | **87.3%** | |

> Last updated: 2026-08-17 21:41:07 UTC by E2E Integration