### PR TITLE
Fix/issue 289

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -153,7 +153,7 @@ Every role change and administrative wallet attach writes a row to `private_chan
 
 This is the trail of privileged grants — one account acting on another. Self-service wallet changes are not in it: verification proves key ownership before it stores anything, and removal only ever touches the caller's own wallets.
 
-Nothing in the service updates or deletes from that table, but the CLI's database role can create tables and so could drop it. If the trail needs to survive a compromised admin credential, give the audit table its own role with `INSERT` only.
+Nothing in the service updates or deletes from that table. The CLI only runs DDL when the schema is missing, so it works under a role with no create rights; if the trail needs to survive a compromised admin credential, that role should also have `INSERT` but not `UPDATE`/`DELETE` on the audit table.
 
 ```sql
 SELECT * FROM private_channel_auth.admin_audit ORDER BY created_at DESC;

--- a/auth/README.md
+++ b/auth/README.md
@@ -151,7 +151,7 @@ AUTH_DATABASE_URL=postgres://... AUTH_ADMIN_ACTOR=you@example.com cargo run -p a
 
 Every role change and administrative wallet attach writes a row to `private_channel_auth.admin_audit` in the same transaction as the change itself, recording the actor, action, target user id and detail (`user -> operator`, or the attached pubkey). The `set-role` detail is read by the same statement that performs the update, so it records the role actually replaced.
 
-This is the trail of privileged grants — one account acting on another. Self-service wallet verification and removal are not in it; those are the account's own actions through a flow that already proves key ownership.
+This is the trail of privileged grants — one account acting on another. Self-service wallet changes are not in it: verification proves key ownership before it stores anything, and removal only ever touches the caller's own wallets.
 
 Nothing in the service updates or deletes from that table, but the CLI's database role can create tables and so could drop it. If the trail needs to survive a compromised admin credential, give the audit table its own role with `INSERT` only.
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -108,22 +108,49 @@ There are two roles: `user` (default) and `operator`.
 | `user` | Standard role. All registered accounts start as `user`. |
 | `operator` | Elevated role. Can call operator-only methods on the gateway without ownership checks. |
 
-**Operators must be provisioned directly in the database** — there is no API to assign or escalate to the operator role. This is intentional: operator access is an infrastructure-level concern, not a self-service one.
+**Operators must be provisioned with the admin CLI** — there is no API to assign or escalate to the operator role. This is intentional: operator access is an infrastructure-level concern, not a self-service one.
 
-```sql
-UPDATE private_channel_auth.users SET role = 'operator' WHERE username = 'alice';
-```
+Never provision by username. Usernames are claimed first-come on `/auth/register`, so anyone who registers the intended operator's name before you promote it receives the operator role instead. The admin CLI takes the immutable user id for exactly this reason.
 
 ## Admin CLI
 
-Operator-only commands for managing users directly against the auth database. Requires `AUTH_DATABASE_URL` (same DB the auth service uses).
+Operator-only commands for managing users directly against the auth database.
+
+| Variable | Description |
+|---|---|
+| `AUTH_DATABASE_URL` | Same DB the auth service uses. |
+| `AUTH_ADMIN_ACTOR` | Who is running the command. Required for `set-role` and `attach-wallet`; recorded in the audit trail. |
+
+Both mutating commands print the target's id, username, current role and creation time and wait for a typed `yes` before proceeding. `--yes` skips the prompt for scripted use.
+
+### Provisioning flow
+
+Ask the account owner for their user id out of band — the registration response and the JWT `sub` claim both carry it. Confirm it against the account before granting anything:
+
+```bash
+AUTH_DATABASE_URL=postgres://... cargo run -p auth --bin auth-admin -- show-user --username alice
+```
+
+### Set a user's role
+
+```bash
+AUTH_DATABASE_URL=postgres://... AUTH_ADMIN_ACTOR=you@example.com cargo run -p auth --bin auth-admin -- set-role --user-id <uuid> --role operator
+```
 
 ### Attach a wallet to a user
 
 Inserts a row into `private_channel_auth.verified_wallets` without running the challenge/signature flow — the operator is asserting trust, the user does not prove ownership. Use this for provisioning or recovery, not as a substitute for the normal verification flow.
 
 ```bash
-AUTH_DATABASE_URL=postgres://... cargo run -p auth --bin admin -- attach-wallet --username alice --pubkey <base58>
+AUTH_DATABASE_URL=postgres://... AUTH_ADMIN_ACTOR=you@example.com cargo run -p auth --bin auth-admin -- attach-wallet --user-id <uuid> --pubkey <base58>
+```
+
+### Audit trail
+
+Every role change and administrative wallet attach writes a row to `private_channel_auth.admin_audit` in the same transaction as the change itself, recording the actor, action, target user id and detail (`user -> operator`, or the attached pubkey). Nothing in the service updates or deletes from that table.
+
+```sql
+SELECT * FROM private_channel_auth.admin_audit ORDER BY created_at DESC;
 ```
 
 ## Wallet verification flow

--- a/auth/README.md
+++ b/auth/README.md
@@ -125,11 +125,13 @@ Both mutating commands print the target's id, username, current role and creatio
 
 ### Provisioning flow
 
-Ask the account owner for their user id out of band — the registration response and the JWT `sub` claim both carry it. Confirm it against the account before granting anything:
+Ask the account owner for their user id out of band — the registration response and the JWT `sub` claim both carry it. Look that id up and check the username and creation time match the account you mean to grant:
 
 ```bash
-AUTH_DATABASE_URL=postgres://... cargo run -p auth --bin auth-admin -- show-user --username alice
+AUTH_DATABASE_URL=postgres://... cargo run -p auth --bin auth-admin -- show-user --user-id <uuid>
 ```
+
+Do not go the other way. `show-user --username alice` resolves a name to whoever holds it, which answers "is this name taken" but not "is this the person" — deriving the id from a name reintroduces exactly the confusion the id-based commands exist to prevent.
 
 ### Set a user's role
 
@@ -147,7 +149,11 @@ AUTH_DATABASE_URL=postgres://... AUTH_ADMIN_ACTOR=you@example.com cargo run -p a
 
 ### Audit trail
 
