### PR TITLE
feat(deploy): Optional Doppler secrets backend, opt-in per operator

### DIFF
--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -51,7 +51,7 @@ The deploy reads secrets from one of two backends, chosen automatically:
 
 Doppler setup (one time):
 
-1. Create a Doppler project and config, and add the `secrets.yml` keys as secrets. Doppler names are the UPPERCASE of the file keys: `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, `JWT_SECRET`, `GRAFANA_ADMIN_PASSWORD`, `SOLANA_KEYPAIR`, `GHCR_USER`, `GHCR_TOKEN`, `YELLOWSTONE_TOKEN`, `RPC_URL`. Two use their rendered `.env` names instead: `DEVNET_YELLOWSTONE_ENDPOINT` (optional; overrides `yellowstone_endpoint` from `vars/<env>.yml`) and `ALERT_WEBHOOK_URL` (the webhook; `NOTIFY_WEBHOOK` is also accepted).
+1. Create a Doppler project and config, and add the `secrets.yml` keys as secrets. Doppler names are the UPPERCASE of the file keys: `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, `JWT_SECRET`, `GRAFANA_ADMIN_PASSWORD`, `GHCR_USER`, `GHCR_TOKEN`, `YELLOWSTONE_TOKEN`, `RPC_URL`. Two use their rendered `.env` names instead: `DEVNET_YELLOWSTONE_ENDPOINT` (optional; overrides `yellowstone_endpoint` from `vars/<env>.yml`) and `ALERT_WEBHOOK_URL` (the webhook; `NOTIFY_WEBHOOK` is also accepted).
 2. Import your existing file in one shot (uppercases the keys, keeps values):
    ```bash
    # from private-channel-deploy/, with the doppler CLI installed + `doppler setup` done.

--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -54,9 +54,13 @@ Doppler setup (one time):
 1. Create a Doppler project and config, and add the `secrets.yml` keys as secrets. Doppler names are the UPPERCASE of the file keys: `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, `JWT_SECRET`, `GRAFANA_ADMIN_PASSWORD`, `SOLANA_KEYPAIR`, `GHCR_USER`, `GHCR_TOKEN`, `YELLOWSTONE_TOKEN`, `RPC_URL`, `NOTIFY_WEBHOOK`.
 2. Import your existing file in one shot (uppercases the keys, keeps values):
    ```bash
-   # from private-channel-deploy/, with the doppler CLI installed + `doppler setup` done
-   uv run --with pyyaml python3 -c "import yaml,json,sys; d=yaml.safe_load(open('secrets.yml')); json.dump({k.upper():('' if v is None else str(v)) for k,v in d.items()}, sys.stdout)" > /tmp/spc-secrets.json
-   doppler secrets upload /tmp/spc-secrets.json && rm -f /tmp/spc-secrets.json
+   # from private-channel-deploy/, with the doppler CLI installed + `doppler setup` done.
+   # Subshell keeps the plaintext in a private 0700 tempdir and wipes it on any exit
+   # (including failure or Ctrl-C), so credentials never linger in a world-readable /tmp.
+   ( set -euo pipefail
+     dir="$(mktemp -d)"; trap 'rm -rf "$dir"' EXIT
+     uv run --with pyyaml python3 -c "import yaml,json,sys; d=yaml.safe_load(open('secrets.yml')); json.dump({k.upper():('' if v is None else str(v)) for k,v in d.items()}, sys.stdout)" > "$dir/secrets.json"
+     doppler secrets upload "$dir/secrets.json" )
    ```
 3. Mint a **read-only** service token scoped to that config, then run deploys with it in the environment:
    ```bash

--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -32,13 +32,13 @@ Three one-time edits per environment, done before the first deploy. They tell th
 
 1. **Point at a host** ([`inventory.ini`](./inventory.ini)): IP, SSH user, key path.
 2. **Choose what to deploy** ([`vars/dev.yml`](./vars/dev.yml)): image registry/tag, target Solana network, on-host paths. Each option has an inline comment explaining what to pick.
-3. **Provide credentials**: copy the template, then fill in real values:
+3. **Provide credentials**, via one of the two backends below. For the default file backend, copy the template and fill in real values:
 
    ```bash
    cp secrets.yml.example secrets.yml
    ```
 
-   `secrets.yml` is plain text and gitignored. See the file header for required vs optional and how to generate each value.
+   `secrets.yml` is plain text and gitignored. See the file header for required vs optional and how to generate each value. Doppler-only operators skip this file entirely — preflight does not require it when the doppler backend is selected.
 
 Everything else is wired and shouldn't need routine changes.
 

--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -51,7 +51,7 @@ The deploy reads secrets from one of two backends, chosen automatically:
 
 Doppler setup (one time):
 
-1. Create a Doppler project and config, and add the `secrets.yml` keys as secrets. Doppler names are the UPPERCASE of the file keys: `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, `JWT_SECRET`, `GRAFANA_ADMIN_PASSWORD`, `SOLANA_KEYPAIR`, `GHCR_USER`, `GHCR_TOKEN`, `YELLOWSTONE_TOKEN`, `RPC_URL`, `NOTIFY_WEBHOOK`.
+1. Create a Doppler project and config, and add the `secrets.yml` keys as secrets. Doppler names are the UPPERCASE of the file keys: `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, `JWT_SECRET`, `GRAFANA_ADMIN_PASSWORD`, `SOLANA_KEYPAIR`, `GHCR_USER`, `GHCR_TOKEN`, `YELLOWSTONE_TOKEN`, `RPC_URL`. Two use their rendered `.env` names instead: `DEVNET_YELLOWSTONE_ENDPOINT` (optional; overrides `yellowstone_endpoint` from `vars/<env>.yml`) and `ALERT_WEBHOOK_URL` (the webhook; `NOTIFY_WEBHOOK` is also accepted).
 2. Import your existing file in one shot (uppercases the keys, keeps values):
    ```bash
    # from private-channel-deploy/, with the doppler CLI installed + `doppler setup` done.

