### PR TITLE
fix(indexer): separate a missing checkpoint from a genesis checkpoint and fail closed (issue-278)

### DIFF
--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -39,7 +39,12 @@ Recovers missed slots on indexer restart or network issues:
      cannot be proven empty aborts the batch rather than being checkpointed past
    - Process blocks in order
    - Update checkpoint per slot via `CheckpointWriter` (driven by `SlotComplete` events)
-4. Switch to real-time mode (Yellowstone or polling)
+4. For the Yellowstone datasource, persist a startup anchor before the live stream runs, so a
+   durable checkpoint always exists: reconnect gap repair replays from it and withholds live slots
+   rather than advancing the checkpoint without one. The anchor is the resolved backfill range's
+   floor, or the current chain tip when backfill is disabled. RPC polling has no reconnect repair
+   and writes no anchor; it resumes from its configured start slot
+5. Switch to real-time mode (Yellowstone or polling)
 
 **Location**: [`indexer/src/indexer/backfill.rs`](../indexer/src/indexer/backfill.rs)
 

--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -4,7 +4,7 @@ use crate::{
     config::{BackfillConfig, ProgramType},
     error::{BackfillError, DataSourceError, IndexerError},
     indexer::{
-        checkpoint::get_last_checkpoint,
+        checkpoint::{get_last_checkpoint, program_key},
         datasource::{
             common::types::{InstructionSender, ProcessorMessage},
             rpc_polling::{decoder, rpc::RpcPoller, types::BlockFetch},
@@ -215,6 +215,70 @@ pub async fn fill_slot_range(
     Ok(processed_count)
 }
 
+/// Fetch the chain tip, retrying transient RPC failures on the same backoff as block fetches.
+pub(crate) async fn latest_slot_with_retry(rpc_poller: &RpcPoller) -> Result<u64, IndexerError> {
+    let mut retry_count = 0;
+    loop {
+        match rpc_poller.get_latest_slot().await {
+            Ok(slot) => return Ok(slot),
+            Err(e) => {
+                retry_count += 1;
+                if retry_count >= BACKFILL_MAX_RETRIES {
+                    error!(
+                        "Failed to fetch latest slot after {} retries: {}",
+                        BACKFILL_MAX_RETRIES, e
+                    );
+                    return Err(BackfillError::SlotFetchFailed { slot: 0, source: e }.into());
+                }
+                warn!(
+                    "Retry {}/{} fetching latest slot after error: {}",
+                    retry_count, BACKFILL_MAX_RETRIES, e
+                );
+                tokio::time::sleep(Duration::from_millis(
+                    BACKFILL_RETRY_DELAY_MS * retry_count as u64,
+                ))
+                .await;
+            }
+        }
+    }
+}
+
+/// Make sure a durable recovery anchor exists before any live slot is processed, and
+/// return the anchor now in force.
+///
+/// Reconnect repair replays everything between the durable checkpoint and the slot the
+/// replacement stream resumes at, so it needs a lower bound it can trust. An existing
+/// checkpoint is that bound and is returned untouched; only a store that has never held one
+/// gets a row written. The value is the bottom of the startup range when one was resolved,
+/// because the range above it has not been filled yet and claiming it would lose those
+/// slots; with no startup backfill there is no range to inherit, so the chain tip is the
+/// boundary the deployment is choosing and persisting it is what makes it recoverable.
+pub async fn ensure_startup_anchor(
+    storage: &Arc<Storage>,
+    program_type: ProgramType,
+    rpc_poller: &RpcPoller,
+    resolved_from_slot: Option<u64>,
+) -> Result<u64, IndexerError> {
+    if let Some(existing) = get_last_checkpoint(storage, program_type).await? {
+        return Ok(existing);
+    }
+
+    let anchor = match resolved_from_slot {
+        Some(from_slot) => from_slot,
+        None => latest_slot_with_retry(rpc_poller).await?,
+    };
+
+    storage
+        .update_committed_checkpoint(&program_key(program_type), anchor)
+        .await?;
+
+    info!(
+        "Startup anchor persisted for {:?}: slot {}",
+        program_type, anchor
+    );
+    Ok(anchor)
+}
+
 /// Resolved startup boundary shared by both producers. Backfill fills `gap` and the
 /// live RPC source resumes at `live_start_slot`, so the two meet with no hole and no
 /// overlap: `live_start_slot` is one past the highest slot backfill covers (or one past
@@ -224,6 +288,8 @@ pub struct StartupRange {
     pub gap: Option<(u64, u64)>,
     /// First slot the live RPC source must request.
     pub live_start_slot: u64,
+    /// Bottom of the resolved range; carried separately because it outlives an empty `gap`.
+    pub anchor: u64,
 }
 
 /// Backfill service for recovering missed slots on startup
@@ -268,7 +334,10 @@ impl BackfillService {
             self.program_type
         );
 
-        let last_checkpoint = get_last_checkpoint(&self.storage, self.program_type).await?;
+        // Catch-up starts at genesis when nothing was ever indexed, so absence is a zero here.
+        let last_checkpoint = get_last_checkpoint(&self.storage, self.program_type)
+            .await?
+            .unwrap_or(0);
 
         // Use the larger of configured start_slot and database checkpoint
         // Note: start_slot is inclusive (first slot to process), checkpoint is exclusive (last processed)
@@ -297,32 +366,7 @@ impl BackfillService {
             last_checkpoint
         };
 
-        // Retry transient RPC failures with backoff (same policy as block fetches), so a
-        // single hiccup gating the checkpoint writer doesn't force an ungated fallback.
-        let mut retry_count = 0;
-        let current_slot = loop {
-            match self.rpc_poller.get_latest_slot().await {
-                Ok(slot) => break slot,
-                Err(e) => {
-                    retry_count += 1;
-                    if retry_count >= BACKFILL_MAX_RETRIES {
-                        error!(
-                            "Failed to fetch latest slot after {} retries: {}",
-                            BACKFILL_MAX_RETRIES, e
-                        );
-                        return Err(BackfillError::SlotFetchFailed { slot: 0, source: e }.into());
-                    }
-                    warn!(
-                        "Retry {}/{} fetching latest slot after error: {}",
-                        retry_count, BACKFILL_MAX_RETRIES, e
-                    );
-                    tokio::time::sleep(Duration::from_millis(
-                        BACKFILL_RETRY_DELAY_MS * retry_count as u64,
-                    ))
-                    .await;
-                }
-            }
-        };
+        let current_slot = latest_slot_with_retry(&self.rpc_poller).await?;
 
         // One past the highest slot backfill covers (gap) or the durable checkpoint
         // (no gap); max guards against an RPC node lagging behind the checkpoint.
@@ -339,6 +383,7 @@ impl BackfillService {
                 Ok(StartupRange {
                     gap: None,
                     live_start_slot,
+                    anchor: from_slot,
                 })
             }
             Some(gap) => {
@@ -349,6 +394,7 @@ impl BackfillService {
                 Ok(StartupRange {
                     gap: Some((from_slot, current_slot)),
                     live_start_slot,
+                    anchor: from_slot,
                 })
             }
         }
@@ -389,6 +435,156 @@ impl BackfillService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::BackfillConfig;
+    use crate::storage::common::storage::mock::MockStorage;
+    use crate::test_utils::rpc_mocks::mock_get_slot;
+    use mockito::Server;
+    use solana_sdk::commitment_config::CommitmentLevel;
+    use solana_transaction_status::UiTransactionEncoding;
+
+    // ============================================================================
+    // Startup anchor Tests
+    // ============================================================================
+
+    /// Mock RPC plus a store either seeded with a checkpoint or left empty.
+    async fn anchor_fixture(
+        seeded: Option<u64>,
+    ) -> (mockito::ServerGuard, Arc<Storage>, RpcPoller) {
+        let server = Server::new_async().await;
+        let mock = MockStorage::new();
+        if let Some(slot) = seeded {
+            mock.set_checkpoint("escrow", slot);
+        }
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+        (server, Arc::new(Storage::Mock(mock)), poller)
+    }
+
+    /// Read back the escrow checkpoint the fixture's store currently holds.
+    async fn stored_checkpoint(storage: &Arc<Storage>) -> Option<u64> {
+        storage.get_committed_checkpoint("escrow").await.unwrap()
+    }
+
+    fn backfill_config(start_slot: Option<u64>, max_gap_slots: u64) -> BackfillConfig {
+        BackfillConfig {
+            enabled: true,
+            exit_after_backfill: false,
+            rpc_url: String::new(),
+            batch_size: 10,
+            max_gap_slots,
+            start_slot,
+        }
+    }
+
+    /// The anchor must be the range bottom in both arms, including the one with no gap.
+    #[tokio::test]
+    async fn resolve_range_anchor_is_from_slot_in_both_arms() {
+        // (tip, expected gap, expected live_start_slot)
+        let cases = [(150u64, Some((100u64, 150u64)), 151u64), (90, None, 101)];
+
+        for (tip, want_gap, want_live_start) in cases {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, tip);
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", 100);
+            let storage: Arc<Storage> = Arc::new(Storage::Mock(mock));
+            let poller = Arc::new(RpcPoller::new(
+                server.url(),
+                UiTransactionEncoding::Json,
+                CommitmentLevel::Finalized,
+            ));
+
+            let service = BackfillService::new(
+                storage,
+                poller,
+                ProgramType::Escrow,
+                backfill_config(None, 1000),
+                None,
+            );
+            let range = service.resolve_range().await.unwrap();
+
+            assert_eq!(range.gap, want_gap, "gap for tip {tip}");
+            assert_eq!(
+                range.anchor, 100,
+                "anchor must be the range bottom for tip {tip}"
+            );
+            assert_eq!(
+                range.live_start_slot, want_live_start,
+                "live_start_slot for tip {tip}"
+            );
+        }
+    }
+
+    /// A resolved boundary is written straight through, with no tip probe.
+    #[tokio::test]
+    async fn ensure_startup_anchor_persists_hint_without_rpc() {
+        let (mut server, storage, poller) = anchor_fixture(None).await;
+        let untouched = server.mock("POST", "/").expect(0).create();
+
+        let anchor = ensure_startup_anchor(&storage, ProgramType::Escrow, &poller, Some(500))
+            .await
+            .unwrap();
+
+        assert_eq!(anchor, 500);
+        assert_eq!(stored_checkpoint(&storage).await, Some(500));
+        untouched.assert();
+    }
+
+    /// With no boundary to inherit, the tip the stream begins at is what gets persisted.
+    #[tokio::test]
+    async fn ensure_startup_anchor_probes_tip_when_no_hint() {
+        let (mut server, storage, poller) = anchor_fixture(None).await;
+        let _slot = mock_get_slot(&mut server, 900);
+
+        let anchor = ensure_startup_anchor(&storage, ProgramType::Escrow, &poller, None)
+            .await
+            .unwrap();
+
+        assert_eq!(anchor, 900);
+        assert_eq!(stored_checkpoint(&storage).await, Some(900));
+    }
+
+    /// The dangerous case. Moving a live checkpoint forward would mark unread slots as
+    /// handled, which is the exact loss this anchor exists to prevent. An existing row must
+    /// therefore win over a hint above it and over a tip above it, and must cost no RPC
+    /// call at all, since a probe that never runs cannot return a value that overwrites it.
+    #[tokio::test]
+    async fn ensure_startup_anchor_never_moves_an_existing_checkpoint() {
+        let (mut server, storage, poller) = anchor_fixture(Some(100)).await;
+        let untouched = server.mock("POST", "/").expect(0).create();
+
+        let from_hint = ensure_startup_anchor(&storage, ProgramType::Escrow, &poller, Some(5_000))
+            .await
+            .unwrap();
+        assert_eq!(from_hint, 100, "a hint above the row must not move it");
+        assert_eq!(stored_checkpoint(&storage).await, Some(100));
+
+        let from_probe = ensure_startup_anchor(&storage, ProgramType::Escrow, &poller, None)
+            .await
+            .unwrap();
+        assert_eq!(from_probe, 100, "the tip probe must not be reached at all");
+        assert_eq!(stored_checkpoint(&storage).await, Some(100));
+
+        untouched.assert();
+    }
+
+    /// A failed anchor write must abort startup, not fall through into live streaming.
+    #[tokio::test]
+    async fn ensure_startup_anchor_fails_closed_on_write_failure() {
+        let (_server, storage, poller) = anchor_fixture(None).await;
+        if let Storage::Mock(mock) = storage.as_ref() {
+            // The mock keys its write fault on the program string, the read on the method.
+            mock.set_should_fail("escrow", true);
+        }
+
+        let result = ensure_startup_anchor(&storage, ProgramType::Escrow, &poller, Some(7)).await;
+
+        assert!(result.is_err(), "a failed anchor write must abort startup");
+        assert_eq!(stored_checkpoint(&storage).await, None);
+    }
 
     // ============================================================================
     // validate_gap Tests

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -304,11 +304,9 @@ impl CheckpointWriter {
             if !state.dirty {
                 continue;
             }
-            let program_type_str = format!("{:?}", program_type).to_lowercase();
-
             match self
                 .storage
-                .update_committed_checkpoint(&program_type_str, state.frontier)
+                .update_committed_checkpoint(&program_key(program_type), state.frontier)
                 .await
             {
                 Ok(_) => {
@@ -329,18 +327,26 @@ impl CheckpointWriter {
     }
 }
 
-/// Helper to get the last checkpoint for a program type
+/// Storage key a program type's checkpoint row is stored under.
+pub(crate) fn program_key(program_type: ProgramType) -> String {
+    format!("{:?}", program_type).to_lowercase()
+}
+
+/// Read a program type's durable checkpoint, or `None` when it has never been written.
+///
+/// Absence and slot zero are deliberately kept apart. A caller that wants to catch up
+/// from the beginning can treat `None` as genesis, but reconnect repair needs to know
+/// it has no recovery anchor at all, because advancing past a gap it cannot replay
+/// would put the missed slots permanently out of reach.
 pub async fn get_last_checkpoint(
     storage: &Arc<Storage>,
     program_type: ProgramType,
-) -> Result<u64, CheckpointError> {
-    let program_type_str = format!("{:?}", program_type).to_lowercase();
+) -> Result<Option<u64>, CheckpointError> {
     let checkpoint = storage
-        .get_committed_checkpoint(&program_type_str)
-        .await?
-        .unwrap_or(0);
+        .get_committed_checkpoint(&program_key(program_type))
+        .await?;
 
-    info!("Last checkpoint for {:?}: {}", program_type, checkpoint);
+    info!("Last checkpoint for {:?}: {:?}", program_type, checkpoint);
     Ok(checkpoint)
 }
 
@@ -691,18 +697,34 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(checkpoint, 12345);
+        assert_eq!(checkpoint, Some(12345));
     }
 
+    /// Both halves belong in one test: the bug was that "never anchored" and
+    /// "anchored at genesis" produced the same value, so the assertion that
+    /// matters is that these two stores now read back differently. Reconnect
+    /// repair keys its fail-closed decision on exactly this distinction.
     #[tokio::test]
-    async fn test_get_last_checkpoint_defaults_to_zero() {
-        let storage: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+    async fn get_last_checkpoint_returns_none_when_absent() {
+        let absent: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+        assert_eq!(
+            get_last_checkpoint(&absent, ProgramType::Escrow)
+                .await
+                .unwrap(),
+            None,
+            "a store with no row must report absence, not slot zero"
+        );
 
-        let checkpoint = get_last_checkpoint(&storage, ProgramType::Escrow)
-            .await
-            .unwrap();
-
-        assert_eq!(checkpoint, 0);
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", 0);
+        let genesis: Arc<Storage> = Arc::new(Storage::Mock(mock));
+        assert_eq!(
+            get_last_checkpoint(&genesis, ProgramType::Escrow)
+                .await
+                .unwrap(),
+            Some(0),
+            "a durable anchor at genesis must be distinguishable from absence"
+        );
     }
 
     #[tokio::test]
@@ -719,8 +741,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(escrow_checkpoint, 100);
-        assert_eq!(withdraw_checkpoint, 200);
+        assert_eq!(escrow_checkpoint, Some(100));
+        assert_eq!(withdraw_checkpoint, Some(200));
     }
 
     // ============================================================================

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -141,7 +141,7 @@ async fn fill_reconnect_gap_to<F, Fut>(
 ) -> GapFillOutcome
 where
     F: Fn() -> Fut,
-    Fut: Future<Output = Result<u64, CheckpointError>>,
+    Fut: Future<Output = Result<Option<u64>, CheckpointError>>,
 {
     loop {
         if cancel.is_cancelled() {
@@ -150,7 +150,23 @@ where
 
         // Re-read every cycle so an operator resync moves the anchor without a restart.
         let checkpoint = match get_checkpoint().await {
-            Ok(slot) => slot,
+            Ok(Some(slot)) => slot,
+            // No anchor means no lower bound to replay from, so resolving here would let
+            // the caller forward live slots over an interval nothing has covered. Retry
+            // instead: startup writes an anchor before any live block, so this only shows
+            // up if the checkpoint row was destroyed underneath a running indexer.
+            Ok(None) => {
+                error!(
+                    "Reconnect gap-fill: no durable checkpoint anchor for {:?}; holding the \
+                     checkpoint rather than skipping the gap",
+                    program_type
+                );
+                record_missing_anchor(program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return GapFillOutcome::Cancelled;
+                }
+                continue;
+            }
             Err(e) => {
                 warn!(
                     "Reconnect gap-fill: checkpoint read failed, retrying: {}",
@@ -163,11 +179,6 @@ where
                 continue;
             }
         };
-
-        // Fresh system: startup backfill owns initial catch-up.
-        if checkpoint == 0 {
-            return GapFillOutcome::Resolved;
-        }
 
         let gap = match validate_gap(target, checkpoint, max_gap_slots) {
             Ok(None) => {
@@ -258,9 +269,10 @@ struct ReconnectGapCtx {
 /// prior is aborted). Sent before the first live block so the gate wins the FIFO race.
 #[cfg(feature = "datasource-rpc")]
 /// Returns whether it is safe to forward the block that triggered this arm. `false`
-/// means cancellation interrupted the checkpoint read before the gate was armed, so the
-/// caller must NOT forward the block: its SlotComplete would advance the checkpoint over
-/// the still-unfilled gap. `true` means the gate is armed, or a fresh system needs none.
+/// means cancellation ended the wait before the gate was armed, so the caller must NOT
+/// forward the block: its SlotComplete would advance the checkpoint over the still
+/// unfilled gap, and every slot underneath it would stop being reachable. `true` means
+/// the gate is armed and the block is safe to hand on.
 async fn arm_reconnect_gap(
     t_sub: u64,
     ctx: &ReconnectGapCtx,
@@ -269,12 +281,25 @@ async fn arm_reconnect_gap(
     backoff: Duration,
     prev: &mut Option<tokio::task::JoinHandle<()>>,
 ) -> Result<bool, DataSourceRpcError> {
-    // Resolve the anchor before arming: the gate must seed the frontier to the durable
-    // checkpoint, so a wrong/zero `from` would freeze it. Retry a failed read until it
-    // succeeds or cancellation ends it (returning false so the block is not forwarded).
+    // Resolve the anchor before arming, because the gate seeds its frontier from it.
     let checkpoint = loop {
         match get_last_checkpoint(&ctx.storage, ctx.program_type).await {
-            Ok(slot) => break slot,
+            Ok(Some(slot)) => break slot,
+            // An anchor at slot zero is a real anchor and gets repaired like any other.
+            // Absence is different: without a lower bound there is nothing to replay
+            // from, so forwarding this block would let its SlotComplete carry the
+            // checkpoint over slots no one has read. Wait for an anchor instead.
+            Ok(None) => {
+                error!(
+                    "Reconnect gap: no durable checkpoint anchor for {:?}; withholding live \
+                     slots until one exists",
+                    ctx.program_type
+                );
+                record_missing_anchor(ctx.program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return Ok(false);
+                }
+            }
             Err(e) => {
                 warn!("Reconnect gap: checkpoint read failed, retrying: {}", e);
                 record_gap_fill_error(ctx.program_type);
@@ -284,12 +309,6 @@ async fn arm_reconnect_gap(
             }
         }
     };
-
-    // Fresh system: startup backfill owns initial catch-up and there is no residual
-    // window; arming would freeze the frontier on a range the fill never emits.
-    if checkpoint == 0 {
-        return Ok(true);
-    }
 
     send_guaranteed(
         tx,
@@ -351,6 +370,17 @@ async fn backoff_cancelled(cancel: &CancellationToken, backoff: Duration) -> boo
 fn record_gap_fill_error(program_type: ProgramType) {
     metrics::INDEXER_RPC_ERRORS
         .with_label_values(&[program_type.as_label(), "gap_fill"])
+        .inc();
+}
+
+/// Counted apart from a gap-fill error because the cause and the fix differ: this one means
+/// the recovery anchor is missing and live slots are being held back, which needs the anchor
+/// restored, while a gap-fill error means the RPC endpoint is misbehaving and usually clears
+/// on its own. Sharing one label would page the wrong person.
+#[cfg(feature = "datasource-rpc")]
+fn record_missing_anchor(program_type: ProgramType) {
+    metrics::INDEXER_RPC_ERRORS
+        .with_label_values(&[program_type.as_label(), "missing_anchor"])
         .inc();
 }
 
@@ -726,8 +756,17 @@ mod tests {
         )
     }
 
-    fn checkpoint_ok(slot: u64) -> impl Fn() -> std::future::Ready<Result<u64, CheckpointError>> {
-        move || std::future::ready(Ok(slot))
+    /// A durable anchor at `slot`.
+    fn checkpoint_ok(
+        slot: u64,
+    ) -> impl Fn() -> std::future::Ready<Result<Option<u64>, CheckpointError>> {
+        move || std::future::ready(Ok(Some(slot)))
+    }
+
+    /// A store that has never recorded an anchor, which must not be read as slot zero.
+    fn checkpoint_absent() -> impl Fn() -> std::future::Ready<Result<Option<u64>, CheckpointError>>
+    {
+        || std::future::ready(Ok(None))
     }
 
     /// Mock storage seeded with an escrow checkpoint, backing arm_reconnect_gap's
@@ -829,19 +868,70 @@ mod tests {
         assert_eq!(slots, vec![100, 101, 102, 103]);
     }
 
-    /// Checkpoint 0 is a fresh system; startup backfill owns catch-up, so the
-    /// fill resolves without a single RPC call.
+    /// A store with no anchor must stall, never resolve over a range nothing has read.
     #[tokio::test]
-    async fn gap_fill_fresh_system_resolves_without_rpc() {
+    async fn gap_fill_missing_anchor_retries_instead_of_resolving() {
         let mut server = Server::new_async().await;
         let untouched = server.mock("POST", "/").expect(0).create_async().await;
 
         let poller = test_poller(&server);
-        let (tx, _rx) = mpsc::channel(64);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let cancel_task = cancel.clone();
+
+        let mut handle = tokio::spawn(async move {
+            fill_reconnect_gap_to(
+                100,
+                checkpoint_absent(),
+                &poller,
+                1000,
+                10,
+                ProgramType::Escrow,
+                None,
+                &tx,
+                &cancel_task,
+                TEST_BACKOFF,
+            )
+            .await
+        });
+
+        // Several retry cycles must pass without the loop resolving or touching the RPC.
+        tokio::time::sleep(TEST_BACKOFF * 5).await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut handle)
+                .await
+                .is_err(),
+            "a missing anchor must stall, not resolve"
+        );
+        untouched.assert_async().await;
+        assert!(
+            rx.try_recv().is_err(),
+            "no message may be emitted while the anchor is missing"
+        );
+
+        cancel.cancel();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("cancellation must end the stall")
+            .unwrap();
+        assert_eq!(outcome, GapFillOutcome::Cancelled);
+    }
+
+    /// A durable slot 0 is a real anchor; the batch starts one past it, so 0 is not replayed.
+    #[tokio::test]
+    async fn gap_fill_genuine_zero_anchor_fills_gap() {
+        let mut server = Server::new_async().await;
+        let _enum = mock_dense_range(&mut server, 1, 3);
+        let _blocks: Vec<_> = (1..=3)
+            .map(|s| mock_get_block_success(&mut server, s))
+            .collect();
+
+        let poller = test_poller(&server);
+        let (tx, mut rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
 
         let outcome = fill_reconnect_gap_to(
-            100,
+            3,
             checkpoint_ok(0),
             &poller,
             1000,
@@ -855,7 +945,15 @@ mod tests {
         .await;
 
         assert_eq!(outcome, GapFillOutcome::Resolved);
-        untouched.assert_async().await;
+        drop(tx);
+
+        let mut slots = vec![];
+        while let Some(msg) = rx.recv().await {
+            if let ProcessorMessage::SlotComplete { slot, .. } = msg {
+                slots.push(slot);
+            }
+        }
+        assert_eq!(slots, vec![1, 2, 3]);
     }
 
     /// A failing checkpoint read retries instead of skipping the gap check.
@@ -873,7 +971,7 @@ mod tests {
                 if n < 2 {
                     Err(CheckpointError::InvalidCheckpoint { slot: 0, last: 0 })
                 } else {
-                    Ok(100)
+                    Ok(Some(100))
                 }
             }
         };
@@ -1114,10 +1212,10 @@ mod tests {
         assert_eq!(slots, vec![100, 101, 102, 103]);
     }
 
-    /// A fresh system (checkpoint 0) arms no gate and spawns no fill: startup
-    /// backfill owns catch-up, and arming would freeze the frontier forever.
+    /// No anchor means the block is unsafe to forward; letting it through was the bug.
     #[tokio::test]
-    async fn arm_reconnect_gap_fresh_system_does_not_arm() {
+    async fn arm_reconnect_gap_missing_anchor_withholds_block() {
+        use crate::storage::common::storage::mock::MockStorage;
         let mut server = Server::new_async().await;
         let no_blocks = server
             .mock("POST", "/")
@@ -1126,20 +1224,29 @@ mod tests {
             .create_async()
             .await;
 
-        let ctx = test_gap_ctx(&server, storage_with_checkpoint(0), 1000);
+        // No checkpoint seeded; the pre-cancelled token ends the retry loop at once.
+        let ctx = test_gap_ctx(&server, Arc::new(Storage::Mock(MockStorage::new())), 1000);
         let (tx, mut rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
+        cancel.cancel();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        let safe = arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
 
-        assert!(prev.is_none(), "a fresh system must not spawn a backfill");
+        assert!(
+            !safe,
+            "a missing anchor must report the block unsafe to forward"
+        );
+        assert!(
+            prev.is_none(),
+            "no backfill is spawned without a durable anchor"
+        );
         assert!(
             rx.recv().await.is_none(),
-            "a fresh system must emit no Regate and no SlotComplete"
+            "no Regate and no SlotComplete may be emitted without an anchor"
         );
         no_blocks.assert_async().await;
     }

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -13,6 +13,9 @@ use crate::{
 #[cfg(feature = "datasource-rpc")]
 use crate::indexer::backfill::BackfillService;
 
+#[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
+use crate::indexer::backfill::ensure_startup_anchor;
+
 #[cfg(feature = "datasource-rpc")]
 use crate::indexer::datasource::rpc_polling::{rpc::RpcPoller, RpcPollingSource};
 
@@ -130,6 +133,10 @@ pub async fn run(
     #[cfg(feature = "datasource-rpc")]
     let mut rpc_live_start_slot: Option<u64> = None;
 
+    // Floor of the resolved startup range; None makes the anchor fall back to the chain tip.
+    #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
+    let mut startup_anchor_hint: Option<u64> = None;
+
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -191,6 +198,11 @@ pub async fn run(
                         // Pin the live source to backfill's boundary so it resumes with
                         // no hole and no overlap, whether or not there is a gap to fill.
                         rpc_live_start_slot = Some(range.live_start_slot);
+                        // The floor, never the target: the range above it is not filled yet.
+                        #[cfg(feature = "datasource-yellowstone")]
+                        {
+                            startup_anchor_hint = Some(range.anchor);
+                        }
                         if let Some((from_slot, target)) = range.gap {
                             checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
                             let instruction_tx_clone = instruction_tx.clone();
@@ -301,6 +313,18 @@ pub async fn run(
                     "Yellowstone gap detection enabled (max_gap: {}, batch_size: {})",
                     indexer_config.backfill.max_gap_slots, indexer_config.backfill.batch_size
                 );
+
+                // Reconnect repair replays from the durable checkpoint, so one has to exist
+                // before the stream can deliver anything. Failing here refuses to start,
+                // which beats streaming past a window that could never be recovered: once a
+                // later slot is checkpointed, the slots below it stop being reachable.
+                ensure_startup_anchor(
+                    &storage,
+                    common_config.program_type,
+                    &gap_rpc_poller,
+                    startup_anchor_hint,
+                )
+                .await?;
 
                 source
                     .with_gap_detection(

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -261,6 +261,7 @@ pub fn init_labels(program_type: &str) {
         "missing_meta",
         "block_unavailable",
         "gap_fill",
+        "missing_anchor",
     ] {
         INDEXER_RPC_ERRORS.with_label_values(&[program_type, error_type]);
     }

--- a/indexer/src/test_utils.rs
+++ b/indexer/src/test_utils.rs
@@ -187,6 +187,18 @@ pub mod rpc_mocks {
     use mockito::{Mock, Server};
     use serde_json::json;
 
+    /// Mock `getSlot` replying with the chain tip.
+    pub fn mock_get_slot(server: &mut Server, slot: u64) -> Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(
+                json!({ "method": "getSlot" }),
+            ))
+            .with_status(200)
+            .with_body(json!({ "jsonrpc": "2.0", "result": slot, "id": 1 }).to_string())
+            .create()
+    }
+
     /// Mock `getBlocks(start, end)` replying with the slots that produced a block.
     /// Body-matched on method and range so it coexists with the getBlock mocks.
     pub fn mock_get_blocks(server: &mut Server, start: u64, end: u64, produced: &[u64]) -> Mock {

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -107,6 +107,11 @@ path = "tests/indexer/yellowstone_reconnect_gap.rs"
 name = "reconnect_gap_fill_fail_closed"
 path = "tests/indexer/reconnect_gap_fill_fail_closed.rs"
 
+# Startup anchor persisted by `run` before the Yellowstone stream starts.
+[[test]]
+name = "startup_anchor"
+path = "tests/indexer/startup_anchor.rs"
+
 # Yellowstone inner_instructions + unknown-discriminator arms.
 [[test]]
 name = "yellowstone_inner_and_unknown"

--- a/integration/tests/indexer/startup_anchor.rs
+++ b/integration/tests/indexer/startup_anchor.rs
@@ -1,0 +1,265 @@
+//! Startup anchor wiring for `private_channel_indexer::indexer::run`.
+//!
+//! Reconnect gap repair replays from the durable checkpoint, so `run` must persist one
+//! before the Yellowstone stream can deliver anything. These tests pin the value it picks:
+//! the chain tip when no startup backfill resolved a boundary, and the boundary's floor
+//! when one did. Picking the top of the resolved range instead would durably claim the
+//! slots backfill has not fetched yet, which is the loss the anchor exists to prevent.
+
+use mockito::{Matcher, Server as MockitoServer};
+use private_channel_indexer::{
+    config::{BackfillConfig, ReconciliationConfig, RpcPollingConfig, YellowstoneConfig},
+    indexer::run,
+    DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig, ProgramType,
+    StorageType,
+};
+use serde_json::json;
+use solana_sdk::commitment_config::CommitmentLevel;
+use solana_transaction_status::UiTransactionEncoding;
+use sqlx::PgPool;
+use std::time::Duration;
+use test_utils::mock_yellowstone::MockYellowstoneServer;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+/// Chain tip both tests' mock RPC reports.
+const TIP: u64 = 900;
+/// First slot to process when backfill is on, so the floor 897 stays distinct from the tip.
+const START_SLOT: u64 = 898;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+}
+
+/// Real Postgres via testcontainers; the container must stay alive for the test.
+async fn start_postgres(
+    db: &str,
+) -> (
+    testcontainers::ContainerAsync<Postgres>,
+    PgPool,
+    PostgresConfig,
+) {
+    let pg = Postgres::default()
+        .with_db_name(db)
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("postgres container");
+    let host = pg.get_host().await.expect("pg host");
+    let port = pg.get_host_port_ipv4(5432).await.expect("pg port");
+    let url = format!("postgres://postgres:password@{host}:{port}/{db}");
+
+    let pool = PgPool::connect(&url).await.expect("pg pool");
+    let config = PostgresConfig {
+        database_url: url,
+        max_connections: 10,
+    };
+    (pg, pool, config)
+}
+
+/// Read the anchor row. `run` creates the schema, so an early query is a "not yet".
+async fn anchor_of(pool: &PgPool, program: &str) -> Option<u64> {
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT last_committed_slot FROM indexer_state WHERE program_type = $1")
+            .bind(program)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten();
+    row.map(|(slot,)| slot as u64)
+}
+
+/// Poll until the anchor row appears, so the assertion does not race startup.
+async fn wait_for_anchor(pool: &PgPool, program: &str, secs: u64) -> u64 {
+    tokio::time::timeout(Duration::from_secs(secs), async {
+        loop {
+            if let Some(slot) = anchor_of(pool, program).await {
+                return slot;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("no startup anchor was ever persisted for {program}"))
+}
+
+/// Yellowstone config pointed at a mock that never sends a block, plus the given backfill
+/// settings. Withdraw skips escrow reconciliation, which needs an on-chain instance.
+/// The rpc_polling block is unused by the Yellowstone datasource but is required whenever
+/// backfill is enabled, so it is always supplied.
+fn indexer_config(geyser_endpoint: String, backfill: BackfillConfig) -> IndexerConfig {
+    IndexerConfig {
+        datasource_type: DatasourceType::Yellowstone,
+        rpc_polling: Some(RpcPollingConfig {
+            from_slot: None,
+            poll_interval_ms: 1_000,
+            error_retry_interval_ms: 1_000,
+            batch_size: 10,
+            encoding: UiTransactionEncoding::Json,
+            commitment: CommitmentLevel::Finalized,
+        }),
+        yellowstone: Some(YellowstoneConfig {
+            endpoint: geyser_endpoint,
+            x_token: None,
+            commitment: "confirmed".to_string(),
+        }),
+        backfill,
+        reconciliation: ReconciliationConfig::default(),
+    }
+}
+
+fn common_config(postgres: PostgresConfig, rpc_url: String) -> PrivateChannelIndexerConfig {
+    PrivateChannelIndexerConfig {
+        program_type: ProgramType::Withdraw,
+        storage_type: StorageType::Postgres,
+        rpc_url,
+        source_rpc_url: None,
+        fallback_rpc_url: None,
+        postgres,
+        escrow_instance_id: None,
+    }
+}
+
+async fn mock_get_slot(rpc: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    rpc.mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": slot, "id": 1}).to_string())
+        .create_async()
+        .await
+}
+
+/// The shipped Yellowstone deployment runs with backfill disabled. Nothing resolves a
+/// boundary there, so the tip the stream is about to start from is the anchor, and it has
+/// to be durable before the first block rather than after the checkpoint writer flushes.
+/// The mock never sends a block, so a row appearing at all can only have come from startup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_persists_tip_anchor_before_streaming() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_anchor_tip").await;
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut rpc, TIP).await;
+    // No block mocks: any fetch would mean a backfill ran where none was configured.
+    let no_blocks = rpc
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getBlock"})))
+        .expect(0)
+        .create_async()
+        .await;
+
+    let ys = MockYellowstoneServer::start().await;
+
+    let backfill = BackfillConfig {
+        enabled: false,
+        exit_after_backfill: false,
+        rpc_url: rpc.url(),
+        batch_size: 100,
+        max_gap_slots: 1_000,
+        start_slot: None,
+    };
+    let indexer = indexer_config(ys.url(), backfill);
+    let common = common_config(postgres, rpc.url());
+
+    // Surface a startup failure instead of letting it look like a missing anchor.
+    let handle = tokio::spawn(async move {
+        if let Err(e) = run(common, indexer, None).await {
+            eprintln!("indexer run exited: {e}");
+        }
+    });
+
+    // The mock never sends a block, so this anchor can only have come from startup.
+    let anchor = wait_for_anchor(&pool, "withdraw", 60).await;
+    assert_eq!(
+        anchor, TIP,
+        "a backfill-disabled deployment must anchor at the tip it starts streaming from"
+    );
+    no_blocks.assert_async().await;
+
+    handle.abort();
+    ys.shutdown().await;
+}
+
+/// With startup backfill resolving a range, the anchor is that range's floor. The tip and
+/// the live start slot both sit above slots backfill has yet to fetch, so recording either
+/// would mark them handled and put them permanently out of reach. All three are plain u64,
+/// so nothing but this test stops the wrong one being passed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_anchors_at_resolved_from_slot_not_the_tip() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_anchor_floor").await;
+
+    let floor = START_SLOT - 1;
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut rpc, TIP).await;
+    let _enumeration = rpc
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlocks", "params": [START_SLOT, TIP]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": [898, 899, 900], "id": 1}).to_string())
+        .expect_at_least(0)
+        .create_async()
+        .await;
+    for slot in START_SLOT..=TIP {
+        let _block = rpc
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "getBlock", "params": [slot]}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "TestBlockHash11111111111111111111111111111",
+                        "parentSlot": slot - 1,
+                        "transactions": []
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(0)
+            .create_async()
+            .await;
+    }
+
+    let ys = MockYellowstoneServer::start().await;
+
+    let backfill = BackfillConfig {
+        enabled: true,
+        exit_after_backfill: false,
+        rpc_url: rpc.url(),
+        batch_size: 100,
+        max_gap_slots: 1_000,
+        start_slot: Some(START_SLOT),
+    };
+    let indexer = indexer_config(ys.url(), backfill);
+    let common = common_config(postgres, rpc.url());
+
+    // Surface a startup failure instead of letting it look like a missing anchor.
+    let handle = tokio::spawn(async move {
+        if let Err(e) = run(common, indexer, None).await {
+            eprintln!("indexer run exited: {e}");
+        }
+    });
+
+    let anchor = wait_for_anchor(&pool, "withdraw", 60).await;
+    assert_eq!(
+        anchor,
+        floor,
+        "the anchor must be the resolved range floor, not the tip ({TIP}) \
+         or the live start slot ({})",
+        TIP + 1
+    );
+
+    handle.abort();
+    ys.shutdown().await;
+}

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -188,11 +188,12 @@ async fn gap_fill_runs_after_drop_stream() {
     server.shutdown().await;
 }
 
-/// Error path: fresh system (checkpoint=0) must skip reconnect gap-fill —
-/// no RPC backfill calls, no spurious SlotCompletes. Startup backfill (when
-/// configured) is responsible for initial catch-up, not the reconnect path.
+/// The bug, end to end. With no durable anchor there is no lower bound to replay from, so
+/// the slot the replacement stream resumes at must be withheld. Forwarding it is what used
+/// to carry the checkpoint over the slots that arrived while nothing was listening, and
+/// once the checkpoint passed them nothing revisited them on any later restart.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn fresh_system_reconnect_does_not_gap_fill() {
+async fn reconnect_without_anchor_withholds_live_slots() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter("info,private_channel_indexer=debug")
         .with_test_writer()
@@ -200,8 +201,13 @@ async fn fresh_system_reconnect_does_not_gap_fill() {
 
     let mut rpc_mock = MockitoServer::new_async().await;
 
-    // No getBlock mocks — any call would panic mockito's matcher. getSlot is
-    // tolerated (the reconnect path may probe it before checking checkpoint).
+    // Any repair attempt would land here; without an anchor none may be made.
+    let no_blocks = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getBlock"})))
+        .expect(0)
+        .create_async()
+        .await;
     let _slot_mock = rpc_mock
         .mock("POST", "/")
         .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
@@ -219,7 +225,7 @@ async fn fresh_system_reconnect_does_not_gap_fill() {
         CommitmentLevel::Confirmed,
     ));
 
-    // No checkpoint seeded → get_last_checkpoint returns 0 → skip path.
+    // No checkpoint seeded, so the source has never recorded a recovery anchor.
     let storage: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
 
     let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(64);
@@ -240,26 +246,42 @@ async fn fresh_system_reconnect_does_not_gap_fill() {
         .await
         .expect("yellowstone source start");
 
-    // Stream one slot, drop, give the reconnect path time to run.
+    // The first connection is a cold start and forwards its block without arming.
     server.enqueue(UpdateMatcher, Update::ok(empty_block(100)));
-    let _ = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
-    server.drop_stream();
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("slot 100 must be forwarded on the first connection");
+    assert!(
+        matches!(
+            first,
+            Some(ProcessorMessage::SlotComplete { slot: 100, .. })
+        ),
+        "expected SlotComplete for slot 100, got {first:?}"
+    );
 
-    // Drain the channel — only the streamed slot 100 should appear, never
-    // any backfill SlotCompletes (which would mean we contacted the RPC).
-    let mut all_slots = vec![];
-    while let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
-        tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
-    {
-        all_slots.push(slot);
+    // Drop, then resume at a later slot. Slot 101 is the value-bearing slot nobody saw.
+    server.drop_stream();
+    server.enqueue(UpdateMatcher, Update::ok(empty_block(102)));
+
+    // Hold well past the 5s retry backoff: a regression forwards 102 almost immediately.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(12);
+    let mut leaked = vec![];
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            leaked.push(slot);
+        }
     }
 
-    let unexpected: Vec<_> = all_slots.iter().filter(|&&s| s != 100).collect();
     assert!(
-        unexpected.is_empty(),
-        "fresh system must NOT trigger gap-fill; unexpected slots: {:?}",
-        unexpected
+        leaked.is_empty(),
+        "no slot may be forwarded without a durable anchor; leaked: {leaked:?}"
+    );
+    no_blocks.assert_async().await;
+    assert!(
+        server.call_count("subscribe") >= 2,
+        "the source resubscribes; the withheld block, not a blocked resubscribe, is the guard"
     );
 
     cancel.cancel();


### PR DESCRIPTION
## Summary

`get_last_checkpoint` previously treated "no checkpoint row" and "checkpoint at slot zero" as the same value. During the first few seconds of a deployment, the checkpoint row may not exist yet because writes are batched every five seconds. If Yellowstone disconnected during that window, the reconnect logic treated the stream as fresh, resumed from the provider's live position, and could skip slots that arrived while it was disconnected. A `WithdrawFunds` burn in that gap could therefore leave tokens burned with no indexed release.

`get_last_checkpoint` now returns `Option<u64>`, so a missing checkpoint is distinguishable from slot zero. On startup, `run` persists an anchor before creating the Yellowstone datasource: it uses the resolved range floor when backfill ran, or the chain tip when no backfill was needed. Reconnects now use any real anchor, including slot zero, and hold the triggering block until an anchor exists. The checkpoint update remains monotonic and only creates a missing row, leaving an existing checkpoint untouched without an RPC call.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 14,011 | 15,713 | 89.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32051141243) |
| Indexer | 35,746 | 39,356 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32051141243) |
| Gateway | 1,476 | 1,698 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32051141243) |
| Auth | 908 | 1,059 | 85.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32051141243) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,356 | 18,269 | 78.6% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32051141243) |
| **Total** | **66,497** | **76,095** | **87.4%** | |

> Last updated: 2026-08-18 15:23:12 UTC by E2E Integration