### PR TITLE
fix(indexer): persist the owed tree rotation and re-arm it at boot (issue-234)

### DIFF
--- a/indexer/src/error/transaction.rs
+++ b/indexer/src/error/transaction.rs
@@ -42,10 +42,14 @@ pub enum ProgramError {
         onchain_tree_index: u64,
     },
 
-    #[error(
-        "Tree rotation to index {target_tree_index} not submitted: on-chain tree index read failed"
-    )]
+    #[error("Tree rotation to index {target_tree_index} not submitted: a gate read failed")]
     RotationGateUnavailable { target_tree_index: u64 },
+
+    #[error("Tree rotation to index {target_tree_index} not submitted: nonce {blocking_nonce} on the closing tree is still unreleased")]
+    RotationBlockedByLowerNonce {
+        target_tree_index: u64,
+        blocking_nonce: u64,
+    },
 
     #[error("Transaction nonce {nonce} expects tree_index {expected_tree_index} but current local tree_index is {current_tree_index}")]
     TreeIndexMismatch {

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -278,6 +278,7 @@ pub fn init_labels(program_type: &str) {
         "status_poll_rpc_error",
         "rotation_not_landed",
         "rotation_gate_unavailable",
+        "rotation_blocked_by_lower_nonce",
         "reset_tree_already_advanced",
     ] {
         OPERATOR_TRANSACTION_ERRORS.with_label_values(&[program_type, error_reason]);

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -20,9 +20,7 @@ use crate::storage::common::storage::RequeueOutcome;
 use crate::storage::Storage;
 use crate::ProgramType;
 use chrono::Utc;
-use private_channel_escrow_program_client::instructions::{
-    ReleaseFundsBuilder, ResetSmtRootBuilder,
-};
+use private_channel_escrow_program_client::instructions::ReleaseFundsBuilder;
 use private_channel_escrow_program_client::programs::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
 use private_channel_metrics::MetricLabel;
 use solana_sdk::pubkey::Pubkey;
@@ -537,28 +535,6 @@ async fn build_release_funds(
     )))
 }
 
-/// Build the tree-rotation TransactionBuilder for a nonce landing on the
-/// MAX_TREE_LEAVES boundary (normal, non-poison path).
-fn build_scheduled_rotation(
-    admin_pubkey: Pubkey,
-    release_funds_state: &ReleaseFundsState,
-    target_tree_index: u64,
-) -> TransactionBuilder {
-    let mut rotation_builder = ResetSmtRootBuilder::new();
-    rotation_builder
-        .payer(admin_pubkey)
-        .operator(release_funds_state.operator_pubkey)
-        .instance(release_funds_state.instance_pda)
-        .operator_pda(release_funds_state.operator_pda)
-        .event_authority(release_funds_state.event_authority_pda);
-    // The target travels with the builder: the sender re-checks it against chain before
-    // every attempt, and cannot re-derive it once the boundary row is out of scope.
-    TransactionBuilder::ResetSmtRoot(Box::new(ResetSmtRootBuilderWithTarget {
-        builder: rotation_builder,
-        target_tree_index,
-    }))
-}
-
 /// Token-2022 pre-flight for a withdrawal.
 ///
 /// Returns:
@@ -695,11 +671,23 @@ pub async fn process_release_funds(
                             target_tree_index,
                             "Tree rotation boundary detected, dispatching ResetSmtRoot"
                         );
-                        let rotation_tx = build_scheduled_rotation(
-                            processor_state.admin_pubkey,
-                            release_funds_state,
-                            target_tree_index,
-                        );
+                        // Record the owed generation before dispatching. The sender's
+                        // arm is in-memory, so this row is what re-arms the rotation
+                        // after a crash; persisting first means a lost dispatch is
+                        // always recoverable, never the reverse.
+                        storage
+                            .set_owed_rotation_target(pt_label, target_tree_index)
+                            .await?;
+                        let rotation_tx = TransactionBuilder::ResetSmtRoot(Box::new(
+                            ResetSmtRootBuilderWithTarget::new(
+                                processor_state.admin_pubkey,
+                                release_funds_state.operator_pubkey,
+                                release_funds_state.instance_pda,
+                                release_funds_state.operator_pda,
+                                release_funds_state.event_authority_pda,
+                                target_tree_index,
+                            ),
+                        ));
                         send_guaranteed(&sender_tx, rotation_tx, "reset smt root")
                             .await
                             .map_err(OperatorError::ChannelSend)?;
@@ -1369,7 +1357,7 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
-            storage,
+            storage.clone(),
             ProgramType::Withdraw,
         )
         .await;
@@ -1384,6 +1372,21 @@ mod tests {
         // re-checking against chain, and it cannot be re-derived there.
         assert_eq!(rotation.target_tree_index, 1);
 
+        // And it is durable before the dispatch, so a crash before the reset confirms
+        // re-arms the rotation at boot instead of dropping it.
+        let Storage::Mock(mock_storage) = storage.as_ref() else {
+            unreachable!("mock storage")
+        };
+        assert_eq!(
+            mock_storage
+                .owed_rotation_targets
+                .lock()
+                .unwrap()
+                .get("withdraw")
+                .copied(),
+            Some(1)
+        );
+
         // Second message must be the ReleaseFunds for the boundary nonce itself
         let msg2 = sender_rx.recv().await.unwrap();
         let TransactionBuilder::ReleaseFunds(b) = msg2 else {
@@ -1394,6 +1397,80 @@ mod tests {
 
         // No further messages — exactly two were sent
         assert!(sender_rx.try_recv().is_err(), "unexpected third message");
+    }
+
+    /// The durable target is written before the dispatch, so if that write fails the
+    /// rotation must not be sent at all: a reset in flight with no stored target is
+    /// exactly the state a crash could drop.
+    #[tokio::test]
+    async fn process_release_funds_boundary_skips_dispatch_when_target_persist_fails() {
+        let mock = MockStorage::new();
+        mock.set_should_fail("set_owed_rotation_target", true);
+        let storage = Arc::new(Storage::Mock(mock));
+
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, instance_account_response(0));
+        let rpc_client = RpcClientWithRetry::new_mocked(mocks);
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
+        };
+
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        {
+            let Storage::Mock(mock_storage) = storage.as_ref() else {
+                unreachable!("mock storage")
+            };
+            mock_storage.mints.lock().unwrap().insert(
+                mint_pubkey.to_string(),
+                DbMint {
+                    mint_address: mint_pubkey.to_string(),
+                    decimals: 6,
+                    token_program: spl_token::id().to_string(),
+                    created_at: chrono::Utc::now(),
+                    status: "allowed".to_string(),
+                    is_pausable: Some(false),
+                    has_permanent_delegate: Some(false),
+                },
+            );
+        }
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        let txn = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(MAX_TREE_LEAVES as i64),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a failed target write must surface, not proceed silently"
+        );
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "neither the rotation nor the boundary withdrawal may be dispatched"
+        );
     }
 
     /// A boundary nonce must not rotate or dispatch while a lower withdrawal is

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -312,6 +312,9 @@ pub async fn run_sender(
     // next tick
     state.recover_pending_remints(&storage_tx).await?;
 
+    // Re-arm the tree rotation this operator still owes, if a crash left one behind.
+    state.rearm_owed_rotation().await?;
+
     // Deferred remints and the two retry queues (every 500ms)
     let mut queue_check_interval = interval(Duration::from_millis(500));
 

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -4,13 +4,18 @@ use crate::error::account::AccountError;
 use crate::error::OperatorError;
 use crate::operator::sender::types::{PendingRemint, PendingSig, TransactionContext};
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
+use crate::operator::utils::instruction_util::ResetSmtRootBuilderWithTarget;
 use crate::operator::utils::smt_util::SmtState;
-use crate::operator::{parse_instance, RetryConfig, RpcClientWithRetry};
+use crate::operator::{
+    find_event_authority_pda, find_operator_pda, parse_instance, RetryConfig, RpcClientWithRetry,
+    SignerUtil,
+};
 use crate::operator::{MintCache, TransactionStatusUpdate, WithdrawalRemintInfo};
 use crate::storage::common::storage::Storage;
 use crate::storage::TransactionStatus;
 use crate::PrivateChannelIndexerConfig;
 use chrono::Utc;
+use private_channel_metrics::MetricLabel;
 use solana_sdk::clock::MAX_PROCESSING_AGE;
 use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_sdk::pubkey::Pubkey;
@@ -20,7 +25,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Semaphore};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use super::types::{InFlightQueue, SenderSMTState, SenderState, MAX_IN_FLIGHT};
 