--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -40,7 +40,31 @@ Three one-time edits per environment, done before the first deploy. They tell th
 
    `secrets.yml` is plain text and gitignored. See the file header for required vs optional and how to generate each value.
 
-Everything else is wired and shouldn't need routine changes. Cross-env defaults that you can override but rarely need to (db/user names, replication user, health-probe budgets) live in [`vars/common.yml`](./vars/common.yml); set the same key in [`vars/dev.yml`](./vars/dev.yml) to override per environment.
+Everything else is wired and shouldn't need routine changes.
+
+### Secrets backends
+
+The deploy reads secrets from one of two backends, chosen automatically:
+
+- **file** (default): the gitignored `secrets.yml` above. No change for existing users.
+- **doppler** (opt-in, per-operator): pulls the same keys from Doppler at deploy time. Auto-selected when `DOPPLER_TOKEN` is set in your shell; otherwise the file backend is used. Force either with `-e secrets_backend=file|doppler`.
+
+Doppler setup (one time):
+
+1. Create a Doppler project and config, and add the `secrets.yml` keys as secrets. Doppler names are the UPPERCASE of the file keys: `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, `JWT_SECRET`, `GRAFANA_ADMIN_PASSWORD`, `SOLANA_KEYPAIR`, `GHCR_USER`, `GHCR_TOKEN`, `YELLOWSTONE_TOKEN`, `RPC_URL`, `NOTIFY_WEBHOOK`.
+2. Import your existing file in one shot (uppercases the keys, keeps values):
+   ```bash
+   # from private-channel-deploy/, with the doppler CLI installed + `doppler setup` done
+   uv run --with pyyaml python3 -c "import yaml,json,sys; d=yaml.safe_load(open('secrets.yml')); json.dump({k.upper():('' if v is None else str(v)) for k,v in d.items()}, sys.stdout)" > /tmp/spc-secrets.json
+   doppler secrets upload /tmp/spc-secrets.json && rm -f /tmp/spc-secrets.json
+   ```
+3. Mint a **read-only** service token scoped to that config, then run deploys with it in the environment:
+   ```bash
+   export DOPPLER_TOKEN=dp.st.xxxxx
+   ansible-playbook deploy.yml -l dev
+   ```
+
+The token pins the project + config, so the playbook needs nothing else. The file backend stays as a fallback: unset `DOPPLER_TOKEN` (or pass `-e secrets_backend=file`) and the deploy reads `secrets.yml` again. Cross-env defaults that you can override but rarely need to (db/user names, replication user, health-probe budgets) live in [`vars/common.yml`](./vars/common.yml); set the same key in [`vars/dev.yml`](./vars/dev.yml) to override per environment.
 
 ### Using GHCR
 

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -77,10 +77,12 @@
         yellowstone_token: "{{ _d.YELLOWSTONE_TOKEN | default('') }}"
         # yellowstone_endpoint normally comes from vars/<env>.yml; only override it
         # when the Doppler config carries DEVNET_YELLOWSTONE_ENDPOINT (its .env name).
-        yellowstone_endpoint: "{{ _d.DEVNET_YELLOWSTONE_ENDPOINT | default(yellowstone_endpoint | default('')) }}"
-        rpc_url: "{{ _d.RPC_URL | default(rpc_url | default('')) }}"
+        # These use the boolean form of default() so a key that exists in Doppler
+        # with an empty value falls through to the vars file instead of clobbering it.
+        yellowstone_endpoint: "{{ _d.DEVNET_YELLOWSTONE_ENDPOINT | default(yellowstone_endpoint | default(''), true) }}"
+        rpc_url: "{{ _d.RPC_URL | default(rpc_url | default(''), true) }}"
         # env.j2 renders notify_webhook into ALERT_WEBHOOK_URL; accept either name.
-        notify_webhook: "{{ _d.ALERT_WEBHOOK_URL | default(_d.NOTIFY_WEBHOOK | default('')) }}"
+        notify_webhook: "{{ _d.ALERT_WEBHOOK_URL | default(_d.NOTIFY_WEBHOOK | default(''), true) }}"
       vars:
         _d: "{{ doppler_download.stdout | from_json }}"
       no_log: true
@@ -318,15 +320,14 @@
           Fix on target: sudo mkdir -p {{ host_data_dir | dirname }} && sudo chown "$USER" {{ host_data_dir | dirname }}
 
     # ---- Files the playbook reads ----
+    # secrets.yml is only required by the file backend: a Doppler-only operator
+    # has no local secrets file at all, and the secret-value asserts below
+    # already fail with the exact missing key if the Doppler config is short.
     - name: Stat required deployment files
       ansible.builtin.stat:
         path: "{{ playbook_dir }}/{{ item }}"
       register: _file_stats
-      loop:
-      - secrets.yml
-      - vars/common.yml
-      - templates/compose.yml.j2
-      - templates/env.j2
+      loop: "{{ (['secrets.yml'] if secrets_backend == 'file' else []) + ['vars/common.yml', 'templates/compose.yml.j2', 'templates/env.j2'] }}"
       delegate_to: localhost
       run_once: true
 
@@ -1182,6 +1183,9 @@
     ansible.builtin.setup:
       gather_subset: [ "!all", "!min", "date_time" ]
 
+  # rpc_url is reduced to scheme + host: paid RPC URLs carry API keys in the
+  # path or query, and this report goes to stdout, ./ansible.log (log_path in
+  # ansible.cfg), and the notify_webhook — all places a credential must not land.
   - name: Build report
     tags: [ report ]
     ansible.builtin.set_fact:
@@ -1193,7 +1197,7 @@
         env (group)    : {{ group_names | difference(['all']) | first | default('?') }}
         image_tag      : {{ image_tag }}
         network        : {{ network }}
-        rpc_url        : {{ rpc_url }}
+        rpc_url        : {{ rpc_url | urlsplit('scheme') }}://{{ rpc_url | urlsplit('hostname') }}{{ ':' ~ rpc_url | urlsplit('port') if rpc_url | urlsplit('port') else '' }} (path/query redacted)
         host_data_dir  : {{ host_data_dir }}
         reset_state    : {{ reset_state | default(false) }}
         services       : {{ compose_services if (compose_services | trim) else '(all)' }}

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -76,8 +76,12 @@
         ghcr_user: "{{ _d.GHCR_USER | default('') }}"
         ghcr_token: "{{ _d.GHCR_TOKEN | default('') }}"
         yellowstone_token: "{{ _d.YELLOWSTONE_TOKEN | default('') }}"
+        # yellowstone_endpoint normally comes from vars/<env>.yml; only override it
+        # when the Doppler config carries DEVNET_YELLOWSTONE_ENDPOINT (its .env name).
+        yellowstone_endpoint: "{{ _d.DEVNET_YELLOWSTONE_ENDPOINT | default(yellowstone_endpoint | default('')) }}"
         rpc_url: "{{ _d.RPC_URL | default(rpc_url | default('')) }}"
-        notify_webhook: "{{ _d.NOTIFY_WEBHOOK | default('') }}"
+        # env.j2 renders notify_webhook into ALERT_WEBHOOK_URL; accept either name.
+        notify_webhook: "{{ _d.ALERT_WEBHOOK_URL | default(_d.NOTIFY_WEBHOOK | default('')) }}"
       vars:
         _d: "{{ doppler_download.stdout | from_json }}"
       no_log: true

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -72,7 +72,6 @@
         postgres_replication_password: "{{ _d.POSTGRES_REPLICATION_PASSWORD | default('') }}"
         jwt_secret: "{{ _d.JWT_SECRET | default('') }}"
         grafana_admin_password: "{{ _d.GRAFANA_ADMIN_PASSWORD | default('') }}"
-        solana_keypair: "{{ _d.SOLANA_KEYPAIR | default('') }}"
         ghcr_user: "{{ _d.GHCR_USER | default('') }}"
         ghcr_token: "{{ _d.GHCR_TOKEN | default('') }}"
         yellowstone_token: "{{ _d.YELLOWSTONE_TOKEN | default('') }}"

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -13,13 +13,74 @@
   - "vars/{{ env | default(group_names | difference(['all']) | first | default('dev')) }}.yml"
 
   pre_tasks:
-  # Load plain-text secrets. File is gitignored (see .gitignore).
-  - name: Load plain-text secrets
-    ansible.builtin.include_vars:
-      file: "{{ playbook_dir }}/secrets.yml"
+  # Secrets backend: 'file' (default) loads the gitignored secrets.yml; 'doppler'
+  # pulls the same keys from Doppler at deploy time. Opt-in and per-operator: it
+  # auto-selects 'doppler' only when DOPPLER_TOKEN is set in your environment, so
+  # every other user's plain-file flow is unchanged. Force either way with
+  # `-e secrets_backend=file` or `-e secrets_backend=doppler`.
+  - name: Resolve secrets backend
+    ansible.builtin.set_fact:
+      secrets_backend: >-
+        {{ secrets_backend | default('doppler' if (lookup('env', 'DOPPLER_TOKEN') | length > 0) else 'file', true) }}
     tags: [ always ]
     run_once: true
     delegate_to: localhost
+
+  - name: Report secrets backend
+    ansible.builtin.debug:
+      msg: "Secrets backend: {{ secrets_backend }}"
+    tags: [ always ]
+    run_once: true
+    delegate_to: localhost
+
+  # File backend: gitignored plain-text secrets.yml (see .gitignore).
+  - name: Load plain-text secrets (file backend)
+    ansible.builtin.include_vars:
+      file: "{{ playbook_dir }}/secrets.yml"
+    when: secrets_backend == 'file'
+    tags: [ always ]
+    run_once: true
+    delegate_to: localhost
+
+  # Doppler backend: fetch the config's secrets at deploy time and map them onto
+  # the same var names the file backend provides, so everything downstream is
+  # unchanged. The service token (DOPPLER_TOKEN) pins the project + config, so no
+  # project/config flags are needed. Doppler keys are the UPPERCASE of these names
+  # (e.g. rpc_url -> RPC_URL). Requires the Doppler CLI on the control node.
+  - name: Load secrets from Doppler (doppler backend)
+    when: secrets_backend == 'doppler'
+    tags: [ always ]
+    run_once: true
+    delegate_to: localhost
+    block:
+    - name: Assert Doppler CLI is available
+      ansible.builtin.command: doppler --version
+      register: doppler_cli
+      changed_when: false
+
+    - name: Fetch secrets from Doppler
+      ansible.builtin.command: doppler secrets download --no-file --format json
+      environment:
+        DOPPLER_TOKEN: "{{ lookup('env', 'DOPPLER_TOKEN') }}"
+      register: doppler_download
+      changed_when: false
+      no_log: true
+
+    - name: Map Doppler secrets onto deploy vars
+      ansible.builtin.set_fact:
+        postgres_password: "{{ _d.POSTGRES_PASSWORD | default('') }}"
+        postgres_replication_password: "{{ _d.POSTGRES_REPLICATION_PASSWORD | default('') }}"
+        jwt_secret: "{{ _d.JWT_SECRET | default('') }}"
+        grafana_admin_password: "{{ _d.GRAFANA_ADMIN_PASSWORD | default('') }}"
+        solana_keypair: "{{ _d.SOLANA_KEYPAIR | default('') }}"
+        ghcr_user: "{{ _d.GHCR_USER | default('') }}"
+        ghcr_token: "{{ _d.GHCR_TOKEN | default('') }}"
+        yellowstone_token: "{{ _d.YELLOWSTONE_TOKEN | default('') }}"
+        rpc_url: "{{ _d.RPC_URL | default(rpc_url | default('')) }}"
+        notify_webhook: "{{ _d.NOTIFY_WEBHOOK | default('') }}"
+      vars:
+        _d: "{{ doppler_download.stdout | from_json }}"
+      no_log: true
 
   # Track total elapsed time for the report phase.
   - name: Capture deploy start time

--- a/private-channel-deploy/secrets.yml.example
+++ b/private-channel-deploy/secrets.yml.example
@@ -3,6 +3,13 @@
 # `secrets.yml` is gitignored — DO NOT COMMIT it.
 # See README "Future improvements" for the SOPS+age upgrade path.
 #
+# Optional Doppler backend (opt-in, per-operator): instead of this file, the
+# deploy can pull these same keys from Doppler at deploy time. Set DOPPLER_TOKEN
+# (a read-only service token scoped to your project/config) in your shell and the
+# playbook auto-uses it; unset, it falls back to this file. Doppler key names are
+# the UPPERCASE of the keys below (postgres_password -> POSTGRES_PASSWORD, etc.).
+# See README "Secrets backends".
+#
 # Required: postgres_password, postgres_replication_password, jwt_secret,
 #           grafana_admin_password, ghcr_user, ghcr_token.
 # Optional: yellowstone_token (devnet/mainnet only), notify_webhook.


### PR DESCRIPTION
Lets an individual operator pull deploy secrets from Doppler instead of the plaintext secrets.yml, without changing anything for everyone else on the repo.

How it works: a secrets_backend toggle in the Ansible deploy. Default is file (the gitignored secrets.yml), so existing users are byte-for-byte unchanged. When DOPPLER_TOKEN is set in your shell, the playbook auto-selects the doppler backend, runs doppler secrets download at deploy time, and maps the keys onto the same var names the file backend provides. Everything downstream (env.j2 render, compose) is identical. Force either way with -e secrets_backend=file or -e secrets_backend=doppler.

Kept it opt-in and per-operator on purpose: the toggle lives in your environment (the token), not in a committed vars file, so nobody deploying with -l dev inherits it. The service token pins the Doppler project and config, so the playbook needs no extra flags. secrets.yml stays as a fallback: unset the token and the deploy reads the file again.

Scope note: this is deploy-time only (control node pulls, renders .env as today). Runtime injection on the VM (no .env on disk) is a separate future step. Also left the RPC token riding in the URL path as-is, worth moving to header auth with the provider separately.

README documents the setup and a one-liner to import an existing secrets.yml into Doppler with the keys uppercased.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...