### PR TITLE
fix(indexer): re-arm the deposit instead of failing it on a transient JIT verdict (issue-285)

### DIFF
--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -18,7 +18,7 @@ maps to a specific sender-side site:
 | `error_message` | Source | Trigger |
 |---|---|---|
 | starts with `Failed idempotency lookup for transaction_id` | `sender/mint.rs` | `getSignaturesForAddress` RPC failed during pre-send memo scan. |
-| `Mint initialization failed` | `sender/transaction.rs` | The just-in-time `InitializeMint` transaction itself failed (e.g. RPC outage during init or send error). The *post-JIT* mint failure case (mint exists but unusable) has been peeled off into [`deposit_manual_review.md`](deposit_manual_review.md) § Path D. |
+| `Mint initialization failed` | `sender/transaction.rs` | Log-only marker, **no webhook**: this message is only built on the defensive `MintNotInitialized`-without-`transaction_id` branch, and with no id there is no row to write a status to. A failing just-in-time `InitializeMint` no longer lands here at all: transient init failures (RPC outage, send error, unconfirmable init) re-arm the deposit to `pending` under the requeue cap instead, and only the recovery worker may escalate one. The *post-JIT* mint failure case (mint exists but unusable) is in [`deposit_manual_review.md`](deposit_manual_review.md) § Path D; the cap-exhausted case is § Path G. |
 | `Unexpected mint error` | `sender/transaction.rs` | `MintNotInitialized` confirmation result on a non-Mint tx (defensive; should never fire). |
 | `Confirmation failed - transaction status unknown, unsafe to retry` | `sender/transaction.rs` | RPC polling timed out for a non-idempotent send; mint may or may not have landed. |
 | free-form (often a program-error debug repr) | `sender/transaction.rs` | On-chain program error during confirmation (e.g. paused mint, bad mint authority — `OwnerMismatch` from SPL Token's `mint_to`) or RPC confirmation error. **The most common rotated-admin-key case lands here, not in `manual_review`** — `OwnerMismatch` is `Custom(3)`, which is not in the JIT-trigger classifier's allow-list. |
@@ -139,6 +139,23 @@ defensive counter that should never fire: a JIT re-fire arrived without the
 ownership epoch its first claim stored. The re-fire is dropped without
 broadcast and the row stays Processing for recovery. A sustained rate is a
 code bug, not an operational condition.
+
+`OPERATOR_TRANSACTION_ERRORS{error_reason="mint_jit_transient"}` counts a
+deposit whose just-in-time `InitializeMint` could not be completed on this
+attempt (channel RPC blip, mint metadata lookup failure, unconfirmable init).
+The deposit's own `mint_to` did reach the chain and failed there saying the mint
+is not initialized, so its signature stays in the journal; no status is written
+and the row is requeued to `pending`, paired with `prebroadcast_requeued`. The
+re-mint on the next pickup is gated on that stored signature being proven dead,
+so this is not a double-mint path. A short burst during a channel RPC wobble is
+expected and self-healing. Watch instead for `prebroadcast_requeue_cap` on the
+escrow operator: that means a deposit spent all three requeues without the mint
+landing and is now waiting on the recovery sweep to quarantine it, which
+surfaces as [`deposit_manual_review.md`](deposit_manual_review.md) § Path G.
+
+`OPERATOR_TRANSACTION_ERRORS{error_reason="mint_jit_requeue_raced"}` is
+informational: the JIT requeue found the row no longer `processing`, so recovery
+or another writer already owns it. Nothing is written and no action is needed.
 
 ## Post-incident artifacts
 

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -55,7 +55,7 @@ to the right Path below.
 | `program_error` | Generic builder error not covered by the specific variants. |
 | `could not verify mint landed` | The recovery worker could not determine whether the deposit's mint landed: the PrivateChannel RPC was uncertain, or a stored signature could not be read or parsed. Quarantined on uncertainty rather than risk a double-mint. See **Path E**. |
 | `legacy in-flight deposit, verify on-chain before re-mint` | A one-time upgrade quarantine: this deposit was already `processing` when the pre-broadcast-persist code was deployed, so it has no persisted signature and recovery cannot prove it never minted. Verify on-chain before re-arming. See **Path E** (treat as `AMBIGUOUS` until the on-chain check resolves). |
-| `recovery requeues without progress` | The recovery worker demoted this `processing` deposit 3 times (mint never landed each cycle) and quarantined rather than loop forever. Row data is fine; the mint keeps failing to land. See **Path G**. |
+| `recovery requeues without progress` | The deposit was re-armed 3 times without the mint landing, and recovery quarantined rather than loop forever. Two things spend that counter: the recovery worker demoting a stale `processing` row, and the sender re-arming a deposit whose just-in-time `InitializeMint` could not be completed. Row data is fine; the mint keeps failing to land. See **Path G**. |
 
 ### Sender-side post-JIT surface (`sender/mint.rs`)
 
@@ -429,12 +429,26 @@ can review the finality timing.
 
 #### Step 2 - find why the mint never lands
 
-The deposit mint is fire-and-forget (`spawn_fire_and_store`), so a
-repeating failure points at a deterministic mint rejection (paused/frozen
-mint, `mint_authority` mismatch, compute) or the sender never
-broadcasting. Read the operator logs for this `transaction_id`'s mint send
-error. A deterministic cause means re-arming will loop again ->
-[escalate](_escalation.md) (Tier 2) to engineering.
+There are two shapes to separate first. Check
+`OPERATOR_TRANSACTION_ERRORS{error_reason="mint_jit_transient"}` and the
+operator logs for this `transaction_id`:
+
+- **Mint never initialized.** The logs carry `JIT` lines for this row, ending in
+  `still failing at the requeue cap`. The `mint_to` reached the chain and came
+  back saying the mint account is not a usable mint, and the just-in-time
+  `InitializeMint` that would fix it could not be completed either. Check
+  channel RPC health and that the mint account exists on the private channel
+  with the operator's admin as `mint_authority`. This is environmental, not row
+  data.
+- **Mint rejected.** No JIT lines in the logs. The deposit mint is
+  fire-and-forget (`spawn_fire_and_store`), so a repeating failure points at a
+  deterministic mint rejection (paused/frozen mint, `mint_authority` mismatch,
+  compute) or the sender never broadcasting. Read this `transaction_id`'s mint
+  send error.
+
+Either way a deterministic cause means re-arming will loop again, so
+[escalate](_escalation.md) (Tier 2) to engineering rather than re-arming
+against an unfixed condition.
 
 #### Step 3 - resolve, then re-arm
 

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -18,13 +18,12 @@ use tracing::{error, info, warn};
 use super::types::{InstructionWithSigners, SenderState};
 
 /// Verdict from `try_jit_mint_initialization`. The caller in
-/// `transaction.rs` matches on this to decide whether to recursively retry,
-/// quarantine the deposit to ManualReview, or route to the existing
-/// PermanentFailure path. The `String` payloads are operator-visible
-/// `error_message`s; ManualReview reasons are constructed in full here
-/// (with the literal `"Mint instruction failed after JIT: "` prefix) so
-/// `drill_1` can grep the runbook-dispatch substrings in a single source
-/// file.
+/// `transaction.rs` matches on this to decide whether to re-issue the mint,
+/// quarantine the deposit to ManualReview, or re-arm it for another attempt.
+/// The ManualReview payload is an operator-visible `error_message` and is
+/// constructed in full here (with the literal `"Mint instruction failed after
+/// JIT: "` prefix) so `drill_1` can grep the runbook-dispatch substrings in a
+/// single source file. The Transient payload only ever reaches the logs.
 pub enum JitOutcome {
     /// Mint is correctly initialized with the operator's admin as
     /// `mint_authority`. Caller should retry the supplied instruction.
@@ -35,10 +34,9 @@ pub enum JitOutcome {
     /// inconsistency). Caller routes to `ManualReview`.
     ManualReview(String),
 
-    /// Transient or builder failure (RPC, mint cache miss, build error).
-    /// Caller routes to the existing permanent-failure path (`Failed`
-    /// status).
-    PermanentFailure(String),
+    /// No site behind this proves the mint unusable, so the caller re-arms
+    /// the deposit under a cap; the re-mint is gated on its stored signature.
+    Transient(String),
 }
 
 /// Outcome of decoding raw mint account bytes and comparing the embedded
@@ -114,7 +112,7 @@ const MR_CORRUPT_MINT_STATE: &str =
     "Mint instruction failed after JIT: corrupt mint state on-chain — decode failed";
 
 /// Attempt JIT mint initialization. Returns a `JitOutcome` verdict for the
-/// caller to dispatch (Retry / ManualReview / PermanentFailure).
+/// caller to dispatch (Retry / ManualReview / Transient).
 pub(super) async fn try_jit_mint_initialization(
     state: &mut SenderState,
     transaction_id: i64,
@@ -122,13 +120,13 @@ pub(super) async fn try_jit_mint_initialization(
 ) -> JitOutcome {
     // 1. Get cached builder + extract mint.
     let Some(builder) = state.mint_builders.get(&transaction_id).cloned() else {
-        return JitOutcome::PermanentFailure(format!(
+        return JitOutcome::Transient(format!(
             "no cached MintToBuilder for transaction_id {}",
             transaction_id
         ));
     };
     let Some(mint) = builder.get_mint() else {
-        return JitOutcome::PermanentFailure(format!(
+        return JitOutcome::Transient(format!(
             "MintToBuilder for transaction_id {} is missing mint pubkey",
             transaction_id
         ));
@@ -188,7 +186,7 @@ pub(super) async fn try_jit_mint_initialization(
     // time execution reaches this point, the mint is known-allowed.
     let Ok(mint_metadata) = state.mint_cache.get_mint_metadata(&mint).await else {
         error!("Mint {} not found in mint cache", mint);
-        return JitOutcome::PermanentFailure(format!("mint not in mint cache: {}", mint));
+        return JitOutcome::Transient(format!("mint not in mint cache: {}", mint));
     };
 
     info!(
@@ -215,7 +213,7 @@ pub(super) async fn try_jit_mint_initialization(
         Ok(ix) => ix,
         Err(e) => {
             error!("Failed to build InitializeMint instruction: {}", e);
-            return JitOutcome::PermanentFailure(format!(
+            return JitOutcome::Transient(format!(
                 "Failed to build InitializeMint instruction: {}",
                 e
             ));
@@ -234,7 +232,7 @@ pub(super) async fn try_jit_mint_initialization(
         Ok((s, _, _)) => s,
         Err(e) => {
             error!("Failed to send InitializeMint transaction: {}", e);
-            return JitOutcome::PermanentFailure(format!(
+            return JitOutcome::Transient(format!(
                 "Failed to send InitializeMint transaction: {}",
                 e
             ));
@@ -254,10 +252,7 @@ pub(super) async fn try_jit_mint_initialization(
         Ok(r) => r,
         Err(e) => {
             error!("Failed to check InitializeMint status: {}", e);
-            return JitOutcome::PermanentFailure(format!(
-                "Failed to check InitializeMint status: {}",
-                e
-            ));
+            return JitOutcome::Transient(format!("Failed to check InitializeMint status: {}", e));
         }
     };
 
@@ -304,8 +299,9 @@ pub(super) async fn try_jit_mint_initialization(
 ///   so operators can see the race-recovery happen; post-init is silent.
 /// - `Uninitialized`: post-init treats this as an RPC inconsistency
 ///   (InitializeMint said Confirmed but the mint isn't there); fallback
-///   treats it as the canonical "InitializeMint could not be confirmed"
-///   permanent failure that drives the existing Failed-runbook dispatch.
+///   treats it as the canonical "InitializeMint could not be confirmed".
+///   Both are Transient: neither proves the mint is unusable, so the
+///   deposit is re-armed rather than ended.
 fn jit_verdict(
     check: AuthorityCheck,
     instruction: InstructionWithSigners,
@@ -340,7 +336,7 @@ fn jit_verdict(
                     "InitializeMint transaction could not be confirmed: {:?}",
                     result
                 );
-                JitOutcome::PermanentFailure(
+                JitOutcome::Transient(
                     "InitializeMint transaction could not be confirmed".to_string(),
                 )
             }
@@ -349,7 +345,7 @@ fn jit_verdict(
                     "JIT post-init: InitializeMint confirmed but mint {} reads as uninitialized",
                     mint
                 );
-                JitOutcome::PermanentFailure(format!(
+                JitOutcome::Transient(format!(
                     "InitializeMint confirmed but mint {} reads as uninitialized — RPC inconsistency",
                     mint
                 ))
@@ -362,7 +358,7 @@ fn jit_verdict(
 /// from the first successful decode. Absorbs read-RPC lag after a racing
 /// InitializeMint. On exhausted attempts with no successful decode,
 /// returns `Uninitialized` (the most conservative "I couldn't confirm
-/// it's there" reading — caller maps this to PermanentFailure on the   
+/// it's there" reading — caller maps this to Transient on the
 /// fallback path).
 async fn mint_authority_check_with_backoff(
     rpc_client: &RpcClientWithRetry,

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -979,8 +979,12 @@ pub(super) fn handle_confirmation_result<'a>(
                         cleanup_failed_transaction(state, ctx.withdrawal_nonce);
                         state.mint_builders.remove(&txn_id);
                     }
-                    JitOutcome::PermanentFailure(reason) => {
-                        handle_permanent_failure(state, ctx, storage_tx, &reason).await;
+                    // Only deposits reach this block: the guard above proves a
+                    // cached mint builder, and those are cached for the deposit
+                    // mint alone. So there is no nonce-keyed state to unwind
+                    // and no withdrawal remint to compensate here.
+                    JitOutcome::Transient(reason) => {
+                        requeue_deposit_after_jit(state, txn_id, &signature, &reason).await;
                     }
                 }
             }
@@ -1241,6 +1245,81 @@ pub(super) async fn requeue_or_fail_prebroadcast(
                 nonce, "Pre-broadcast requeue write failed, row left Processing for recovery: {e}"
             );
         }
+    }
+}
+
+/// Re-arm a deposit whose JIT mint initialization could not be completed yet.
+/// The `mint_to` was already broadcast and failed on chain, and its signature is
+/// still journaled; the helper only adds an `InitializeMint`, which moves no
+/// balance and is idempotent, so re-arming sends nothing value-bearing. The
+/// re-mint is authorized by the processor's journal gate, which re-mints only
+/// once the stored attempt is proven dead, so bypassing that gate here would
+/// allow a double mint. No status is written on any branch: the cap, a raced row
+/// and a failed write all leave the row to the recovery sweep, which classifies
+/// the deposit on-chain before escalating to a human.
+pub(super) async fn requeue_deposit_after_jit(
+    state: &mut SenderState,
+    txn_id: i64,
+    signature: &Signature,
+    reason: &str,
+) {
+    let pt = state.program_type.as_label();
+    metrics::OPERATOR_TRANSACTION_ERRORS
+        .with_label_values(&[pt, "mint_jit_transient"])
+        .inc();
+
+    // The row leaves this task on every branch below and the next pickup builds
+    // its own builder, so the cached one would only go stale here.
+    state.mint_builders.remove(&txn_id);
+
+    match state
+        .storage
+        .try_requeue_prebroadcast(txn_id, MAX_RECOVERY_REQUEUE_ATTEMPTS)
+        .await
+    {
+        Ok(RequeueOutcome::Requeued { attempts }) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "prebroadcast_requeued"])
+                .inc();
+            warn!(
+                transaction_id = txn_id,
+                attempts, "JIT verdict: transient - requeued deposit to Pending: {reason}"
+            );
+        }
+        // The capped write still matches the row, so its `updated_at` trigger
+        // fires and the staleness clock restarts. That delays the recovery
+        // sweep by one window, which is the cost of keeping the cap inside a
+        // single statement rather than reading the counter separately.
+        Ok(RequeueOutcome::AtCap) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "prebroadcast_requeue_cap"])
+                .inc();
+            leave_processing_for_recovery(
+                pt,
+                Some(txn_id),
+                signature,
+                &format!("JIT mint initialization still failing at the requeue cap ({reason})"),
+            );
+        }
+        // Someone else advanced the row, so it is not Processing and the
+        // recovery sweep will not look at it. Reporting it as left-for-recovery
+        // would send an on-call after a reconciliation that never runs.
+        Ok(RequeueOutcome::NotProcessing) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "mint_jit_requeue_raced"])
+                .inc();
+            warn!(
+                transaction_id = txn_id,
+                signature = %signature,
+                "JIT requeue skipped, row no longer Processing and now owned elsewhere: {reason}",
+            );
+        }
+        Err(e) => leave_processing_for_recovery(
+            pt,
+            Some(txn_id),
+            signature,
+            &format!("JIT requeue write failed ({e}); underlying verdict: {reason}"),
+        ),
     }
 }
 
@@ -7553,6 +7632,189 @@ mod tests {
             !mock.get_release_signatures(77).await.unwrap().is_empty(),
             "JIT retry must reuse the freed parent slot and journal its signature at saturation"
         );
+    }
+
+    // ── JIT transient verdict: bounded requeue, never terminal ────────
+
+    /// Seed a cached builder that carries no mint pubkey so the JIT helper returns
+    /// its transient verdict on the second guard, before it reads the signer or
+    /// issues any RPC. That keeps the tests below on the caller arm alone.
+    fn seed_mint_builder_without_mint(state: &mut SenderState, txn_id: i64) {
+        use crate::operator::utils::instruction_util::MintToBuilder;
+        state.mint_builders.insert(txn_id, MintToBuilder::new());
+    }
+
+    /// Set the durable requeue counter on an already-seeded mock row.
+    fn set_requeue_attempts(state: &SenderState, id: i64, attempts: i32) {
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let mut rows = mock.pending_transactions.lock().unwrap();
+        let row = rows
+            .iter_mut()
+            .find(|t| t.id == id)
+            .expect("row must be seeded");
+        row.recovery_requeue_attempts = attempts;
+    }
+
+    /// Read a seeded mock row's status and durable requeue counter together.
+    fn deposit_row_state(state: &SenderState, id: i64) -> (TransactionStatus, i32) {
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let rows = mock.pending_transactions.lock().unwrap();
+        let row = rows
+            .iter()
+            .find(|t| t.id == id)
+            .expect("row must be seeded");
+        (row.status, row.recovery_requeue_attempts)
+    }
+
+    /// Drive the caller arm with a transient JIT verdict against a mock storage
+    /// whose RPC endpoint is unreachable, which is itself the proof that this
+    /// path issues no RPC.
+    async fn drive_transient_jit(
+        state: &mut SenderState,
+        txn_id: i64,
+    ) -> mpsc::Receiver<TransactionStatusUpdate> {
+        let (storage_tx, storage_rx) = mpsc::channel(10);
+        handle_confirmation_result(
+            state,
+            Ok(ConfirmationResult::MintNotInitialized),
+            Signature::new_unique(),
+            None,
+            &mint_ctx(txn_id),
+            dummy_instruction(),
+            RetryPolicy::None,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+        storage_rx
+    }
+
+    /// A transient JIT verdict on a funded deposit must re-arm the row, not end it.
+    /// The source-chain escrow is already funded at this point and no worker reads
+    /// a Failed row, so a terminal status here strands the deposit until a human
+    /// edits the database.
+    #[tokio::test]
+    async fn jit_transient_requeues_deposit_to_pending() {
+        ensure_test_signer();
+        let mut state = make_sender_state_with_server("http://127.0.0.1:1");
+        seed_mint_builder_without_mint(&mut state, 88);
+        seed_mock_deposit(&state, 88, TransactionStatus::Processing, Utc::now());
+
+        let mut storage_rx = drive_transient_jit(&mut state, 88).await;
+
+        let (status, attempts) = deposit_row_state(&state, 88);
+        assert_eq!(
+            status,
+            TransactionStatus::Pending,
+            "a transient JIT verdict must re-arm the deposit for the fetcher"
+        );
+        assert_eq!(attempts, 1, "the durable requeue counter must be consumed");
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "the sender must write no status for a transient deposit verdict"
+        );
+        assert!(
+            !state.mint_builders.contains_key(&88),
+            "the cached builder must be released once the row leaves this task"
+        );
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            mock.get_release_signatures(88).await.unwrap().is_empty(),
+            "a transient verdict must journal nothing"
+        );
+        assert!(
+            state.in_flight.is_empty(),
+            "a transient verdict must stash no in-flight entry"
+        );
+    }
+
+    /// At the requeue cap the sender stops re-arming and hands the row to the
+    /// recovery sweep, which classifies the deposit on-chain before it escalates.
+    /// `decide_action_caps_demote_at_threshold` in the recovery module pins the
+    /// other half of that handoff: a deposit row at the cap yields Quarantine.
+    #[tokio::test]
+    async fn jit_transient_at_cap_leaves_processing() {
+        ensure_test_signer();
+        let mut state = make_sender_state_with_server("http://127.0.0.1:1");
+        seed_mint_builder_without_mint(&mut state, 89);
+        seed_mock_deposit(&state, 89, TransactionStatus::Processing, Utc::now());
+        set_requeue_attempts(&state, 89, MAX_RECOVERY_REQUEUE_ATTEMPTS);
+
+        let mut storage_rx = drive_transient_jit(&mut state, 89).await;
+
+        let (status, attempts) = deposit_row_state(&state, 89);
+        assert_eq!(
+            status,
+            TransactionStatus::Processing,
+            "at the cap the row stays Processing for the recovery sweep"
+        );
+        assert_eq!(
+            attempts, MAX_RECOVERY_REQUEUE_ATTEMPTS,
+            "the cap must not be exceeded"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "the sender must never terminalize a deposit, even at the cap"
+        );
+        assert!(!state.mint_builders.contains_key(&89));
+    }
+
+    /// A row another writer already advanced is left alone: nothing to requeue and
+    /// nothing to report. The row is not Processing, so the recovery sweep will not
+    /// pick it up either, which is why this branch does not claim it was left for
+    /// recovery.
+    #[tokio::test]
+    async fn jit_transient_not_processing_is_noop() {
+        ensure_test_signer();
+        let mut state = make_sender_state_with_server("http://127.0.0.1:1");
+        seed_mint_builder_without_mint(&mut state, 90);
+        seed_mock_deposit(&state, 90, TransactionStatus::Pending, Utc::now());
+
+        let mut storage_rx = drive_transient_jit(&mut state, 90).await;
+
+        let (status, attempts) = deposit_row_state(&state, 90);
+        assert_eq!(status, TransactionStatus::Pending, "row left untouched");
+        assert_eq!(attempts, 0, "no counter is spent on a row we do not own");
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a raced row must not receive a status from this sender"
+        );
+        assert!(!state.mint_builders.contains_key(&90));
+    }
+
+    /// A failed requeue write leaves the row exactly where it was. Recovery reads
+    /// the same row and reconciles it, so nothing is lost by not retrying here.
+    #[tokio::test]
+    async fn jit_transient_requeue_write_error_leaves_processing() {
+        ensure_test_signer();
+        let mut state = make_sender_state_with_server("http://127.0.0.1:1");
+        seed_mint_builder_without_mint(&mut state, 91);
+        seed_mock_deposit(&state, 91, TransactionStatus::Processing, Utc::now());
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("try_requeue_prebroadcast", true);
+
+        let mut storage_rx = drive_transient_jit(&mut state, 91).await;
+
+        let (status, attempts) = deposit_row_state(&state, 91);
+        assert_eq!(
+            status,
+            TransactionStatus::Processing,
+            "a failed requeue write must leave the row for recovery"
+        );
+        assert_eq!(attempts, 0, "a failed write consumes no attempt");
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a failed requeue write must not be escalated into a terminal status"
+        );
+        assert!(!state.mint_builders.contains_key(&91));
     }
 
     /// A Terminal run broadcasts without writing any signature even though a

--- a/integration/tests/indexer/jit_mint_helper.rs
+++ b/integration/tests/indexer/jit_mint_helper.rs
@@ -129,12 +129,12 @@ fn make_mint_builder(mint: Pubkey) -> MintToBuilder {
 ///
 /// `populate_builder` controls whether `state.mint_builders` is pre-seeded
 /// for `txn_id` (when false, the helper hits its no-cached-builder
-/// PermanentFailure branch on first lookup).
+/// Transient branch on first lookup).
 ///
 /// `populate_mint_cache` controls whether `mock_storage.mints` carries a
 /// `DbMint` for the mint pubkey. The mint-cache-miss test relies on
 /// passing `false` here so `get_mint_metadata` returns the
-/// `PermanentFailure("mint not in mint cache")` branch.
+/// `Transient("mint not in mint cache")` branch.
 struct Fixture {
     state: private_channel_indexer::operator::sender::types::SenderState,
     mock: MockRpcServer,
@@ -428,14 +428,14 @@ async fn jit_returns_manual_review_when_post_init_authority_mismatch() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Mint cache miss — PermanentFailure.
+// Mint cache miss — Transient.
 // ─────────────────────────────────────────────────────────────────────
 //
 // Pre-check sees uninit (would normally fall through to init), but
 // `get_mint_metadata` fails because the mint cache is empty. Routes to
-// PermanentFailure with the cache-miss reason string.
+// Transient with the cache-miss reason string.
 #[tokio::test]
-async fn jit_returns_permanent_failure_when_mint_cache_miss() {
+async fn jit_returns_transient_when_mint_cache_miss() {
     let Fixture {
         mut state,
         mock,
@@ -448,13 +448,13 @@ async fn jit_returns_permanent_failure_when_mint_cache_miss() {
     let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     match outcome {
-        JitOutcome::PermanentFailure(reason) => {
+        JitOutcome::Transient(reason) => {
             assert!(
                 reason.contains("mint not in mint cache"),
                 "cache-miss must surface the cache-miss reason; got {reason:?}"
             );
         }
-        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+        other => panic!("expected Transient, got {:?}", debug_outcome(&other)),
     }
     assert_eq!(
         mock.call_count("sendTransaction"),
@@ -508,10 +508,10 @@ async fn jit_falls_through_when_initial_probe_returns_rpc_error() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// sendTransaction fails — PermanentFailure without polling.
+// sendTransaction fails — Transient without polling.
 // ─────────────────────────────────────────────────────────────────────
 #[tokio::test]
-async fn jit_returns_permanent_failure_when_send_transaction_fails() {
+async fn jit_returns_transient_when_send_transaction_fails() {
     let Fixture {
         mut state,
         mock,
@@ -529,13 +529,13 @@ async fn jit_returns_permanent_failure_when_send_transaction_fails() {
     let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     match outcome {
-        JitOutcome::PermanentFailure(reason) => {
+        JitOutcome::Transient(reason) => {
             assert!(
                 reason.contains("Failed to send InitializeMint transaction"),
                 "send failure must surface the send-failure reason; got {reason:?}"
             );
         }
-        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+        other => panic!("expected Transient, got {:?}", debug_outcome(&other)),
     }
     assert_eq!(mock.call_count("sendTransaction"), 1);
     assert_eq!(
@@ -639,14 +639,14 @@ async fn jit_returns_manual_review_when_backoff_recovers_with_authority_mismatch
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Backoff exhausts with uninit reads — PermanentFailure.
+// Backoff exhausts with uninit reads — Transient.
 // ─────────────────────────────────────────────────────────────────────
 //
 // Wall-clock note: this is the only test that pays the full
 // 4 × BACKOFF_MS = ~750 ms for the backoff loop; do not duplicate this
 // shape elsewhere.
 #[tokio::test]
-async fn jit_returns_permanent_failure_when_backoff_exhausts_with_uninit() {
+async fn jit_returns_transient_when_backoff_exhausts_with_uninit() {
     let Fixture {
         mut state,
         mock,
@@ -667,13 +667,13 @@ async fn jit_returns_permanent_failure_when_backoff_exhausts_with_uninit() {
     let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     match outcome {
-        JitOutcome::PermanentFailure(reason) => {
+        JitOutcome::Transient(reason) => {
             assert!(
                 reason.contains("InitializeMint transaction could not be confirmed"),
                 "exhausted-backoff must surface the could-not-be-confirmed reason; got {reason:?}"
             );
         }
-        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+        other => panic!("expected Transient, got {:?}", debug_outcome(&other)),
     }
     assert_eq!(
         mock.call_count("getAccountInfo"),
@@ -685,10 +685,10 @@ async fn jit_returns_permanent_failure_when_backoff_exhausts_with_uninit() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// No cached builder — PermanentFailure, zero RPC calls.
+// No cached builder — Transient, zero RPC calls.
 // ─────────────────────────────────────────────────────────────────────
 #[tokio::test]
-async fn jit_returns_permanent_failure_when_no_cached_builder() {
+async fn jit_returns_transient_when_no_cached_builder() {
     let Fixture {
         mut state,
         mock,
@@ -699,13 +699,13 @@ async fn jit_returns_permanent_failure_when_no_cached_builder() {
     let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     match outcome {
-        JitOutcome::PermanentFailure(reason) => {
+        JitOutcome::Transient(reason) => {
             assert!(
                 reason.contains("no cached MintToBuilder"),
                 "missing-builder branch must surface its specific reason; got {reason:?}"
             );
         }
-        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+        other => panic!("expected Transient, got {:?}", debug_outcome(&other)),
     }
     assert_eq!(
         mock.call_count("getAccountInfo"),
@@ -722,6 +722,6 @@ fn debug_outcome(outcome: &JitOutcome) -> String {
     match outcome {
         JitOutcome::Retry(_) => "Retry(_)".to_string(),
         JitOutcome::ManualReview(reason) => format!("ManualReview({reason:?})"),
-        JitOutcome::PermanentFailure(reason) => format!("PermanentFailure({reason:?})"),
+        JitOutcome::Transient(reason) => format!("Transient({reason:?})"),
     }
 }

--- a/integration/tests/indexer/sender_onchain_error_arms.rs
+++ b/integration/tests/indexer/sender_onchain_error_arms.rs
@@ -292,11 +292,14 @@ async fn build_state_for_jit_caller_arm(
     (state, storage_rx, storage_tx, mock, mint)
 }
 
-/// Seed a Processing deposit row in the mock store so JIT re-fire tests have a target.
+/// Seed a Processing deposit row in the mock store so JIT re-fire tests have a
+/// target. `requeue_attempts` seeds the durable counter the transient verdict
+/// spends, so a test can start the row at the cap.
 fn seed_processing_deposit(
     storage: &MockStorage,
     id: i64,
     updated_at: chrono::DateTime<chrono::Utc>,
+    requeue_attempts: i32,
 ) {
     use private_channel_indexer::storage::common::models::DbTransactionBuilder;
     let owner = Pubkey::new_unique().to_string();
@@ -309,7 +312,18 @@ fn seed_processing_deposit(
     tx.id = id;
     tx.status = TransactionStatus::Processing;
     tx.updated_at = updated_at;
+    tx.recovery_requeue_attempts = requeue_attempts;
     storage.pending_transactions.lock().unwrap().push(tx);
+}
+
+/// Read a seeded deposit row's status and durable requeue counter together.
+fn deposit_row_state(storage: &MockStorage, id: i64) -> (TransactionStatus, i32) {
+    let rows = storage.pending_transactions.lock().unwrap();
+    let row = rows
+        .iter()
+        .find(|t| t.id == id)
+        .expect("row must be seeded");
+    (row.status, row.recovery_requeue_attempts)
 }
 
 fn make_mint_builder_for_caller_arm(mint: Pubkey) -> MintToBuilder {
@@ -372,7 +386,7 @@ async fn mint_not_initialized_jit_retry_completes() {
     // Seed a Processing row the re-fire's claim owns via the same t0 the ctx carries.
     let t0 = chrono::Utc::now();
     if let Storage::Mock(mock_storage) = &*state.storage {
-        seed_processing_deposit(mock_storage, 5001, t0);
+        seed_processing_deposit(mock_storage, 5001, t0, 0);
     }
 
     // JIT pre-check sees admin-owned init, so Retry without sending init.
@@ -487,11 +501,13 @@ async fn mint_not_initialized_jit_manual_review_corrupt_state() {
     mock.shutdown().await;
 }
 
-/// JitOutcome::PermanentFailure — the caller arm routes through
-/// `handle_permanent_failure` and the resulting status is Failed.
+/// JitOutcome::Transient: a real RPC-driven transient verdict must re-arm the
+/// funded deposit for the fetcher instead of ending it. A terminal status here
+/// is read by no worker, so the deposit would sit with its escrow funded and no
+/// private channel mint until someone edited the database by hand.
 #[tokio::test]
-async fn mint_not_initialized_jit_permanent_failure() {
-    // Mint cache empty → JIT body returns PermanentFailure("mint not in mint cache").
+async fn mint_not_initialized_jit_transient_requeues_deposit() {
+    // Mint cache empty, so the JIT body returns Transient("mint not in mint cache").
     let (mut state, mut storage_rx, storage_tx, mock, mint) =
         build_state_for_jit_caller_arm(false).await;
 
@@ -503,23 +519,71 @@ async fn mint_not_initialized_jit_permanent_failure() {
     );
 
     let txn_id: i64 = 5004;
+    if let Storage::Mock(mock_storage) = &*state.storage {
+        seed_processing_deposit(mock_storage, txn_id, chrono::Utc::now(), 0);
+    }
+
     drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, None, &storage_tx).await;
 
-    let update = storage_rx
-        .recv()
-        .await
-        .expect("PermanentFailure path must emit a status update");
-    assert_eq!(update.transaction_id, txn_id);
-    assert_eq!(
-        update.status,
-        TransactionStatus::Failed,
-        "JitOutcome::PermanentFailure must route through handle_permanent_failure"
-    );
-    let msg = update.error_message.unwrap_or_default();
     assert!(
-        msg.contains("mint not in mint cache"),
-        "Failed error_message must surface the permanent-failure reason; got {msg:?}"
+        storage_rx.try_recv().is_err(),
+        "a transient JIT verdict must not write any status for a funded deposit"
     );
+    if let Storage::Mock(mock_storage) = &*state.storage {
+        let (status, attempts) = deposit_row_state(mock_storage, txn_id);
+        assert_eq!(
+            status,
+            TransactionStatus::Pending,
+            "the deposit must be re-armed for the fetcher"
+        );
+        assert_eq!(attempts, 1, "the durable requeue counter must be consumed");
+        assert!(
+            mock_storage
+                .get_release_signatures(txn_id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a transient verdict must broadcast nothing and journal nothing"
+        );
+    }
+    mock.shutdown().await;
+}
+
+/// At the durable requeue cap the sender stops re-arming, but it still must not
+/// terminalize the deposit. The row is left Processing so the recovery sweep,
+/// which verifies the mint on-chain first, owns the escalation.
+#[tokio::test]
+async fn mint_not_initialized_jit_transient_at_cap_leaves_processing() {
+    let (mut state, mut storage_rx, storage_tx, mock, mint) =
+        build_state_for_jit_caller_arm(false).await;
+
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply_bytes(&[0u8; Mint::LEN]),
+    );
+
+    // The cap constant is crate-private to the indexer, so this mirrors its
+    // value rather than importing it.
+    let txn_id: i64 = 5005;
+    if let Storage::Mock(mock_storage) = &*state.storage {
+        seed_processing_deposit(mock_storage, txn_id, chrono::Utc::now(), 3);
+    }
+
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, None, &storage_tx).await;
+
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "the sender must never terminalize a deposit, even at the requeue cap"
+    );
+    if let Storage::Mock(mock_storage) = &*state.storage {
+        let (status, attempts) = deposit_row_state(mock_storage, txn_id);
+        assert_eq!(
+            status,
+            TransactionStatus::Processing,
+            "at the cap the row waits for the recovery sweep"
+        );
+        assert_eq!(attempts, 3, "the cap must not be exceeded");
+    }
     mock.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary

Closes issue 285. A deposit funds escrow before the operator mints on the PrivateChannel, so its row is the only record that a mint is still owed. When `mint_to` returned `MintNotInitialized`, failures from the JIT `InitializeMint` helper were incorrectly classified as `PermanentFailure` and moved the deposit to terminal `Failed`. These failures can be transient, such as RPC, signer, send, or confirmation errors, and no worker retries `Failed` rows, leaving funded deposits stranded.

These failures are now classified as `Transient` and re-arm the deposit from `processing` to `pending` through the existing cap-gated `try_requeue_prebroadcast` CAS. This does not introduce another value-bearing send: the helper only broadcasts `InitializeMint`, which moves no funds and is idempotent. The failed `mint_to` signature remains in the journal, allowing the processor to re-check it and retry the mint only after the attempt is proven dead. The sender does not write a final status on cap, races, or write errors; recovery remains responsible for escalation and verifies the deposit on-chain first.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 14,024 | 15,713 | 89.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32050980226) |
| Indexer | 35,657 | 39,254 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32050980226) |
| Gateway | 1,476 | 1,698 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32050980226) |
| Auth | 908 | 1,059 | 85.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32050980226) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,344 | 18,258 | 78.6% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32050980226) |
| **Total** | **66,409** | **75,982** | **87.4%** | |

> Last updated: 2026-08-18 15:32:45 UTC by E2E Integration