@@ -557,6 +562,62 @@ impl SenderState {
         }
 
         Ok(())
+    }
+
+    /// Re-arm the rotation this operator still owes the chain, read from the durable
+    /// target the processor wrote before dispatching it. A reset carries no DB row and
+    /// no nonce, so without this a crash between arming and confirmation would drop the
+    /// only automatic rotation for that boundary.
+    ///
+    /// Arming is all this does: the rotation tick reads the chain before every attempt,
+    /// so a target the chain already reached is disarmed there without sending.
+    pub(super) async fn rearm_owed_rotation(&mut self) -> Result<(), OperatorError> {
+        // Only the withdraw role can owe a rotation: it is the only one with an escrow
+        // instance to reset, so instance_pda is None for every other role.
+        let Some(instance_pda) = self.instance_pda else {
+            return Ok(());
+        };
+
+        let Some(target_tree_index) = self
+            .storage
+            .get_owed_rotation_target(self.program_type.as_label())
+            .await?
+        else {
+            return Ok(());
+        };
+
+        let operator_pubkey = SignerUtil::get_operator_pubkey();
+        self.pending_rotation = Some(Box::new(ResetSmtRootBuilderWithTarget::new(
+            SignerUtil::get_admin_pubkey(),
+            operator_pubkey,
+            instance_pda,
+            find_operator_pda(&instance_pda, &operator_pubkey),
+            find_event_authority_pda(),
+            target_tree_index,
+        )));
+
+        info!(
+            target_tree_index,
+            "Re-armed owed tree rotation from persistent storage"
+        );
+
+        Ok(())
+    }
+
+    /// Retire the rotation now that a chain read proved `target_tree_index` landed.
+    /// Clears the durable target first, then the in-memory arm.
+    ///
+    /// A failed clear is not fatal: the next boot re-arms the target, and the submit
+    /// gate's chain read disarms it again without sending anything.
+    pub(super) async fn disarm_rotation(&mut self, target_tree_index: u64) {
+        if let Err(e) = self
+            .storage
+            .clear_owed_rotation_target(self.program_type.as_label(), target_tree_index)
+            .await
+        {
+            warn!(target_tree_index, "Owed rotation clear failed: {e}");
+        }
+        self.pending_rotation = None;
     }
 }
 