-Every role change and administrative wallet attach writes a row to `private_channel_auth.admin_audit` in the same transaction as the change itself, recording the actor, action, target user id and detail (`user -> operator`, or the attached pubkey). Nothing in the service updates or deletes from that table.
+Every role change and administrative wallet attach writes a row to `private_channel_auth.admin_audit` in the same transaction as the change itself, recording the actor, action, target user id and detail (`user -> operator`, or the attached pubkey). The `set-role` detail is read by the same statement that performs the update, so it records the role actually replaced.
+
+This is the trail of privileged grants — one account acting on another. Self-service wallet verification and removal are not in it; those are the account's own actions through a flow that already proves key ownership.
+
+Nothing in the service updates or deletes from that table, but the CLI's database role can create tables and so could drop it. If the trail needs to survive a compromised admin credential, give the audit table its own role with `INSERT` only.
 
 ```sql
 SELECT * FROM private_channel_auth.admin_audit ORDER BY created_at DESC;

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -174,11 +174,26 @@ async fn connect(database_url: &str) -> Result<sqlx::PgPool> {
         .await
         .map_err(|e| anyhow!("Failed to connect to auth DB: {}", e))?;
 
-    // Idempotent, and it keeps the tool usable against a database whose auth
-    // service hasn't yet restarted onto a schema carrying `admin_audit`.
-    db::init_schema(&pool).await?;
+    ensure_schema(&pool).await?;
 
     Ok(pool)
+}
+
+/// Create the schema only when it is actually missing, which keeps the tool
+/// usable against a database whose auth service hasn't yet restarted onto a
+/// schema carrying `admin_audit`. Running the DDL unconditionally would mean a
+/// least-privilege admin role couldn't so much as look a user up.
+async fn ensure_schema(pool: &sqlx::PgPool) -> Result<()> {
+    let (initialized,): (bool,) =
+        sqlx::query_as(r#"SELECT to_regclass('private_channel_auth.admin_audit') IS NOT NULL"#)
+            .fetch_one(pool)
+            .await?;
+
+    if !initialized {
+        db::init_schema(pool).await?;
+    }
+
+    Ok(())
 }
 
 /// Names the person running the command in the audit trail. Required rather than
@@ -700,6 +715,39 @@ mod tests {
                 "answer {answer:?} must not be recorded"
             );
         }
+    }
+
+    /// Runs on every command, so a role without CREATE rights — the
+    /// least-privilege deployment — has to get through an initialized database.
+    #[tokio::test]
+    async fn ensure_schema_skips_ddl_when_already_initialized() {
+        let (pool, container) = start_pool().await;
+        sqlx::query("CREATE ROLE restricted LOGIN PASSWORD 'password'")
+            .execute(&pool)
+            .await
+            .expect("create role");
+        sqlx::query("GRANT USAGE ON SCHEMA private_channel_auth TO restricted")
+            .execute(&pool)
+            .await
+            .expect("grant usage");
+
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(5432).await.unwrap();
+        let restricted = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&format!(
+                "postgres://restricted:password@{host}:{port}/auth_test"
+            ))
+            .await
+            .expect("connect as restricted");
+
+        // Precondition: the role really can't run the DDL that was previously
+        // unconditional, so the assertion below isn't vacuous.
+        db::init_schema(&restricted)
+            .await
+            .expect_err("restricted must lack DDL rights");
+
+        ensure_schema(&restricted).await.expect("must not run DDL");
     }
 
     #[tokio::test]

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -212,8 +212,8 @@ fn confirm(user: &User, action: &str, skip: bool, input: &mut impl BufRead) -> R
     print!("type 'yes' to continue: ");
     io::stdout().flush()?;
 
-    // A closed stdin reads as end-of-input, which leaves the answer empty and
-    // aborts. Piping into the tool never grants anything by default.
+    // A closed or empty stdin reads as end-of-input, leaving the answer empty,
+    // which aborts.
     let mut answer = String::new();
     input.read_line(&mut answer)?;
 
@@ -322,10 +322,11 @@ async fn attach_wallet(
 
 #[cfg(test)]
 // `ENV_LOCK` is a synchronous Mutex held across `.await` on purpose: it
-// serializes process-global env-var mutation across async tests, so the lock
-// has to stay held for the whole `run` call that reads the vars, not just the
-// setup. An async Mutex would let another test swap the environment mid-run.
-// Clippy can't distinguish the two cases, so silence the lint module-wide.
+// serializes process-global env-var mutation, so the lock has to stay held for
+// the whole `run` call that reads the vars, not just the setup. The lint guards
+// against a std guard blocking an executor thread that other tasks need; each
+// `#[tokio::test]` here gets its own runtime with a single task, so there is no
+// other task to starve. Clippy can't see that, so silence it module-wide.
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
@@ -699,6 +700,34 @@ mod tests {
                 "answer {answer:?} must not be recorded"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn attach_wallet_grants_nothing_without_confirmation() {
+        let (pool, _c) = start_pool().await;
+        let user = db::insert_user(&pool, "frank", "$argon2id$placeholder")
+            .await
+            .expect("insert user");
+        let pubkey = Pubkey::new_unique().to_string();
+
+        attach_wallet(
+            &pool,
+            "admin",
+            AttachWalletArgs {
+                user_id: user.id,
+                pubkey,
+                yes: false,
+            },
+            &mut Cursor::new("no\n"),
+        )
+        .await
+        .expect("declining is not an error");
+
+        assert!(db::list_verified_wallets(&pool, user.id)
+            .await
+            .expect("list wallets")
+            .is_empty());
+        assert!(audit_rows(&pool).await.is_empty());
     }
 
     #[tokio::test]

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -1,11 +1,20 @@
 use {
     anyhow::{anyhow, Result},
     clap::{Parser, Subcommand},
-    private_channel_auth::{db, error::AppError, models::Role},
+    private_channel_auth::{
+        db,
+        error::AppError,
+        models::{Role, User},
+    },
     solana_sdk::pubkey::Pubkey,
     sqlx::postgres::PgPoolOptions,
-    std::{env, str::FromStr},
+    std::{
+        env,
+        io::{self, Write},
+        str::FromStr,
+    },
     tracing::{error, info},
+    uuid::Uuid,
 };
 
 #[derive(Parser, Debug)]
@@ -28,6 +37,8 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Look up a user's immutable id, role and creation time
+    ShowUser(ShowUserArgs),
     /// Attach a wallet to a user without verification — operator asserts trust
     AttachWallet(AttachWalletArgs),
     /// Set a user's RBAC role (e.g. promote to operator so the gateway grants it
@@ -36,14 +47,25 @@ enum Command {
 }
 
 #[derive(Parser, Debug)]
-struct AttachWalletArgs {
-    /// Username of the user to attach the wallet to
+struct ShowUserArgs {
+    /// Username to resolve to an id
     #[arg(long)]
     username: String,
+}
+
+#[derive(Parser, Debug)]
+struct AttachWalletArgs {
+    /// Immutable id of the user to attach the wallet to
+    #[arg(long)]
+    user_id: Uuid,
 
     /// Base58-encoded Solana pubkey to attach to the user
     #[arg(long)]
     pubkey: String,
+
+    /// Skip the confirmation prompt
+    #[arg(long)]
+    yes: bool,
 }
 
 #[derive(Clone, Debug, clap::ValueEnum)]
@@ -53,13 +75,6 @@ enum RoleArg {
 }
 
 impl RoleArg {
-    fn as_str(&self) -> &'static str {
-        match self {
-            RoleArg::Operator => "operator",
-            RoleArg::User => "user",
-        }
-    }
-
     fn to_model(&self) -> Role {
         match self {
             RoleArg::Operator => Role::Operator,
@@ -70,13 +85,17 @@ impl RoleArg {
 
 #[derive(Parser, Debug)]
 struct SetRoleArgs {
-    /// Username of the user whose role to change
+    /// Immutable id of the user whose role to change
     #[arg(long)]
-    username: String,
+    user_id: Uuid,
 
     /// Role to assign
     #[arg(long)]
     role: RoleArg,
+
+    /// Skip the confirmation prompt
+    #[arg(long)]
+    yes: bool,
 }
 
 #[tokio::main]
@@ -120,54 +139,129 @@ async fn run(args: Args) -> Result<()> {
         .await
         .map_err(|e| anyhow!("Failed to connect to auth DB: {}", e))?;
 
+    // Idempotent, and it keeps the tool usable against a database whose auth
+    // service hasn't yet restarted onto a schema carrying `admin_audit`.
+    db::init_schema(&pool).await?;
+
     match args.command {
-        Command::AttachWallet(args) => attach_wallet(&pool, args).await?,
-        Command::SetRole(args) => set_role(&pool, args).await?,
+        Command::ShowUser(args) => show_user(&pool, args).await?,
+        Command::AttachWallet(args) => attach_wallet(&pool, &admin_actor()?, args).await?,
+        Command::SetRole(args) => set_role(&pool, &admin_actor()?, args).await?,
     }
 
     Ok(())
 }
 
-async fn set_role(pool: &sqlx::PgPool, args: SetRoleArgs) -> Result<()> {
-    let role = args.role.as_str();
-    let updated = db::set_user_role(pool, &args.username, args.role.to_model()).await?;
-    if !updated {
-        return Err(anyhow!("user not found: {}", args.username));
+/// Names the person running the command in the audit trail. Required rather than
+/// defaulted: a row recording "unknown" is not worth writing.
+fn admin_actor() -> Result<String> {
+    let actor = env::var("AUTH_ADMIN_ACTOR").map_err(|_| anyhow!("AUTH_ADMIN_ACTOR is not set"))?;
+    if actor.trim().is_empty() {
+        return Err(anyhow!("AUTH_ADMIN_ACTOR must not be empty"));
     }
-    info!(username = %args.username, role, "set role");
-    println!("set role of {} to {}", args.username, role);
-    Ok(())
+    Ok(actor)
 }
 
-async fn attach_wallet(pool: &sqlx::PgPool, args: AttachWalletArgs) -> Result<()> {
-    let pubkey = Pubkey::from_str(&args.pubkey)
-        .map_err(|_| anyhow!("invalid pubkey: {}", args.pubkey))?
-        .to_string();
+fn print_user(user: &User) {
+    println!("  id:         {}", user.id);
+    println!("  username:   {}", user.username);
+    println!("  role:       {}", user.role.as_str());
+    println!("  created_at: {}", user.created_at);
+}
 
+/// Show who is about to be changed and require an explicit `yes`. These are the
+/// fields an administrator matches against what the account owner reported out of
+/// band, so a grant lands on the person it was meant for and not on whoever
+/// registered the name first.
+fn confirm(user: &User, action: &str, skip: bool) -> Result<bool> {
+    if skip {
+        return Ok(true);
+    }
+
+    println!("about to {action} for:");
+    print_user(user);
+    print!("type 'yes' to continue: ");
+    io::stdout().flush()?;
+
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+
+    Ok(answer.trim() == "yes")
+}
+
+async fn show_user(pool: &sqlx::PgPool, args: ShowUserArgs) -> Result<()> {
     let user = db::find_user_by_username(pool, &args.username)
         .await?
         .ok_or_else(|| anyhow!("user not found: {}", args.username))?;
 
-    let wallet = db::insert_verified_wallet(pool, user.id, &pubkey)
+    print_user(&user);
+
+    Ok(())
+}
+
+async fn set_role(pool: &sqlx::PgPool, actor: &str, args: SetRoleArgs) -> Result<()> {
+    let user = db::find_user_by_id(pool, args.user_id)
+        .await?
+        .ok_or_else(|| anyhow!("user not found: {}", args.user_id))?;
+
+    let role = args.role.to_model();
+    let role_str = role.as_str();
+    if !confirm(&user, &format!("set role to {role_str}"), args.yes)? {
+        println!("aborted");
+        return Ok(());
+    }
+
+    // Both ends of the transition, so a real promotion is distinguishable from a
+    // command that changed nothing.
+    let detail = format!("{} -> {role_str}", user.role.as_str());
+
+    let mut tx = pool.begin().await?;
+    if !db::set_user_role(&mut *tx, user.id, role).await? {
+        return Err(anyhow!("user not found: {}", args.user_id));
+    }
+    db::insert_admin_audit(&mut *tx, actor, "set_role", user.id, &detail).await?;
+    tx.commit().await?;
+
+    info!(user_id = %user.id, username = %user.username, actor, detail = %detail, "set role");
+    println!("set role of {} ({}) to {role_str}", user.username, user.id);
+
+    Ok(())
+}
+
+async fn attach_wallet(pool: &sqlx::PgPool, actor: &str, args: AttachWalletArgs) -> Result<()> {
+    let pubkey = Pubkey::from_str(&args.pubkey)
+        .map_err(|_| anyhow!("invalid pubkey: {}", args.pubkey))?
+        .to_string();
+
+    let user = db::find_user_by_id(pool, args.user_id)
+        .await?
+        .ok_or_else(|| anyhow!("user not found: {}", args.user_id))?;
+
+    if !confirm(&user, &format!("attach wallet {pubkey}"), args.yes)? {
+        println!("aborted");
+        return Ok(());
+    }
+
+    let mut tx = pool.begin().await?;
+    let wallet = db::insert_verified_wallet(&mut *tx, user.id, &pubkey)
         .await
         .map_err(|e| match e {
             // Unique constraint on (user_id, pubkey) — wallet already attached.
             AppError::Db(sqlx::Error::Database(ref db_err))
                 if db_err.constraint() == Some("verified_wallets_user_id_pubkey_key") =>
             {
-                anyhow!(
-                    "wallet {} is already attached to user {}",
-                    pubkey,
-                    args.username
-                )
+                anyhow!("wallet {} is already attached to user {}", pubkey, user.id)
             }
             other => anyhow::Error::new(other),
         })?;
+    db::insert_admin_audit(&mut *tx, actor, "attach_wallet", user.id, &wallet.pubkey).await?;
+    tx.commit().await?;
 
     info!(
         user_id = %user.id,
         username = %user.username,
         pubkey = %wallet.pubkey,
+        actor,
         "attached wallet"
     );
 
@@ -219,11 +313,31 @@ mod tests {
         (pool, container)
     }
 
-    fn attach_args(username: &str, pubkey: &str) -> AttachWalletArgs {
+    // Every test drives the commands non-interactively; the confirmation prompt
+    // reads stdin, which no test has.
+    fn attach_args(user_id: Uuid, pubkey: &str) -> AttachWalletArgs {
         AttachWalletArgs {
-            username: username.into(),
+            user_id,
             pubkey: pubkey.into(),
+            yes: true,
         }
+    }
+
+    fn set_role_args(user_id: Uuid, role: RoleArg) -> SetRoleArgs {
+        SetRoleArgs {
+            user_id,
+            role,
+            yes: true,
+        }
+    }
+
+    async fn audit_rows(pool: &PgPool) -> Vec<(String, String, Uuid, String)> {
+        sqlx::query_as(
+            r#"SELECT actor, action, target_user_id, detail FROM private_channel_auth.admin_audit"#,
+        )
+        .fetch_all(pool)
+        .await
+        .expect("read audit trail")
     }
 
     fn run_args(command: Command) -> Args {
@@ -240,7 +354,11 @@ mod tests {
         let prev = env::var("AUTH_DATABASE_URL").ok();
         env::remove_var("AUTH_DATABASE_URL");
 
-        let result = run(run_args(Command::AttachWallet(attach_args("u", "p")))).await;
+        let result = run(run_args(Command::AttachWallet(attach_args(
+            Uuid::new_v4(),
+            "p",
+        ))))
+        .await;
 
         match prev {
             Some(p) => env::set_var("AUTH_DATABASE_URL", p),
@@ -257,7 +375,11 @@ mod tests {
         let prev = env::var("AUTH_DATABASE_URL").ok();
         env::set_var("AUTH_DATABASE_URL", "mysql://localhost/test");
 
-        let result = run(run_args(Command::AttachWallet(attach_args("u", "p")))).await;
+        let result = run(run_args(Command::AttachWallet(attach_args(
+            Uuid::new_v4(),
+            "p",
+        ))))
+        .await;
 
         match prev {
             Some(p) => env::set_var("AUTH_DATABASE_URL", p),
@@ -274,7 +396,7 @@ mod tests {
     #[tokio::test]
     async fn attach_wallet_rejects_invalid_pubkey() {
         let (pool, _c) = start_pool().await;
-        let err = attach_wallet(&pool, attach_args("alice", "not-base58"))
+        let err = attach_wallet(&pool, "admin", attach_args(Uuid::new_v4(), "not-base58"))
             .await
             .expect_err("expected error");
         assert!(err.to_string().contains("invalid pubkey"), "got: {err}");
@@ -284,7 +406,7 @@ mod tests {
     async fn attach_wallet_rejects_unknown_user() {
         let (pool, _c) = start_pool().await;
         let pubkey = Pubkey::new_unique().to_string();
-        let err = attach_wallet(&pool, attach_args("ghost", &pubkey))
+        let err = attach_wallet(&pool, "admin", attach_args(Uuid::new_v4(), &pubkey))
             .await
             .expect_err("expected error");
         assert!(err.to_string().contains("user not found"), "got: {err}");
@@ -298,7 +420,7 @@ mod tests {
             .expect("insert user");
         let pubkey = Pubkey::new_unique().to_string();
 
-        attach_wallet(&pool, attach_args("bob", &pubkey))
+        attach_wallet(&pool, "admin", attach_args(user.id, &pubkey))
             .await
             .expect("attach should succeed");
 
@@ -307,6 +429,16 @@ mod tests {
             .expect("list wallets");
         assert_eq!(wallets.len(), 1);
         assert_eq!(wallets[0].pubkey, pubkey);
+
+        assert_eq!(
+            audit_rows(&pool).await,
+            vec![(
+                "admin".to_string(),
+                "attach_wallet".to_string(),
+                user.id,
+                pubkey
+            )]
+        );
     }
 
     #[tokio::test]
@@ -317,11 +449,11 @@ mod tests {
             .expect("insert user");
         let pubkey = Pubkey::new_unique().to_string();
 
-        attach_wallet(&pool, attach_args("carol", &pubkey))
+        attach_wallet(&pool, "admin", attach_args(user.id, &pubkey))
             .await
             .expect("first attach should succeed");
 
-        let err = attach_wallet(&pool, attach_args("carol", &pubkey))
+        let err = attach_wallet(&pool, "admin", attach_args(user.id, &pubkey))
             .await
             .expect_err("second attach should fail");
         assert!(
@@ -335,30 +467,37 @@ mod tests {
             .expect("list wallets");
         assert_eq!(wallets.len(), 1, "failed attach should not duplicate row");
         assert_eq!(wallets[0].pubkey, pubkey);
+
+        // The rolled-back attach must not leave a record of a change that never happened.
+        assert_eq!(audit_rows(&pool).await.len(), 1);
     }
 
     #[tokio::test]
     async fn set_role_promotes_user_to_operator() {
         let (pool, _c) = start_pool().await;
-        db::insert_user(&pool, "dave", "$argon2id$placeholder")
+        let user = db::insert_user(&pool, "dave", "$argon2id$placeholder")
             .await
             .expect("insert user");
 
-        set_role(
-            &pool,
-            SetRoleArgs {
-                username: "dave".into(),
-                role: RoleArg::Operator,
-            },
-        )
-        .await
-        .expect("set role should succeed");
+        set_role(&pool, "admin", set_role_args(user.id, RoleArg::Operator))
+            .await
+            .expect("set role should succeed");
 
-        let user = db::find_user_by_username(&pool, "dave")
+        let promoted = db::find_user_by_id(&pool, user.id)
             .await
             .expect("find user")
             .expect("user exists");
-        assert_eq!(user.role, private_channel_auth::models::Role::Operator);
+        assert_eq!(promoted.role, Role::Operator);
+
+        assert_eq!(
+            audit_rows(&pool).await,
+            vec![(
+                "admin".to_string(),
+                "set_role".to_string(),
+                user.id,
+                "user -> operator".to_string()
+            )]
+        );
     }
 
     #[tokio::test]
@@ -366,13 +505,12 @@ mod tests {
         let (pool, _c) = start_pool().await;
         let err = set_role(
             &pool,
-            SetRoleArgs {
-                username: "ghost".into(),
-                role: RoleArg::Operator,
-            },
+            "admin",
+            set_role_args(Uuid::new_v4(), RoleArg::Operator),
         )
         .await
         .expect_err("expected error");
         assert!(err.to_string().contains("user not found"), "got: {err}");
+        assert!(audit_rows(&pool).await.is_empty());
     }
 }

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -10,7 +10,7 @@ use {
     sqlx::postgres::PgPoolOptions,
     std::{
         env,
-        io::{self, Write},
+        io::{self, BufRead, Write},
         str::FromStr,
     },
     tracing::{error, info},
@@ -47,10 +47,15 @@ enum Command {
 }
 
 #[derive(Parser, Debug)]
+#[group(required = true, multiple = false)]
 struct ShowUserArgs {
+    /// Id to look up, to confirm an id reported out of band against the account
+    #[arg(long)]
+    user_id: Option<Uuid>,
+
     /// Username to resolve to an id
     #[arg(long)]
-    username: String,
+    username: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -133,9 +138,39 @@ async fn run(args: Args) -> Result<()> {
         return Err(anyhow!("AUTH_DATABASE_URL must be a PostgreSQL URL"));
     }
 
+    // The actor is resolved before connecting so a missing one fails without the
+    // tool having touched the database.
+    match args.command {
+        Command::ShowUser(args) => show_user(&connect(&database_url).await?, args).await?,
+        Command::AttachWallet(args) => {
+            let actor = admin_actor()?;
+            attach_wallet(
+                &connect(&database_url).await?,
+                &actor,
+                args,
+                &mut io::stdin().lock(),
+            )
+            .await?
+        }
+        Command::SetRole(args) => {
+            let actor = admin_actor()?;
+            set_role(
+                &connect(&database_url).await?,
+                &actor,
+                args,
+                &mut io::stdin().lock(),
+            )
+            .await?
+        }
+    }
+
+    Ok(())
+}
+
+async fn connect(database_url: &str) -> Result<sqlx::PgPool> {
     let pool = PgPoolOptions::new()
         .max_connections(1)
-        .connect(&database_url)
+        .connect(database_url)
         .await
         .map_err(|e| anyhow!("Failed to connect to auth DB: {}", e))?;
 
@@ -143,13 +178,7 @@ async fn run(args: Args) -> Result<()> {
     // service hasn't yet restarted onto a schema carrying `admin_audit`.
     db::init_schema(&pool).await?;
 
-    match args.command {
-        Command::ShowUser(args) => show_user(&pool, args).await?,
-        Command::AttachWallet(args) => attach_wallet(&pool, &admin_actor()?, args).await?,
-        Command::SetRole(args) => set_role(&pool, &admin_actor()?, args).await?,
-    }
-
-    Ok(())
+    Ok(pool)
 }
 
 /// Names the person running the command in the audit trail. Required rather than
@@ -173,7 +202,7 @@ fn print_user(user: &User) {
 /// fields an administrator matches against what the account owner reported out of
 /// band, so a grant lands on the person it was meant for and not on whoever
 /// registered the name first.
-fn confirm(user: &User, action: &str, skip: bool) -> Result<bool> {
+fn confirm(user: &User, action: &str, skip: bool, input: &mut impl BufRead) -> Result<bool> {
     if skip {
         return Ok(true);
     }
@@ -183,42 +212,55 @@ fn confirm(user: &User, action: &str, skip: bool) -> Result<bool> {
     print!("type 'yes' to continue: ");
     io::stdout().flush()?;
 
+    // A closed stdin reads as end-of-input, which leaves the answer empty and
+    // aborts. Piping into the tool never grants anything by default.
     let mut answer = String::new();
-    io::stdin().read_line(&mut answer)?;
+    input.read_line(&mut answer)?;
 
     Ok(answer.trim() == "yes")
 }
 
 async fn show_user(pool: &sqlx::PgPool, args: ShowUserArgs) -> Result<()> {
-    let user = db::find_user_by_username(pool, &args.username)
-        .await?
-        .ok_or_else(|| anyhow!("user not found: {}", args.username))?;
+    let user = match (args.user_id, &args.username) {
+        (Some(user_id), _) => db::find_user_by_id(pool, user_id)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {user_id}"))?,
+        (None, Some(username)) => db::find_user_by_username(pool, username)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {username}"))?,
+        // clap's argument group requires exactly one of the two.
+        (None, None) => return Err(anyhow!("one of --user-id or --username is required")),
+    };
 
     print_user(&user);
 
     Ok(())
 }
 
-async fn set_role(pool: &sqlx::PgPool, actor: &str, args: SetRoleArgs) -> Result<()> {
+async fn set_role(
+    pool: &sqlx::PgPool,
+    actor: &str,
+    args: SetRoleArgs,
+    input: &mut impl BufRead,
+) -> Result<()> {
     let user = db::find_user_by_id(pool, args.user_id)
         .await?
         .ok_or_else(|| anyhow!("user not found: {}", args.user_id))?;
 
     let role = args.role.to_model();
     let role_str = role.as_str();
-    if !confirm(&user, &format!("set role to {role_str}"), args.yes)? {
+    if !confirm(&user, &format!("set role to {role_str}"), args.yes, input)? {
         println!("aborted");
         return Ok(());
     }
 
-    // Both ends of the transition, so a real promotion is distinguishable from a
-    // command that changed nothing.
-    let detail = format!("{} -> {role_str}", user.role.as_str());
-
     let mut tx = pool.begin().await?;
-    if !db::set_user_role(&mut *tx, user.id, role).await? {
-        return Err(anyhow!("user not found: {}", args.user_id));
-    }
+    // Both ends of the transition, taken from the statement that performed it, so
+    // a real promotion is distinguishable from a command that changed nothing.
+    let previous = db::set_user_role(&mut *tx, user.id, role)
+        .await?
+        .ok_or_else(|| anyhow!("user not found: {}", args.user_id))?;
+    let detail = format!("{} -> {role_str}", previous.as_str());
     db::insert_admin_audit(&mut *tx, actor, "set_role", user.id, &detail).await?;
     tx.commit().await?;
 
@@ -228,7 +270,12 @@ async fn set_role(pool: &sqlx::PgPool, actor: &str, args: SetRoleArgs) -> Result
     Ok(())
 }
 
-async fn attach_wallet(pool: &sqlx::PgPool, actor: &str, args: AttachWalletArgs) -> Result<()> {
+async fn attach_wallet(
+    pool: &sqlx::PgPool,
+    actor: &str,
+    args: AttachWalletArgs,
+    input: &mut impl BufRead,
+) -> Result<()> {
     let pubkey = Pubkey::from_str(&args.pubkey)
         .map_err(|_| anyhow!("invalid pubkey: {}", args.pubkey))?
         .to_string();
@@ -237,7 +284,7 @@ async fn attach_wallet(pool: &sqlx::PgPool, actor: &str, args: AttachWalletArgs)
         .await?
         .ok_or_else(|| anyhow!("user not found: {}", args.user_id))?;
 
-    if !confirm(&user, &format!("attach wallet {pubkey}"), args.yes)? {
+    if !confirm(&user, &format!("attach wallet {pubkey}"), args.yes, input)? {
         println!("aborted");
         return Ok(());
     }
@@ -275,22 +322,22 @@ async fn attach_wallet(pool: &sqlx::PgPool, actor: &str, args: AttachWalletArgs)
 
 #[cfg(test)]
 // `ENV_LOCK` is a synchronous Mutex held across `.await` on purpose: it
-// serializes process-global env-var mutation across async tests. An async
-// Mutex would defeat the point — the lock window must include the spawned
-// child process's read of the env var, not just the in-test setup. Clippy
-// can't distinguish the two cases, so silence the lint module-wide.
+// serializes process-global env-var mutation across async tests, so the lock
+// has to stay held for the whole `run` call that reads the vars, not just the
+// setup. An async Mutex would let another test swap the environment mid-run.
+// Clippy can't distinguish the two cases, so silence the lint module-wide.
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use solana_sdk::pubkey::Pubkey;
     use sqlx::PgPool;
-    use std::sync::Mutex;
+    use std::{io::Cursor, sync::Mutex};
     use testcontainers::{runners::AsyncRunner, ContainerAsync};
     use testcontainers_modules::postgres::Postgres;
 
-    // env::set_var / remove_var mutate process-global state. The two `run` tests
-    // touch AUTH_DATABASE_URL — serialize them so they don't race when the
-    // surrounding test runner schedules them in parallel.
+    // env::set_var / remove_var mutate process-global state. The `run` tests
+    // touch AUTH_DATABASE_URL and AUTH_ADMIN_ACTOR — serialize them so they don't
+    // race when the surrounding test runner schedules them in parallel.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     async fn start_pool() -> (PgPool, ContainerAsync<Postgres>) {
@@ -313,8 +360,15 @@ mod tests {
         (pool, container)
     }
 
-    // Every test drives the commands non-interactively; the confirmation prompt
-    // reads stdin, which no test has.
+    fn restore(key: &str, prev: Option<String>) {
+        match prev {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+    }
+
+    // Most tests drive the commands non-interactively. The ones covering the
+    // prompt build their args inline with `yes: false` and feed a reader.
     fn attach_args(user_id: Uuid, pubkey: &str) -> AttachWalletArgs {
         AttachWalletArgs {
             user_id,
@@ -333,7 +387,7 @@ mod tests {
 
     async fn audit_rows(pool: &PgPool) -> Vec<(String, String, Uuid, String)> {
         sqlx::query_as(
-            r#"SELECT actor, action, target_user_id, detail FROM private_channel_auth.admin_audit"#,
+            r#"SELECT actor, action, target_user_id, detail FROM private_channel_auth.admin_audit ORDER BY created_at"#,
         )
         .fetch_all(pool)
         .await
@@ -360,10 +414,7 @@ mod tests {
         ))))
         .await;
 
-        match prev {
-            Some(p) => env::set_var("AUTH_DATABASE_URL", p),
-            None => env::remove_var("AUTH_DATABASE_URL"),
-        }
+        restore("AUTH_DATABASE_URL", prev);
 
         let err = result.expect_err("expected error");
         assert!(err.to_string().contains("is not set"), "got: {err}");
@@ -381,10 +432,7 @@ mod tests {
         ))))
         .await;
 
-        match prev {
-            Some(p) => env::set_var("AUTH_DATABASE_URL", p),
-            None => env::remove_var("AUTH_DATABASE_URL"),
-        }
+        restore("AUTH_DATABASE_URL", prev);
 
         let err = result.expect_err("expected error");
         assert!(
@@ -393,12 +441,75 @@ mod tests {
         );
     }
 
+    /// A missing actor has to fail before the tool connects, so it can't run DDL
+    /// against the auth database and only then refuse the command.
+    #[tokio::test]
+    async fn run_rejects_missing_admin_actor() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev_url = env::var("AUTH_DATABASE_URL").ok();
+        let prev_actor = env::var("AUTH_ADMIN_ACTOR").ok();
+        // Unroutable on purpose: reaching the connect step at all is a failure.
+        env::set_var(
+            "AUTH_DATABASE_URL",
+            "postgres://auth:pw@240.0.0.1:5432/auth",
+        );
+        env::remove_var("AUTH_ADMIN_ACTOR");
+
+        let result = run(run_args(Command::SetRole(set_role_args(
+            Uuid::new_v4(),
+            RoleArg::Operator,
+        ))))
+        .await;
+
+        restore("AUTH_DATABASE_URL", prev_url);
+        restore("AUTH_ADMIN_ACTOR", prev_actor);
+
+        let err = result.expect_err("expected error");
+        assert!(
+            err.to_string().contains("AUTH_ADMIN_ACTOR is not set"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_rejects_blank_admin_actor() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev_url = env::var("AUTH_DATABASE_URL").ok();
+        let prev_actor = env::var("AUTH_ADMIN_ACTOR").ok();
+        env::set_var(
+            "AUTH_DATABASE_URL",
+            "postgres://auth:pw@240.0.0.1:5432/auth",
+        );
+        env::set_var("AUTH_ADMIN_ACTOR", "   ");
+
+        let result = run(run_args(Command::SetRole(set_role_args(
+            Uuid::new_v4(),
+            RoleArg::Operator,
+        ))))
+        .await;
+
+        restore("AUTH_DATABASE_URL", prev_url);
+        restore("AUTH_ADMIN_ACTOR", prev_actor);
+
+        let err = result.expect_err("expected error");
+        assert!(
+            err.to_string()
+                .contains("AUTH_ADMIN_ACTOR must not be empty"),
+            "got: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn attach_wallet_rejects_invalid_pubkey() {
         let (pool, _c) = start_pool().await;
-        let err = attach_wallet(&pool, "admin", attach_args(Uuid::new_v4(), "not-base58"))
-            .await
-            .expect_err("expected error");
+        let err = attach_wallet(
+            &pool,
+            "admin",
+            attach_args(Uuid::new_v4(), "not-base58"),
+            &mut io::empty(),
+        )
+        .await
+        .expect_err("expected error");
         assert!(err.to_string().contains("invalid pubkey"), "got: {err}");
     }
 
@@ -406,9 +517,14 @@ mod tests {
     async fn attach_wallet_rejects_unknown_user() {
         let (pool, _c) = start_pool().await;
         let pubkey = Pubkey::new_unique().to_string();
-        let err = attach_wallet(&pool, "admin", attach_args(Uuid::new_v4(), &pubkey))
-            .await
-            .expect_err("expected error");
+        let err = attach_wallet(
+            &pool,
+            "admin",
+            attach_args(Uuid::new_v4(), &pubkey),
+            &mut io::empty(),
+        )
+        .await
+        .expect_err("expected error");
         assert!(err.to_string().contains("user not found"), "got: {err}");
     }
 
@@ -420,9 +536,14 @@ mod tests {
             .expect("insert user");
         let pubkey = Pubkey::new_unique().to_string();
 
-        attach_wallet(&pool, "admin", attach_args(user.id, &pubkey))
-            .await
-            .expect("attach should succeed");
+        attach_wallet(
+            &pool,
+            "admin",
+            attach_args(user.id, &pubkey),
+            &mut io::empty(),
+        )
+        .await
+        .expect("attach should succeed");
 
         let wallets = db::list_verified_wallets(&pool, user.id)
             .await
@@ -449,13 +570,23 @@ mod tests {
             .expect("insert user");
         let pubkey = Pubkey::new_unique().to_string();
 
-        attach_wallet(&pool, "admin", attach_args(user.id, &pubkey))
-            .await
-            .expect("first attach should succeed");
+        attach_wallet(
+            &pool,
+            "admin",
+            attach_args(user.id, &pubkey),
+            &mut io::empty(),
+        )
+        .await
+        .expect("first attach should succeed");
 
-        let err = attach_wallet(&pool, "admin", attach_args(user.id, &pubkey))
-            .await
-            .expect_err("second attach should fail");
+        let err = attach_wallet(
+            &pool,
+            "admin",
+            attach_args(user.id, &pubkey),
+            &mut io::empty(),
+        )
+        .await
+        .expect_err("second attach should fail");
         assert!(
             err.to_string().contains("is already attached"),
             "got: {err}"
@@ -472,16 +603,23 @@ mod tests {
         assert_eq!(audit_rows(&pool).await.len(), 1);
     }
 
+    /// Both directions, because the audit detail claims to record the role the
+    /// change replaced — not just the one it assigned.
     #[tokio::test]
-    async fn set_role_promotes_user_to_operator() {
+    async fn set_role_records_each_transition() {
         let (pool, _c) = start_pool().await;
         let user = db::insert_user(&pool, "dave", "$argon2id$placeholder")
             .await
             .expect("insert user");
 
-        set_role(&pool, "admin", set_role_args(user.id, RoleArg::Operator))
-            .await
-            .expect("set role should succeed");
+        set_role(
+            &pool,
+            "admin",
+            set_role_args(user.id, RoleArg::Operator),
+            &mut io::empty(),
+        )
+        .await
+        .expect("promotion should succeed");
 
         let promoted = db::find_user_by_id(&pool, user.id)
             .await
@@ -489,15 +627,78 @@ mod tests {
             .expect("user exists");
         assert_eq!(promoted.role, Role::Operator);
 
+        set_role(
+            &pool,
+            "admin",
+            set_role_args(user.id, RoleArg::User),
+            &mut io::empty(),
+        )
+        .await
+        .expect("demotion should succeed");
+
+        let demoted = db::find_user_by_id(&pool, user.id)
+            .await
+            .expect("find user")
+            .expect("user exists");
+        assert_eq!(demoted.role, Role::User);
+
         assert_eq!(
             audit_rows(&pool).await,
-            vec![(
-                "admin".to_string(),
-                "set_role".to_string(),
-                user.id,
-                "user -> operator".to_string()
-            )]
+            vec![
+                (
+                    "admin".to_string(),
+                    "set_role".to_string(),
+                    user.id,
+                    "user -> operator".to_string()
+                ),
+                (
+                    "admin".to_string(),
+                    "set_role".to_string(),
+                    user.id,
+                    "operator -> user".to_string()
+                ),
+            ]
         );
+    }
+
+    /// The prompt is the control that keeps a grant from landing on the wrong
+    /// account, so anything other than `yes` — including a closed stdin — has to
+    /// leave both the role and the trail alone.
+    #[tokio::test]
+    async fn set_role_grants_nothing_without_confirmation() {
+        let (pool, _c) = start_pool().await;
+        let user = db::insert_user(&pool, "erin", "$argon2id$placeholder")
+            .await
+            .expect("insert user");
+
+        for answer in ["no\n", "y\n", ""] {
+            set_role(
+                &pool,
+                "admin",
+                SetRoleArgs {
+                    user_id: user.id,
+                    role: RoleArg::Operator,
+                    yes: false,
+                },
+                &mut Cursor::new(answer),
+            )
+            .await
+            .expect("declining is not an error");
+
+            let unchanged = db::find_user_by_id(&pool, user.id)
+                .await
+                .expect("find user")
+                .expect("user exists");
+            assert_eq!(
+                unchanged.role,
+                Role::User,
+                "answer {answer:?} must not promote"
+            );
+            assert!(
+                audit_rows(&pool).await.is_empty(),
+                "answer {answer:?} must not be recorded"
+            );
+        }
     }
 
     #[tokio::test]
@@ -507,6 +708,7 @@ mod tests {
             &pool,
             "admin",
             set_role_args(Uuid::new_v4(), RoleArg::Operator),
+            &mut io::empty(),
         )
         .await
         .expect_err("expected error");

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -3,7 +3,7 @@ use sqlx::{PgExecutor, PgPool};
 use uuid::Uuid;
 
 use crate::{
-    error::AppResult,
+    error::{AppError, AppResult},
     models::{Challenge, Role, User, VerifiedWallet},
 };
 
@@ -114,6 +114,9 @@ pub async fn init_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
 
 type UserRow = (Uuid, String, String, String, DateTime<Utc>);
 
+/// Unknown labels fall back to the least privileged role. Only for reading a user
+/// to authorize them — the audit path parses strictly instead, since a wrong
+/// label there records a transition that never happened.
 fn role_from_str(role: &str) -> Role {
     match role {
         "operator" => Role::Operator,
@@ -215,7 +218,14 @@ pub async fn set_user_role<'e, E: PgExecutor<'e>>(
     .fetch_optional(executor)
     .await?;
 
-    Ok(row.map(|(previous,)| role_from_str(&previous)))
+    row.map(|(previous,)| match previous.as_str() {
+        "operator" => Ok(Role::Operator),
+        "user" => Ok(Role::User),
+        other => Err(AppError::Internal(anyhow::anyhow!(
+            "unknown role {other} on user {user_id}"
+        ))),
+    })
+    .transpose()
 }
 
 /// Record a privileged administrative change. Callers pass the transaction that

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -114,16 +114,20 @@ pub async fn init_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
 
 type UserRow = (Uuid, String, String, String, DateTime<Utc>);
 
+fn role_from_str(role: &str) -> Role {
+    match role {
+        "operator" => Role::Operator,
+        _ => Role::User,
+    }
+}
+
 fn user_from_row(row: UserRow) -> User {
     let (id, username, password_hash, role, created_at) = row;
     User {
         id,
         username,
         password_hash,
-        role: match role.as_str() {
-            "operator" => Role::Operator,
-            _ => Role::User,
-        },
+        role: role_from_str(&role),
         created_at,
     }
 }
@@ -177,9 +181,15 @@ pub async fn insert_user(pool: &PgPool, username: &str, password_hash: &str) -> 
     })
 }
 
-/// Set a user's role by immutable id. Returns `false` if no such user exists.
-/// Takes the typed `Role` so the variant is compiler-enforced; the SQL casts
-/// the lowercase string to the postgres `user_role` enum.
+/// Set a user's role by immutable id. Returns the role the user held before, or
+/// `None` if no such user exists. Takes the typed `Role` so the variant is
+/// compiler-enforced; the SQL casts the lowercase string to the postgres
+/// `user_role` enum.
+///
+/// The CTE takes the row lock before reading, so the returned previous role is
+/// the one this statement actually replaced rather than a value some concurrent
+/// change had already overwritten. Callers record it, so a stale read would put
+/// a transition in the audit trail that never happened.
 ///
 /// Generic over the executor so the caller can commit the change and its audit
 /// row together.
@@ -187,14 +197,25 @@ pub async fn set_user_role<'e, E: PgExecutor<'e>>(
     executor: E,
     user_id: Uuid,
     role: Role,
-) -> AppResult<bool> {
-    let result =
-        sqlx::query(r#"UPDATE private_channel_auth.users SET role = $2::private_channel_auth.user_role WHERE id = $1"#)
-            .bind(user_id)
-            .bind(role.as_str())
-            .execute(executor)
-            .await?;
-    Ok(result.rows_affected() > 0)
+) -> AppResult<Option<Role>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"
+        WITH locked AS (
+            SELECT id, role FROM private_channel_auth.users WHERE id = $1 FOR UPDATE
+        )
+        UPDATE private_channel_auth.users u
+        SET role = $2::private_channel_auth.user_role
+        FROM locked
+        WHERE u.id = locked.id
+        RETURNING locked.role::text
+        "#,
+    )
+    .bind(user_id)
+    .bind(role.as_str())
+    .fetch_optional(executor)
+    .await?;
+
+    Ok(row.map(|(previous,)| role_from_str(&previous)))
 }
 
 /// Record a privileged administrative change. Callers pass the transaction that

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+use sqlx::{PgExecutor, PgPool};
 use uuid::Uuid;
 
 use crate::{
@@ -73,8 +73,32 @@ pub async fn init_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // Append-only trail of privileged administrative changes. `target_user_id` is
+    // deliberately not a foreign key: deleting a user cascades through challenges
+    // and wallets, and the record of who was granted what has to outlive the account.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS private_channel_auth.admin_audit (
+            id UUID PRIMARY KEY,
+            actor TEXT NOT NULL,
+            action TEXT NOT NULL,
+            target_user_id UUID NOT NULL,
+            detail TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
     sqlx::query(
         r#"CREATE INDEX IF NOT EXISTS idx_verified_wallets_user_id ON private_channel_auth.verified_wallets (user_id)"#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        r#"CREATE INDEX IF NOT EXISTS idx_admin_audit_target_user_id ON private_channel_auth.admin_audit (target_user_id)"#,
     )
     .execute(pool)
     .await?;
@@ -88,26 +112,46 @@ pub async fn init_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
+type UserRow = (Uuid, String, String, String, DateTime<Utc>);
+
+fn user_from_row(row: UserRow) -> User {
+    let (id, username, password_hash, role, created_at) = row;
+    User {
+        id,
+        username,
+        password_hash,
+        role: match role.as_str() {
+            "operator" => Role::Operator,
+            _ => Role::User,
+        },
+        created_at,
+    }
+}
+
 pub async fn find_user_by_username(pool: &PgPool, username: &str) -> AppResult<Option<User>> {
-    let row: Option<(Uuid, String, String, String, DateTime<Utc>)> = sqlx::query_as(
+    let row: Option<UserRow> = sqlx::query_as(
         r#"SELECT id, username, password_hash, role::text, created_at FROM private_channel_auth.users WHERE username = $1"#,
     )
     .bind(username)
     .fetch_optional(pool)
     .await?;
 
-    Ok(
-        row.map(|(id, username, password_hash, role, created_at)| User {
-            id,
-            username,
-            password_hash,
-            role: match role.as_str() {
-                "operator" => Role::Operator,
-                _ => Role::User,
-            },
-            created_at,
-        }),
+    Ok(row.map(user_from_row))
+}
+
+/// Find a user by their immutable id. Privileged administrative commands key on
+/// the id rather than the username: usernames are claimed first-come on
+/// `/auth/register`, so anyone who registers the intended operator's name first
+/// would otherwise receive the grant meant for them.
+pub async fn find_user_by_id(pool: &PgPool, id: Uuid) -> AppResult<Option<User>> {
+    let row: Option<UserRow> = sqlx::query_as(
+        r#"SELECT id, username, password_hash, role::text, created_at FROM private_channel_auth.users WHERE id = $1"#,
     )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(user_from_row))
 }
 
 pub async fn insert_user(pool: &PgPool, username: &str, password_hash: &str) -> AppResult<User> {
@@ -133,21 +177,50 @@ pub async fn insert_user(pool: &PgPool, username: &str, password_hash: &str) -> 
     })
 }
 
-/// Set a user's role by username. Returns `false` if no such user exists.
+/// Set a user's role by immutable id. Returns `false` if no such user exists.
 /// Takes the typed `Role` so the variant is compiler-enforced; the SQL casts
 /// the lowercase string to the postgres `user_role` enum.
-pub async fn set_user_role(pool: &PgPool, username: &str, role: Role) -> AppResult<bool> {
-    let role_str = match role {
-        Role::Operator => "operator",
-        Role::User => "user",
-    };
+///
+/// Generic over the executor so the caller can commit the change and its audit
+/// row together.
+pub async fn set_user_role<'e, E: PgExecutor<'e>>(
+    executor: E,
+    user_id: Uuid,
+    role: Role,
+) -> AppResult<bool> {
     let result =
-        sqlx::query(r#"UPDATE private_channel_auth.users SET role = $2::private_channel_auth.user_role WHERE username = $1"#)
-            .bind(username)
-            .bind(role_str)
-            .execute(pool)
+        sqlx::query(r#"UPDATE private_channel_auth.users SET role = $2::private_channel_auth.user_role WHERE id = $1"#)
+            .bind(user_id)
+            .bind(role.as_str())
+            .execute(executor)
             .await?;
     Ok(result.rows_affected() > 0)
+}
+
+/// Record a privileged administrative change. Callers pass the transaction that
+/// carries the change itself, so the trail can't drift from what happened.
+pub async fn insert_admin_audit<'e, E: PgExecutor<'e>>(
+    executor: E,
+    actor: &str,
+    action: &str,
+    target_user_id: Uuid,
+    detail: &str,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO private_channel_auth.admin_audit (id, actor, action, target_user_id, detail)
+        VALUES ($1, $2, $3, $4, $5)
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(actor)
+    .bind(action)
+    .bind(target_user_id)
+    .bind(detail)
+    .execute(executor)
+    .await?;
+
+    Ok(())
 }
 
 /// Insert a new challenge tied to this user. Expires in 10 minutes.
@@ -196,8 +269,10 @@ pub async fn consume_challenge(
     Ok(row.map(|(nonce, expires_at)| Challenge { nonce, expires_at }))
 }
 
-pub async fn insert_verified_wallet(
-    pool: &PgPool,
+/// Generic over the executor so an administrative attach can commit the wallet
+/// and its audit row together.
+pub async fn insert_verified_wallet<'e, E: PgExecutor<'e>>(
+    executor: E,
     user_id: Uuid,
     pubkey: &str,
 ) -> AppResult<VerifiedWallet> {
@@ -211,7 +286,7 @@ pub async fn insert_verified_wallet(
     .bind(Uuid::new_v4())
     .bind(user_id)
     .bind(pubkey)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await?;
 
     Ok(VerifiedWallet {

--- a/auth/src/models.rs
+++ b/auth/src/models.rs
@@ -14,6 +14,17 @@ pub enum Role {
     User,
 }
 
+impl Role {
+    /// The wire and database spelling. Must stay lowercase to match the postgres
+    /// `user_role` enum and the gateway's role claim.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Role::Operator => "operator",
+            Role::User => "user",
+        }
+    }
+}
+
 // DB rows
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## fix(auth): provision roles and wallets by user id, not username (issue-289)

`/auth/register` hands out usernames first-come, but the documented promotion path identified the account by that public name (`UPDATE ... WHERE username = 'alice'`, and `auth-admin set-role --username`). Registering the intended operator's name before they were provisioned redirected the grant to the squatter, who could then log in with their own password and receive an operator JWT. `attach-wallet --username` had the same confusion.

### Changes

  - `set-role` and `attach-wallet` take `--user-id <uuid>`; `db::set_user_role` keys on the id.
  - `show-user` takes `--user-id` or `--username` (mutually exclusive). The documented flow uses `--user-id` — resolving a name to an id is the direction that reintroduces the bug.
  - Both mutating commands print id, username, current role and creation time and require a typed `yes` (`--yes` for scripts). A closed stdin reads as EOF and aborts.
  - `AUTH_ADMIN_ACTOR` is required for both, resolved before the tool connects.
  - New `private_channel_auth.admin_audit`: actor, action, target user id, detail, written in the same transaction as the change. `set-role` reads the replaced role from the statement performing the update (`SELECT ... FOR UPDATE` CTE), so the recorded transition is the one that happened.
  - README drops the raw SQL and documents the resolve → confirm → `--user-id` flow.

### Scope

`admin_audit` records privileged grants — one account acting on another. Self-service wallet verify/delete are deliberately excluded: those are the account's own actions through a flow that already proves key ownership. Append-only is a convention, not a permission boundary — the CLI's role can create tables and so could drop this one; enforcing it means an INSERT-only DB role.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 13,783 | 15,483 | 89.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31751972692) |
| Indexer | 34,025 | 37,569 | 90.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31751972692) |
| Gateway | 1,476 | 1,698 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31751972692) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31751972692) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **50,596** | **56,256** | **89.9%** | |

> Last updated: 2026-08-13 23:11:48 UTC by Auth