@@ -1115,6 +1176,118 @@ mod tests {
         assert!(
             storage_rx.try_recv().is_err(),
             "Escrow must not emit any status update for a remint row"
+        );
+    }
+
+    // ── rearm_owed_rotation ──────────────────────────────────────────
+
+    static INIT_TEST_SIGNER: std::sync::Once = std::sync::Once::new();
+
+    /// Configure an in-memory admin signer so the rotation builder's account wiring can
+    /// resolve the process-global signers. Must run before their first access.
+    fn ensure_test_signer() {
+        INIT_TEST_SIGNER.call_once(|| {
+            let keypair = solana_sdk::signer::keypair::Keypair::new();
+            let encoded = bs58::encode(keypair.to_bytes()).into_string();
+            std::env::set_var("ADMIN_SIGNER", "memory");
+            std::env::set_var("ADMIN_PRIVATE_KEY", &encoded);
+        });
+    }
+
+    /// The finding's restart hole: a reset carries no DB row and no nonce, so a crash
+    /// between arming and confirmation dropped the only automatic rotation for the
+    /// boundary. The stored target is what puts it back.
+    #[tokio::test]
+    async fn rearm_owed_rotation_arms_from_stored_target() {
+        ensure_test_signer();
+        let target_tree_index = 3u64;
+
+        let mock = MockStorage::new();
+        let mut state = make_sender_state(mock);
+        state.instance_pda = Some(Pubkey::new_unique());
+        state
+            .storage
+            .set_owed_rotation_target(state.program_type.as_label(), target_tree_index)
+            .await
+            .unwrap();
+
+        state.rearm_owed_rotation().await.unwrap();
+
+        let rotation = state
+            .pending_rotation
+            .as_ref()
+            .expect("a stored target must re-arm the rotation");
+        assert_eq!(rotation.target_tree_index, target_tree_index);
+
+        // The re-armed builder must be a complete reset, not just a carrier for the
+        // target: the sender wires these accounts itself, from globals and the instance,
+        // so a wrong or missing one would only surface on-chain. Bind the generation the
+        // way the submit path does, which is the only field left unset here.
+        let operator_pubkey = SignerUtil::get_operator_pubkey();
+        let mut builder = rotation.builder.clone();
+        builder.expected_current_tree_index(target_tree_index - 1);
+        let accounts: Vec<Pubkey> = builder
+            .instruction()
+            .accounts
+            .iter()
+            .map(|account| account.pubkey)
+            .collect();
+        let instance_pda = state.instance_pda.unwrap();
+        for expected in [
+            SignerUtil::get_admin_pubkey(),
+            operator_pubkey,
+            instance_pda,
+            find_operator_pda(&instance_pda, &operator_pubkey),
+            find_event_authority_pda(),
+        ] {
+            assert!(
+                accounts.contains(&expected),
+                "re-armed reset is missing account {expected}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rearm_owed_rotation_noop_without_stored_target() {
+        ensure_test_signer();
+        let mock = MockStorage::new();
+        let mut state = make_sender_state(mock);
+        state.instance_pda = Some(Pubkey::new_unique());
+
+        state.rearm_owed_rotation().await.unwrap();
+
+        assert!(
+            state.pending_rotation.is_none(),
+            "nothing owed means nothing armed"
+        );
+    }
+
+    /// Both roles can share a database, so the escrow sender must not pick up the
+    /// withdraw operator's owed rotation. It has no instance to reset, so it must not
+    /// even read the target.
+    #[tokio::test]
+    async fn rearm_owed_rotation_noop_for_escrow_role() {
+        let mock = MockStorage::new();
+        let mut state = make_sender_state_with_role(mock, crate::config::ProgramType::Escrow);
+        state
+            .storage
+            .set_owed_rotation_target("withdraw", 3)
+            .await
+            .unwrap();
+
+        state.rearm_owed_rotation().await.unwrap();
+
+        assert!(
+            state.pending_rotation.is_none(),
+            "Escrow must not claim the withdraw operator's rotation"
+        );
+        let Storage::Mock(mock) = state.storage.as_ref() else {
+            unreachable!("mock storage")
+        };
+        assert_eq!(
+            mock.calls("get_owed_rotation_target"),
+            0,
+            "Escrow must not even read the owed target"
         );
     }
 

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -141,7 +141,7 @@ impl SenderState {
                 // validate_smt_root reports a root mismatch).
                 match check_rotation_against_chain(self, target_tree_index).await {
                     RotationCheck::Landed { onchain_index } => {
-                        self.pending_rotation = None;
+                        self.disarm_rotation(target_tree_index).await;
                         return Err(ProgramError::RotationNotOwed {
                             target_tree_index,
                             onchain_tree_index: onchain_index,
@@ -174,6 +174,52 @@ impl SenderState {
                     );
 
                     return Err(ProgramError::RotationPending { in_flight_count }.into());
+                }
+
+                // Never close a tree a lower nonce still has to release on: that release can
+                // only land while the chain holds its tree, so rotating past it strands an
+                // already-burned withdrawal.
+                //
+                // The processor applies this same rule at dispatch but excludes Processing
+                // rows, covering those with the sender's in-flight map instead. That map does
+                // not survive a restart while the owed target now does, so the durable check
+                // runs here, fresh on every attempt.
+                //
+                // Below the in-flight check on purpose: a release the sender just confirmed
+                // leaves that map before its Completed write reaches the database, so the
+                // in-memory answer is both free and fresher, and normal pacing takes the
+                // quiet RotationPending branch rather than this one.
+                //
+                // Checked both ways: a saturating multiply would wrap to -1 as an i64 and
+                // make the query match nothing, turning this gate into a no-op on exactly
+                // the corrupt target it should refuse to act on.
+                let Some(boundary_nonce) = target_tree_index
+                    .checked_mul(MAX_TREE_LEAVES as u64)
+                    .and_then(|nonce| i64::try_from(nonce).ok())
+                else {
+                    error!("Owed rotation target {target_tree_index} has no boundary nonce");
+                    return Err(ProgramError::RotationGateUnavailable { target_tree_index }.into());
+                };
+                match self
+                    .storage
+                    .lowest_unreleased_withdrawal_below(boundary_nonce)
+                    .await
+                {
+                    Ok(Some(blocking_nonce)) => {
+                        return Err(ProgramError::RotationBlockedByLowerNonce {
+                            target_tree_index,
+                            blocking_nonce: blocking_nonce as u64,
+                        }
+                        .into())
+                    }
+                    Ok(None) => {}
+                    // Fail closed: an unevaluated gate is not a passed gate.
+                    Err(e) => {
+                        error!("Unreleased-nonce gate read failed: {e}");
+                        return Err(
+                            ProgramError::RotationGateUnavailable { target_tree_index }.into()
+                        );
+                    }
                 }
 
                 // Bind the reset to the generation before the target so the program's
@@ -429,7 +475,26 @@ pub(super) async fn route_builder_error(
                 .inc();
             warn!(
                 target_tree_index,
-                "Tree index unreadable, rotation stays armed and was not submitted"
+                "Rotation gate unreadable, rotation stays armed and was not submitted"
+            );
+        }
+        // Distinct from the unavailable case above: the gate was read and says the
+        // closing tree still owes a release. Resolving that nonce is what unblocks it,
+        // so it gets its own label rather than reading as a chain or RPC problem.
+        OperatorError::Program(ProgramError::RotationBlockedByLowerNonce {
+            target_tree_index,
+            blocking_nonce,
+        }) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[
+                    state.program_type.as_label(),
+                    "rotation_blocked_by_lower_nonce",
+                ])
+                .inc();
+            warn!(
+                target_tree_index,
+                blocking_nonce,
+                "Rotation withheld: a lower nonce still owes a release on the closing tree"
             );
         }
         OperatorError::Program(ProgramError::TreeIndexMismatch {
@@ -976,7 +1041,7 @@ pub(super) fn handle_confirmation_result<'a>(
                         check_rotation_against_chain(state, target_tree_index).await,
                         RotationCheck::Landed { .. }
                     ) {
-                        state.pending_rotation = None;
+                        state.disarm_rotation(target_tree_index).await;
                     }
                 }
             }
@@ -1074,14 +1139,16 @@ pub(super) async fn handle_success(
     // a local SMT being present, or a confirmed reset could leave the rotation owed.
     // InitializeMint has no id either but never arrives here: it confirms inline in the
     // JIT path, so a reset is the only thing this branch can be.
-    else if let Some(rotation) = state.pending_rotation.take() {
+    else if let Some(target_tree_index) = state
+        .pending_rotation
+        .as_ref()
+        .map(|rotation| rotation.target_tree_index)
+    {
+        state.disarm_rotation(target_tree_index).await;
         if let Some(ref mut smt_state) = state.smt_state {
-            smt_state.smt_state.reset(rotation.target_tree_index);
+            smt_state.smt_state.reset(target_tree_index);
         }
-        info!(
-            "Tree rotation complete! Updated local SMT to tree_index {}",
-            rotation.target_tree_index
-        );
+        info!("Tree rotation complete! Updated local SMT to tree_index {target_tree_index}");
     }
 }
 
@@ -2240,14 +2307,20 @@ mod tests {
 
     /// Serialized `Instance` reporting `current_tree_index`. Its root is deliberately
     /// not `EMPTY_TREE_ROOT`, so any `validate_smt_root` that runs against it fails.
+    /// Instance bytes whose root matches no rebuilt tree, so an SMT init on top of it
+    /// fails. Gate tests rely on that to prove the gate ran before the init.
     fn instance_bytes(current_tree_index: u64) -> Vec<u8> {
+        instance_bytes_with_root(current_tree_index, [0u8; 32])
+    }
+
+    fn instance_bytes_with_root(current_tree_index: u64, root: [u8; 32]) -> Vec<u8> {
         let instance = Instance {
             discriminator: 0,
             bump: 0,
             version: 0,
             instance_seed: Pubkey::new_unique(),
             admin: Pubkey::new_unique(),
-            withdrawal_transactions_root: [0u8; 32],
+            withdrawal_transactions_root: root,
             current_tree_index,
         };
         let mut bytes = Vec::new();
@@ -4048,6 +4121,12 @@ mod tests {
             builder: ResetSmtRootBuilder::new(),
             target_tree_index,
         }));
+        let pt = state.program_type.as_label();
+        state
+            .storage
+            .set_owed_rotation_target(pt, target_tree_index)
+            .await
+            .unwrap();
 
         let (tx, mut rx) = mpsc::channel(10);
         // No transaction_id, no withdrawal_nonce = ResetSmtRoot context
@@ -4072,6 +4151,15 @@ mod tests {
         assert!(
             state.pending_rotation.is_none(),
             "a confirmed reset proves the tree advanced, so the rotation is disarmed"
+        );
+        assert!(
+            state
+                .storage
+                .get_owed_rotation_target(pt)
+                .await
+                .unwrap()
+                .is_none(),
+            "the durable target must retire on a confirmed reset"
         );
     }
 
@@ -4199,6 +4287,12 @@ mod tests {
             builder: ResetSmtRootBuilder::new(),
             target_tree_index,
         }));
+        let pt = state.program_type.as_label();
+        state
+            .storage
+            .set_owed_rotation_target(pt, target_tree_index)
+            .await
+            .unwrap();
 
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = TransactionContext {
@@ -4230,6 +4324,15 @@ mod tests {
         assert!(
             state.pending_rotation.is_none(),
             "chain reached the target, so the rotation is no longer owed"
+        );
+        assert!(
+            state
+                .storage
+                .get_owed_rotation_target(pt)
+                .await
+                .unwrap()
+                .is_none(),
+            "the durable target must retire once the chain proved it landed"
         );
         drop(tx);
         assert!(
@@ -4473,6 +4576,12 @@ mod tests {
         let mut state = make_sender_state();
         state.instance_pda = Some(Pubkey::new_unique());
         state.rpc_client = mock_rpc_client(&instance_bytes(target_tree_index));
+        let pt = state.program_type.as_label();
+        state
+            .storage
+            .set_owed_rotation_target(pt, target_tree_index)
+            .await
+            .unwrap();
         assert!(
             state.smt_state.is_none(),
             "the gate must not need a local SMT"
@@ -4503,6 +4612,15 @@ mod tests {
         assert!(
             state.pending_rotation.is_none(),
             "a rotation the chain completed is no longer owed"
+        );
+        assert!(
+            state
+                .storage
+                .get_owed_rotation_target(pt)
+                .await
+                .unwrap()
+                .is_none(),
+            "the durable target must retire too, or the next boot re-arms a landed rotation"
         );
     }
 
@@ -4546,6 +4664,197 @@ mod tests {
         );
     }
 
+    /// A server whose every `getAccountInfo` returns an instance at `tree_index` carrying
+    /// the root of an empty tree there, so a `validate_smt_root` against an empty database
+    /// agrees with it.
+    ///
+    /// Needed wherever a test drives both the rotation gate's chain read and the SMT init
+    /// above it: the mocked `RpcClient` consumes one canned response per request, while a
+    /// mockito mock answers every call.
+    async fn server_serving_empty_instance(tree_index: u64) -> mockito::ServerGuard {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getAccountInfo"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [
+                                STANDARD.encode(instance_bytes_with_root(
+                                    tree_index,
+                                    SmtState::new(tree_index).current_root(),
+                                )),
+                                "base64"
+                            ],
+                            "executable": false,
+                            "rentEpoch": 0
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect_at_least(1)
+            .create();
+        server
+    }
+
+    /// A withdrawal row on the closing tree, at `nonce`, in a status that still owes a
+    /// release.
+    fn unreleased_withdrawal_row(nonce: i64, status: TransactionStatus) -> DbTransaction {
+        let now = Utc::now();
+        DbTransaction {
+            id: nonce,
+            signature: Signature::new_unique().to_string(),
+            trace_id: format!("trace-{nonce}"),
+            slot: 100,
+            initiator: Pubkey::new_unique().to_string(),
+            recipient: Pubkey::new_unique().to_string(),
+            mint: Pubkey::new_unique().to_string(),
+            amount: TokenAmount(5_000),
+            memo: None,
+            transaction_type: TransactionType::Withdrawal,
+            withdrawal_nonce: Some(nonce),
+            status,
+            created_at: now,
+            updated_at: now,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            remint_last_valid_block_heights: None,
+            pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
+            instruction_index: 0,
+            inner_index: None,
+            landed_remint_signature: None,
+        }
+    }
+
+    /// The durable half of the in-flight guard. A release can only land while the chain
+    /// holds its tree, so a rotation must not close a tree a lower nonce still owes a
+    /// release on. The processor checks this at dispatch but excludes Processing rows,
+    /// relying on the sender's in-flight map for those; that map is gone after a restart
+    /// while the owed target survives, so the check has to hold here too.
+    #[tokio::test]
+    async fn reset_gate_withholds_while_lower_nonce_unreleased() {
+        ensure_test_signer();
+        let target_tree_index = 1u64;
+        let blocking_nonce = MAX_TREE_LEAVES as i64 - 1;
+
+        // Chain a generation behind the target, so the rotation is genuinely owed.
+        let server = server_serving_empty_instance(target_tree_index - 1).await;
+        let mut state = make_sender_state_with_server(&server.url());
+        state.instance_pda = Some(Pubkey::new_unique());
+        let pt = state.program_type.as_label();
+        state
+            .storage
+            .set_owed_rotation_target(pt, target_tree_index)
+            .await
+            .unwrap();
+
+        // Processing, the status a restart leaves behind and the one the processor's
+        // dispatch-time query deliberately ignores.
+        let Storage::Mock(mock) = state.storage.as_ref() else {
+            unreachable!("mock storage")
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(unreleased_withdrawal_row(
+                blocking_nonce,
+                TransactionStatus::Processing,
+            ));
+
+        let Err(err) = state
+            .handle_transaction_builder(TransactionBuilder::ResetSmtRoot(Box::new(
+                ResetSmtRootBuilderWithTarget {
+                    builder: ResetSmtRootBuilder::new(),
+                    target_tree_index,
+                },
+            )))
+            .await
+        else {
+            panic!("a rotation that would strand a lower nonce must not be submitted")
+        };
+
+        assert!(
+            matches!(
+                err,
+                OperatorError::Program(ProgramError::RotationBlockedByLowerNonce {
+                    target_tree_index: target,
+                    blocking_nonce: blocking,
+                }) if target == target_tree_index && blocking == blocking_nonce as u64
+            ),
+            "expected RotationBlockedByLowerNonce, got {err:?}"
+        );
+        assert!(
+            state.pending_rotation.is_some(),
+            "the rotation is still owed, just withheld"
+        );
+        assert_eq!(
+            state.storage.get_owed_rotation_target(pt).await.unwrap(),
+            Some(target_tree_index),
+            "withholding must not retire the durable target"
+        );
+    }
+
+    /// The mirror case: a lower nonce that already released is no reason to withhold, or
+    /// the tree could never rotate at all.
+    #[tokio::test]
+    async fn reset_gate_submits_when_lower_nonces_are_terminal() {
+        ensure_test_signer();
+        let target_tree_index = 1u64;
+
+        let server = server_serving_empty_instance(target_tree_index - 1).await;
+        let mut state = make_sender_state_with_server(&server.url());
+        state.instance_pda = Some(Pubkey::new_unique());
+
+        let Storage::Mock(mock) = state.storage.as_ref() else {
+            unreachable!("mock storage")
+        };
+        // Written off and reminted, not Completed: a completed nonce would join the rebuilt
+        // tree and no longer match the empty root this instance serves. That `completed`
+        // counts as settled is pinned against Postgres instead.
+        mock.pending_transactions.lock().unwrap().extend([
+            unreleased_withdrawal_row(MAX_TREE_LEAVES as i64 - 2, TransactionStatus::Failed),
+            unreleased_withdrawal_row(
+                MAX_TREE_LEAVES as i64 - 1,
+                TransactionStatus::FailedReminted,
+            ),
+        ]);
+
+        // Fully wired, unlike the tests that return before the build: this one gets all the
+        // way to the instruction.
+        let instance_pda = state.instance_pda.unwrap();
+        let result = state
+            .handle_transaction_builder(TransactionBuilder::ResetSmtRoot(Box::new(
+                ResetSmtRootBuilderWithTarget::new(
+                    Pubkey::new_unique(),
+                    Pubkey::new_unique(),
+                    instance_pda,
+                    Pubkey::new_unique(),
+                    Pubkey::new_unique(),
+                    target_tree_index,
+                ),
+            )))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "released and reminted nonces must not withhold the rotation, got {:?}",
+            result.err()
+        );
+    }
+
     // ── rotation arming ──────────────────────────────────────────────
 
     /// A rotation must survive the whole submission path when it cannot be sent, error
@@ -4559,6 +4868,12 @@ mod tests {
         // make_sender_state leaves instance_pda None, so the gate's tree-index read fails
         // and the rotation is never submitted.
         let mut state = make_sender_state();
+        let pt = state.program_type.as_label();
+        state
+            .storage
+            .set_owed_rotation_target(pt, target_tree_index)
+            .await
+            .unwrap();
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
         handle_transaction_submission(
@@ -4574,6 +4889,94 @@ mod tests {
         assert!(
             state.pending_rotation.is_some(),
             "rotation must survive a failed submission so the tick can retry it"
+        );
+        assert_eq!(
+            state.storage.get_owed_rotation_target(pt).await.unwrap(),
+            Some(target_tree_index),
+            "the durable target must survive too, so a crash here still re-arms"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a reset has no row, so no status update"
+        );
+    }
+
+    /// A crash leaves nothing in memory, only the durable target. Boot re-arms from it, the
+    /// tick drives it, and the reset is signed, broadcast, confirmed, then retired from both
+    /// the arm and the row.
+    ///
+    /// The pieces are covered in isolation elsewhere; this is the one that proves they
+    /// connect, since a re-arm that never reaches `sendTransaction` would leave the rotation
+    /// owed forever while every isolated assertion still passed.
+    #[tokio::test]
+    async fn owed_rotation_survives_restart_and_is_sent_by_the_tick() {
+        ensure_test_signer();
+        let target_tree_index = 1u64;
+
+        // Chain a generation behind the target, so the rotation is owed and lands.
+        let mut server = server_serving_empty_instance(target_tree_index - 1).await;
+        let _hash = mock_blockhash(&mut server);
+        // The RPC client rejects a response whose signature differs from the one it sent,
+        // and this transaction is really signed, so echo it back out of the request: a
+        // serialized legacy transaction is a 1-byte signature count then the signature.
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body_from_request(|req| {
+                let body: serde_json::Value =
+                    serde_json::from_slice(req.body().expect("request body present"))
+                        .expect("request body is json");
+                let encoded = body["params"][0].as_str().expect("transaction param");
+                let raw = STANDARD.decode(encoded).expect("base64 transaction");
+                let signature = bs58::encode(&raw[1..1 + 64]).into_string();
+                serde_json::json!({"jsonrpc": "2.0", "id": 1, "result": signature})
+                    .to_string()
+                    .into_bytes()
+            })
+            .expect(1)
+            .create();
+        let _status = mock_status_bodies(&mut server, |_, count| finalized_value_body(count));
+
+        // A fresh process: no armed rotation, no SMT state, only the durable target.
+        let mut state = make_sender_state_with_server(&server.url());
+        state.instance_pda = Some(Pubkey::new_unique());
+        let pt = state.program_type.as_label();
+        state
+            .storage
+            .set_owed_rotation_target(pt, target_tree_index)
+            .await
+            .unwrap();
+
+        state.rearm_owed_rotation().await.unwrap();
+        assert!(
+            state.pending_rotation.is_some(),
+            "boot must re-arm from the durable target"
+        );
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        drive_pending_rotation(&mut state, &storage_tx).await;
+
+        send.assert();
+        assert!(
+            state.pending_rotation.is_none(),
+            "a confirmed reset retires the arm"
+        );
+        assert!(
+            state
+                .storage
+                .get_owed_rotation_target(pt)
+                .await
+                .unwrap()
+                .is_none(),
+            "and the durable target, so the next boot does not re-arm it"
+        );
+        assert_eq!(
+            state.smt_state.as_ref().unwrap().smt_state.tree_index(),
+            target_tree_index,
+            "local SMT moves to the generation the reset proved"
         );
         assert!(
             storage_rx.try_recv().is_err(),

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -194,7 +194,8 @@ pub struct SenderState {
     /// travels with the parked withdrawal.
     pub ambiguous_retry_queue: Vec<Box<ReleaseFundsBuilderWithNonce>>,
     /// The tree rotation the sender owes the chain, with the generation it owes.
-    /// A reset has no DB row and no nonce, so this is its only record; it is cleared
+    /// A reset has no DB row and no nonce, so its durable record is
+    /// `indexer_state.owed_rotation_target`, re-armed here at boot. Both are cleared
     /// only where a fresh on-chain read shows the chain reached the target.
     pub pending_rotation: Option<Box<ResetSmtRootBuilderWithTarget>>,
     pub program_type: ProgramType,

--- a/indexer/src/operator/utils/instruction_util.rs
+++ b/indexer/src/operator/utils/instruction_util.rs
@@ -252,6 +252,32 @@ pub struct ResetSmtRootBuilderWithTarget {
     pub target_tree_index: u64,
 }
 
+impl ResetSmtRootBuilderWithTarget {
+    /// Wire the reset's accounts. One constructor for both arming paths, the
+    /// processor's boundary dispatch and the sender's re-arm from the stored target,
+    /// so an account added here can never be missed by one of them.
+    pub fn new(
+        admin_pubkey: Pubkey,
+        operator_pubkey: Pubkey,
+        instance_pda: Pubkey,
+        operator_pda: Pubkey,
+        event_authority_pda: Pubkey,
+        target_tree_index: u64,
+    ) -> Self {
+        let mut builder = ResetSmtRootBuilder::new();
+        builder
+            .payer(admin_pubkey)
+            .operator(operator_pubkey)
+            .instance(instance_pda)
+            .operator_pda(operator_pda)
+            .event_authority(event_authority_pda);
+        Self {
+            builder,
+            target_tree_index,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ReleaseFundsBuilderWithNonce {
     pub builder: ReleaseFundsBuilder,

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -4,6 +4,7 @@ pub use try_requeue_prebroadcast::RequeueOutcome;
 pub mod bump_pending_remint_finality_attempt;
 pub mod claim_and_persist_deposit_signature;
 pub mod claim_remint_attempt;
+pub mod clear_owed_rotation_target;
 pub mod close;
 pub mod count_pending_transactions;
 pub mod delete_release_signatures;
@@ -21,6 +22,7 @@ pub mod get_mint;
 pub mod get_mint_balances_for_reconciliation;
 pub mod get_mint_status_at_slot;
 pub mod get_orphan_deposit_ids;
+pub mod get_owed_rotation_target;
 pub mod get_pending_db_transactions;
 pub mod get_pending_remint_transactions;
 pub mod get_release_signatures;
@@ -34,11 +36,13 @@ pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
 pub mod insert_mint_statuses_batch;
 pub mod insert_release_signature;
+pub mod lowest_unreleased_withdrawal_below;
 pub mod quarantine_all_active_withdrawals;
 pub mod reconciliation_halt;
 pub mod record_remint_result;
 pub mod sender_lock;
 pub mod set_mint_extension_flags;
+pub mod set_owed_rotation_target;
 pub mod set_pending_remint;
 pub mod sync_mint_status;
 pub mod try_complete_processing;
@@ -144,6 +148,38 @@ impl Storage {
         slot: u64,
     ) -> Result<(), StorageError> {
         update_committed_checkpoint::update_committed_checkpoint(self, program_type, slot).await
+    }
+
+    /// Tree generation the sender owes the chain; `None` if none is owed.
+    pub async fn get_owed_rotation_target(
+        &self,
+        program_type: &str,
+    ) -> Result<Option<u64>, StorageError> {
+        get_owed_rotation_target::get_owed_rotation_target(self, program_type).await
+    }
+
+    /// Record the owed tree generation before its rotation is dispatched.
+    pub async fn set_owed_rotation_target(
+        &self,
+        program_type: &str,
+        target_tree_index: u64,
+    ) -> Result<(), StorageError> {
+        set_owed_rotation_target::set_owed_rotation_target(self, program_type, target_tree_index)
+            .await
+    }
+
+    /// Retire the owed rotation once a chain read proved the target landed.
+    pub async fn clear_owed_rotation_target(
+        &self,
+        program_type: &str,
+        target_tree_index: u64,
+    ) -> Result<(), StorageError> {
+        clear_owed_rotation_target::clear_owed_rotation_target(
+            self,
+            program_type,
+            target_tree_index,
+        )
+        .await
     }
 
     /// Terminal status write; `Ok(false)` if row already off Processing.
@@ -284,6 +320,16 @@ impl Storage {
 
     pub async fn has_active_withdrawal_below(&self, nonce: i64) -> Result<bool, StorageError> {
         has_active_withdrawal_below::has_active_withdrawal_below(self, nonce).await
+    }
+
+    /// Lowest withdrawal nonce below `nonce` that still owes a release; `None` if all
+    /// lower nonces are terminal. Counts `Processing` where `has_active_withdrawal_below`
+    /// does not, so it holds on the sender's submit path across a restart.
+    pub async fn lowest_unreleased_withdrawal_below(
+        &self,
+        nonce: i64,
+    ) -> Result<Option<i64>, StorageError> {
+        lowest_unreleased_withdrawal_below::lowest_unreleased_withdrawal_below(self, nonce).await
     }
 
     /// Get completed withdrawal nonces in the given range [min_nonce, max_nonce)
@@ -1284,6 +1330,45 @@ mod tests {
             .unwrap();
         let val = storage.get_committed_checkpoint("escrow").await.unwrap();
         assert_eq!(val, Some(42));
+    }
+
+    #[tokio::test]
+    async fn dispatch_owed_rotation_target_via_mock() {
+        let (storage, _mock) = make_mock_storage();
+        assert!(storage
+            .get_owed_rotation_target("withdraw")
+            .await
+            .unwrap()
+            .is_none());
+
+        storage
+            .set_owed_rotation_target("withdraw", 7)
+            .await
+            .unwrap();
+        assert_eq!(
+            storage.get_owed_rotation_target("withdraw").await.unwrap(),
+            Some(7)
+        );
+
+        // A clear naming a different target must leave the owed one alone.
+        storage
+            .clear_owed_rotation_target("withdraw", 6)
+            .await
+            .unwrap();
+        assert_eq!(
+            storage.get_owed_rotation_target("withdraw").await.unwrap(),
+            Some(7)
+        );
+
+        storage
+            .clear_owed_rotation_target("withdraw", 7)
+            .await
+            .unwrap();
+        assert!(storage
+            .get_owed_rotation_target("withdraw")
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/indexer/src/storage/common/storage/clear_owed_rotation_target.rs
+++ b/indexer/src/storage/common/storage/clear_owed_rotation_target.rs
@@ -1,0 +1,20 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Retire the owed rotation once a chain read proved `target_tree_index` landed.
+pub async fn clear_owed_rotation_target(
+    storage: &Storage,
+    program_type: &str,
+    target_tree_index: u64,
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .clear_owed_rotation_target_internal(program_type, target_tree_index)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .clear_owed_rotation_target(program_type, target_tree_index)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/get_owed_rotation_target.rs
+++ b/indexer/src/storage/common/storage/get_owed_rotation_target.rs
@@ -1,0 +1,13 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Tree generation the sender still owes the chain, or `None` if none is owed.
+pub async fn get_owed_rotation_target(
+    storage: &Storage,
+    program_type: &str,
+) -> Result<Option<u64>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db.get_owed_rotation_target_internal(program_type).await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.get_owed_rotation_target(program_type).await,
+    }
+}

--- a/indexer/src/storage/common/storage/lowest_unreleased_withdrawal_below.rs
+++ b/indexer/src/storage/common/storage/lowest_unreleased_withdrawal_below.rs
@@ -1,0 +1,16 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Lowest withdrawal nonce below `nonce` that still owes a release, or `None` if every
+/// lower nonce is terminal. Gates the sender's tree-rotation submit.
+pub async fn lowest_unreleased_withdrawal_below(
+    storage: &Storage,
+    nonce: i64,
+) -> Result<Option<i64>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .lowest_unreleased_withdrawal_below_internal(nonce)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.lowest_unreleased_withdrawal_below(nonce).await,
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -54,6 +54,9 @@ pub struct MockStorage {
     pub completed_release_signatures: Arc<Mutex<HashMap<i64, Vec<String>>>>,
     /// Mirrors the single-row `reconciliation_halt` table; `None` = not halted.
     pub reconciliation_halt: Arc<Mutex<Option<HaltInfo>>>,
+    /// Mirrors `indexer_state.owed_rotation_target`: the tree generation the sender
+    /// owes, per program type. An absent key is a NULL column.
+    pub owed_rotation_targets: Arc<Mutex<HashMap<String, u64>>>,
 }
 
 impl MockStorage {
@@ -296,6 +299,32 @@ impl MockStorage {
         }))
     }
 
+    pub async fn lowest_unreleased_withdrawal_below(
+        &self,
+        nonce: i64,
+    ) -> Result<Option<i64>, StorageError> {
+        self.check_should_fail("lowest_unreleased_withdrawal_below")?;
+        let pending = self.pending_transactions.lock().unwrap();
+        // Processing included, unlike has_active_withdrawal_below: this gates the
+        // sender's submit, which must hold after a restart dropped its in-flight map.
+        Ok(pending
+            .iter()
+            .filter(|t| {
+                t.transaction_type == TransactionType::Withdrawal
+                    && matches!(
+                        t.status,
+                        TransactionStatus::Pending
+                            | TransactionStatus::Processing
+                            | TransactionStatus::Parked
+                            | TransactionStatus::PendingRemint
+                            | TransactionStatus::ManualReview
+                    )
+            })
+            .filter_map(|t| t.withdrawal_nonce)
+            .filter(|lower| *lower < nonce)
+            .min())
+    }
+
     pub async fn get_committed_checkpoint(
         &self,
         program_type: &str,
@@ -325,6 +354,46 @@ impl MockStorage {
                 }
             })
             .or_insert(slot);
+        Ok(())
+    }
+
+    pub async fn get_owed_rotation_target(
+        &self,
+        program_type: &str,
+    ) -> Result<Option<u64>, StorageError> {
+        self.check_should_fail("get_owed_rotation_target")?;
+        Ok(self
+            .owed_rotation_targets
+            .lock()
+            .unwrap()
+            .get(program_type)
+            .copied())
+    }
+
+    pub async fn set_owed_rotation_target(
+        &self,
+        program_type: &str,
+        target_tree_index: u64,
+    ) -> Result<(), StorageError> {
+        self.check_should_fail("set_owed_rotation_target")?;
+        self.owed_rotation_targets
+            .lock()
+            .unwrap()
+            .insert(program_type.to_string(), target_tree_index);
+        Ok(())
+    }
+
+    pub async fn clear_owed_rotation_target(
+        &self,
+        program_type: &str,
+        target_tree_index: u64,
+    ) -> Result<(), StorageError> {
+        self.check_should_fail("clear_owed_rotation_target")?;
+        // Mirrors the postgres WHERE guard: only the proven target is retired.
+        let mut map = self.owed_rotation_targets.lock().unwrap();
+        if map.get(program_type) == Some(&target_tree_index) {
+            map.remove(program_type);
+        }
         Ok(())
     }
 

--- a/indexer/src/storage/common/storage/set_owed_rotation_target.rs
+++ b/indexer/src/storage/common/storage/set_owed_rotation_target.rs
@@ -1,0 +1,20 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Record the tree generation the sender owes, before the rotation is dispatched.
+pub async fn set_owed_rotation_target(
+    storage: &Storage,
+    program_type: &str,
+    target_tree_index: u64,
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .set_owed_rotation_target_internal(program_type, target_tree_index)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .set_owed_rotation_target(program_type, target_tree_index)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -516,6 +516,15 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
 
+        // Tree generation the sender still owes the chain. NULL means none owed.
+        // Written before the rotation is dispatched, cleared only once a chain read
+        // shows the tree reached it, so a crash leaves the rotation re-armable.
+        sqlx::query(
+            "ALTER TABLE indexer_state ADD COLUMN IF NOT EXISTS owed_rotation_target BIGINT",
+        )
+        .execute(&self.pool)
+        .await?;
+
         // Create updated_at trigger function
         sqlx::query(
             r#"
@@ -1233,6 +1242,68 @@ impl PostgresDb {
         Ok(())
     }
 
+    pub async fn get_owed_rotation_target_internal(
+        &self,
+        program_type: &str,
+    ) -> Result<Option<u64>, sqlx::Error> {
+        let result: Option<(Option<i64>,)> = sqlx::query_as(
+            "SELECT owed_rotation_target FROM indexer_state WHERE program_type = $1",
+        )
+        .bind(program_type)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(result
+            .and_then(|(target,)| target)
+            .map(|target| target as u64))
+    }
+
+    pub async fn set_owed_rotation_target_internal(
+        &self,
+        program_type: &str,
+        target_tree_index: u64,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO indexer_state (program_type, owed_rotation_target, updated_at)
+            VALUES ($1, $2, NOW())
+            ON CONFLICT (program_type)
+            DO UPDATE SET
+                owed_rotation_target = EXCLUDED.owed_rotation_target,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(program_type)
+        .bind(target_tree_index as i64)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Clear only if the stored target is still the one the caller proved landed, so a
+    /// clear can never retire a rotation that is still owed.
+    pub async fn clear_owed_rotation_target_internal(
+        &self,
+        program_type: &str,
+        target_tree_index: u64,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            UPDATE indexer_state
+            SET owed_rotation_target = NULL
+            WHERE program_type = $1
+              AND owed_rotation_target = $2
+            "#,
+        )
+        .bind(program_type)
+        .bind(target_tree_index as i64)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn get_and_lock_pending_transactions_internal(
         &self,
         transaction_type: TransactionType,
@@ -1381,6 +1452,39 @@ impl PostgresDb {
         .fetch_one(&self.pool)
         .await?;
         Ok(exists)
+    }
+
+    /// Lowest withdrawal nonce below `nonce` that still owes a release, or `None` if every
+    /// lower nonce is terminal. Gates the sender's rotation submit: rotating past a nonce
+    /// that still owes a release closes the only tree that release can ever land on.
+    ///
+    /// Evaluated fresh on every attempt, so it covers rows that entered a live status
+    /// after the rotation was dispatched (a recovery demote to `pending`, a park, a queued
+    /// remint, a quarantine). `Processing` is included where
+    /// `has_active_withdrawal_below_internal` omits it: that query runs in the processor,
+    /// where a `Processing` row is one the sender holds in memory, and this one must hold
+    /// after a restart dropped that memory. Terminal means `completed` (released) or
+    /// `failed`/`failed_reminted` (written off or reminted), which are safe to rotate past.
+    pub async fn lowest_unreleased_withdrawal_below_internal(
+        &self,
+        nonce: i64,
+    ) -> Result<Option<i64>, sqlx::Error> {
+        let lowest: Option<i64> = sqlx::query_scalar(&format!(
+            r#"
+            SELECT MIN({nonce_col}) FROM transactions
+            WHERE {ttype} = $2
+              AND {nonce_col} < $1
+              AND {status} IN ('pending', 'processing', 'parked', 'pending_remint', 'manual_review')
+            "#,
+            ttype = transaction_cols::TRANSACTION_TYPE,
+            nonce_col = transaction_cols::WITHDRAWAL_NONCE,
+            status = transaction_cols::STATUS,
+        ))
+        .bind(nonce)
+        .bind(TransactionType::Withdrawal)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(lowest)
     }
 
     /// Returns true if the row was updated; false if already terminal.

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -576,6 +576,175 @@ async fn checkpoint_update_higher_slot() -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
+/// Settled means the nonce owes nothing on the closing tree: released, written off, or
+/// reminted back to the user.
+#[tokio::test(flavor = "multi_thread")]
+async fn lowest_unreleased_withdrawal_below_ignores_settled_statuses(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // Nonces are trigger-assigned from a sequence, so insert order fixes them: 0, 1, 2.
+    for (nonce, status) in [(0, "completed"), (1, "failed"), (2, "failed_reminted")] {
+        let row = make_db_transaction(&format!("settled_{nonce}"), TransactionType::Withdrawal);
+        let id = storage.insert_db_transaction(&row).await?;
+        sqlx::query("UPDATE transactions SET status = $1::text::transaction_status WHERE id = $2")
+            .bind(status)
+            .bind(id)
+            .execute(&pool)
+            .await?;
+    }
+
+    assert_eq!(storage.lowest_unreleased_withdrawal_below(3).await?, None);
+    Ok(())
+}
+
+/// Every live status blocks, `MIN` picks the lowest, and the boundary nonce never blocks
+/// its own rotation. The `processing` step is the one that matters most: this query counts
+/// it where `has_active_withdrawal_below` does not, which is what makes the gate hold
+/// after a restart dropped the sender's in-flight map.
+#[tokio::test(flavor = "multi_thread")]
+async fn lowest_unreleased_withdrawal_below_counts_every_live_status(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // Insert order fixes the trigger-assigned nonces 0..4.
+    let mut ids = Vec::new();
+    for nonce in 0..5 {
+        let row = make_db_transaction(&format!("live_{nonce}"), TransactionType::Withdrawal);
+        ids.push(storage.insert_db_transaction(&row).await?);
+    }
+    let set_status = |id: i64, status: &'static str| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query(
+                "UPDATE transactions SET status = $1::text::transaction_status WHERE id = $2",
+            )
+            .bind(status)
+            .bind(id)
+            .execute(&pool)
+            .await
+        }
+    };
+
+    // Settled one at a time, so each assertion names the status that is now lowest, and
+    // the walk ends with only the processing row live.
+    set_status(ids[0], "manual_review").await?;
+    set_status(ids[1], "parked").await?;
+    set_status(ids[2], "pending_remint").await?;
+    set_status(ids[3], "processing").await?;
+    set_status(ids[4], "completed").await?;
+
+    assert_eq!(
+        storage.lowest_unreleased_withdrawal_below(5).await?,
+        Some(0),
+        "manual_review blocks and is the lowest"
+    );
+
+    set_status(ids[0], "completed").await?;
+    assert_eq!(
+        storage.lowest_unreleased_withdrawal_below(5).await?,
+        Some(1),
+        "parked blocks"
+    );
+
+    set_status(ids[1], "completed").await?;
+    assert_eq!(
+        storage.lowest_unreleased_withdrawal_below(5).await?,
+        Some(2),
+        "pending_remint blocks"
+    );
+
+    // Only the processing row is live now, which is exactly where the two queries differ.
+    set_status(ids[2], "completed").await?;
+    assert_eq!(
+        storage.lowest_unreleased_withdrawal_below(5).await?,
+        Some(3),
+        "processing blocks the sender's submit"
+    );
+    assert!(
+        !storage.has_active_withdrawal_below(5).await?,
+        "while the processor's dispatch-time query ignores it, by design"
+    );
+
+    assert_eq!(
+        storage.lowest_unreleased_withdrawal_below(3).await?,
+        None,
+        "the boundary nonce belongs to the tree being opened, so it cannot block its own rotation"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn owed_rotation_target_no_row_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    assert!(storage
+        .get_owed_rotation_target("withdraw")
+        .await?
+        .is_none());
+    Ok(())
+}
+
+/// The set must work whether or not the program's `indexer_state` row exists yet: the
+/// sender's boot re-arm reads it, so an insert that silently no-ops would drop the
+/// rotation the same way the in-memory-only arm did.
+#[tokio::test(flavor = "multi_thread")]
+async fn owed_rotation_target_set_inserts_then_updates() -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+
+    storage.set_owed_rotation_target("withdraw", 1).await?;
+    assert_eq!(storage.get_owed_rotation_target("withdraw").await?, Some(1));
+
+    // Row now exists (and carries a checkpoint), so this takes the ON CONFLICT path.
+    storage.update_committed_checkpoint("withdraw", 42).await?;
+    storage.set_owed_rotation_target("withdraw", 2).await?;
+    assert_eq!(storage.get_owed_rotation_target("withdraw").await?, Some(2));
+    assert_eq!(
+        storage.get_committed_checkpoint("withdraw").await?,
+        Some(42),
+        "arming a rotation must not disturb the slot cursor on the same row"
+    );
+    Ok(())
+}
+
+/// A clear names the target it proved landed. Anything else must leave the rotation
+/// owed, or a stale clear would retire a rotation that still has to happen.
+#[tokio::test(flavor = "multi_thread")]
+async fn owed_rotation_target_clear_only_matching_target() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_pool, storage, _pg) = start_postgres().await?;
+
+    storage.set_owed_rotation_target("withdraw", 7).await?;
+
+    storage.clear_owed_rotation_target("withdraw", 6).await?;
+    assert_eq!(
+        storage.get_owed_rotation_target("withdraw").await?,
+        Some(7),
+        "a clear for a different target must not retire the owed rotation"
+    );
+
+    storage.clear_owed_rotation_target("withdraw", 7).await?;
+    assert!(
+        storage
+            .get_owed_rotation_target("withdraw")
+            .await?
+            .is_none(),
+        "the proven target must retire"
+    );
+    Ok(())
+}
+
+/// Both roles can share a database, so each reads only its own owed rotation.
+#[tokio::test(flavor = "multi_thread")]
+async fn owed_rotation_target_is_per_program_type() -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+
+    storage.set_owed_rotation_target("withdraw", 3).await?;
+
+    assert!(storage.get_owed_rotation_target("escrow").await?.is_none());
+    assert_eq!(storage.get_owed_rotation_target("withdraw").await?, Some(3));
+    Ok(())
+}
+
 /// Monotonic guard: lower slot never overwrites a higher one.
 #[tokio::test(flavor = "multi_thread")]
 async fn checkpoint_update_lower_slot_is_noop() -> Result<(), Box<dyn std::error::Error>> {

--- a/monitoring/provisioning/alerting/alert-rules.yml
+++ b/monitoring/provisioning/alerting/alert-rules.yml
@@ -374,3 +374,76 @@ groups:
                     type: gt
                     params: [0]
               refId: C
+
+  - orgId: 1
+    name: tree-rotation-alerts
+    folder: Solana Private Channels Alerts
+    interval: 1m
+    rules:
+      - uid: rotation-not-landing
+        title: "Tree rotation owed but not landing"
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: "Operator {{ $labels.job }} ({{ $labels.program_type }}) owes a tree rotation that keeps failing to land. The owed target is durable, so it is retried every 5s and survives restarts, and nothing else pages for it. Until the tree advances, the boundary withdrawal and every higher nonce cannot be released. Check the destination RPC, the signers, the fee payer balance and the database (a failed gate read also withholds it); the armed target is in indexer_state.owed_rotation_target."
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(private_channel_operator_transaction_errors_total{error_reason="rotation_not_landed"}[10m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [30]
+              refId: C
+
+      - uid: rotation-blocked-by-lower-nonce
+        title: "Tree rotation withheld: a lower nonce still owes a release"
+        condition: C
+        for: 15m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: "Operator {{ $labels.job }} ({{ $labels.program_type }}) is withholding a tree rotation because a withdrawal on the closing tree has not released yet. This is the safe outcome, not a fault: rotating would close the only tree that release can ever land on. The withheld nonce is in the sender log. Resolve that withdrawal, by releasing it or letting its remint finish, and the rotation proceeds on its own."
+        labels:
+          severity: warning
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(private_channel_operator_transaction_errors_total{error_reason="rotation_blocked_by_lower_nonce"}[10m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [30]
+              refId: C


### PR DESCRIPTION
## Context

dba96f0 made the tree rotation durable *within a process*: armed before anything fallible, gated on an on-chain read before every submit, cleared only on proof the chain reached the target, retried on a 5s tick. It claimed the boundary withdrawal row was the record across a restart, so the processor could re-derive the target.

That claim does not hold. The row is `Processing` with no signature, recovery quarantines exactly that shape, and `manual_review` blocks the dequeue frontier, so the row never reaches the processor again. `pending_rotation` was memory-only, and a crash before the reset landed dropped the only automatic rotation for that boundary.

## What this does

  - Adds `indexer_state.owed_rotation_target` (nullable, `ALTER ... IF NOT EXISTS` in `init_schema`, no manual migration). The processor persists the target **before** dispatching, so a failed write bubbles as Transient with the head row requeued rather than a reset flying with no record.
  - The sender re-arms from it at boot, next to `recover_pending_remints`, and returns early for any role without an escrow instance. Arming is all it does: the existing tick reads the chain and disarms without sending if the tree already advanced.
  - `disarm_rotation` replaces the three bare `pending_rotation = None` sites and clears the row first. A failed clear is benign: the next boot re-arms and the gate disarms it again without sending.
  - `ResetSmtRootBuilderWithTarget::new` is now the only place the reset's accounts are wired, called by both the dispatch and the boot re-arm, so an added account cannot be missed by one path.

## Second-order fix included

Making the rotation outlive its process broke an existing invariant. Two guards protect a closing tree and only one was durable: the processor's query excludes `Processing` rows on purpose (`db.rs:1357-1361`), covering them with the sender's in-memory in-flight map. That map dies with the process while the owed target now survives, so a re-armed rotation could close a tree a lower nonce still had to release on, and `release_funds` rejects that nonce forever afterwards (`instance.rs:87-98`).

New `lowest_unreleased_withdrawal_below` gate on the submit path, evaluated fresh per attempt, placed below the in-flight check so normal pacing stays on the quiet branch, with checked arithmetic so a corrupt target cannot wrap into a no-op, and failing closed on a read error.

Also adds a `tree-rotation-alerts` group: `rotation_not_landing` (critical, nothing else pages) and `rotation-blocked-by-lower-nonce` (warning, resolve that nonce).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 13,783 | 15,483 | 89.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31737452452) |
| Indexer | 34,851 | 38,359 | 90.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31737452452) |
| Gateway | 1,476 | 1,698 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31737452452) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31737452452) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,249 | 18,087 | 78.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31737452452) |
| **Total** | **65,144** | **74,530** | **87.4%** | |

> Last updated: 2026-08-13 20:31:37 UTC by E2E Integration