### PR TITLE
fix(core): treat Redis as a cache behind Postgres, not a source of truth (issue-178-179)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ PRIVATE_CHANNEL_BATCH_DEADLINE_MS=10
 PRIVATE_CHANNEL_BATCH_CHANNEL_CAPACITY=16
 # Executor parallel SVM worker cap.
 PRIVATE_CHANNEL_MAX_SVM_WORKERS=8
+# Optional Redis read cache in front of Postgres. Leave unset to run
+# Postgres-only. Both the write node and the read node take this one value, so
+# they cannot end up pointing at different caches. Needs a Redis instance; the
+# compose stack does not ship one.
+# PRIVATE_CHANNEL_REDIS_CACHE_URL=redis://redis:6379
 # Space-separated channel admin pubkey(s): the write-node's InitializeMint gate.
 # `make build-localnet` fills this (and ADMIN_PRIVATE_KEY) with a generated keypair.
 # Must not list the escrow instance admin, which is a separate offline key.

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -1945,7 +1945,21 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn preload_marks_db_loaded_account_clean() {
-        let (mut redis_raw, _redis) = crate::test_helpers::start_test_redis().await;
+        // The cache needs its Postgres source of truth, though this test seeds
+        // the key directly so every read below is a cache hit.
+        let (pg_db, _pg) = crate::test_helpers::start_test_postgres().await;
+        let crate::accounts::AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (mut redis_raw, _redis) =
+            crate::test_helpers::start_test_redis(postgres_db.clone()).await;
+        // A cache is only read from while it names this deployment.
+        let deployment_id = crate::accounts::redis_coherence::read_deployment_id(postgres_db)
+            .await
+            .unwrap();
+        crate::accounts::redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
         let pubkey = Pubkey::new_unique();
         let account = make_account(5000, &[7, 7, 7], &Pubkey::default());
         // Seed Redis using the exact key/serialization get_accounts_redis expects.

--- a/core/src/accounts/get_account_shared_data.rs
+++ b/core/src/accounts/get_account_shared_data.rs
@@ -69,14 +69,31 @@ async fn get_account_shared_data_redis(
     db: &RedisAccountsDB,
     pubkey: &Pubkey,
 ) -> Option<AccountSharedData> {
-    let mut conn = db.connection.clone();
     let key = format!("account:{}", pubkey);
-    let data: redis::RedisResult<Vec<u8>> = conn.get(key).await;
-    match data {
-        Ok(bytes) => bincode::deserialize(&bytes).ok(),
+    let cached = match db.get_trusted::<Vec<u8>>(&key).await {
+        Ok(bytes) => bytes,
         Err(e) => {
             error!("Failed to get account {} from Redis: {}", pubkey, e);
             None
         }
+    };
+
+    if let Some(bytes) = cached {
+        match bincode::deserialize(&bytes) {
+            Ok(account) => return Some(account),
+            Err(e) => {
+                error!("Failed to deserialize cached account {}: {}", pubkey, e);
+                // Evict it, or every later read pays both hops to reach the same
+                // conclusion. Nothing else would ever remove it.
+                let mut conn = db.connection.clone();
+                if let Err(e) = conn.del::<_, ()>(&key).await {
+                    error!("Failed to evict corrupt cached account {}: {}", pubkey, e);
+                }
+            }
+        }
     }
+
+    // Absent, unreadable or corrupt cache entries are misses, not proof the
+    // account does not exist. Resolve them against the source of truth.
+    get_account_shared_data_postgres(&db.fallback, pubkey).await
 }

--- a/core/src/accounts/get_accounts.rs
+++ b/core/src/accounts/get_accounts.rs
@@ -71,18 +71,68 @@ async fn get_accounts_redis(
     redis_db: &RedisAccountsDB,
     accounts: &[Pubkey],
 ) -> Vec<Option<AccountSharedData>> {
+    // MGET with no keys is a Redis error, and there is nothing to resolve.
+    if accounts.is_empty() {
+        return Vec::new();
+    }
+
     let mut conn = redis_db.connection.clone();
-    let keys = accounts
-        .iter()
-        .map(|key| format!("account:{}", key))
-        .collect::<Vec<_>>();
+    // The deployment stamp rides along as the first key, so the same round trip
+    // that fetches the values also proves the cache may still be read from.
+    let mut keys = Vec::with_capacity(accounts.len() + 1);
+    keys.push(crate::accounts::redis_coherence::DEPLOYMENT_ID_KEY.to_string());
+    keys.extend(accounts.iter().map(|key| format!("account:{}", key)));
     let data: RedisResult<Vec<Option<Vec<u8>>>> = conn.mget(keys).await;
 
-    match data {
-        Ok(results) => results
-            .into_iter()
-            .map(|opt| opt.and_then(|bytes| bincode::deserialize(&bytes).ok()))
-            .collect(),
-        Err(_) => vec![None; accounts.len()],
+    let mut results: Vec<Option<AccountSharedData>> = match data {
+        // MGET answers one entry per key, so the split always succeeds; a short
+        // reply is treated as an untrusted cache rather than indexed into, since
+        // this runs under an RPC request where a panic is far worse than a miss.
+        Ok(cached) if cached.len() == accounts.len() + 1 => {
+            let (stamp, values) = cached.split_first().expect("checked non-empty above");
+            if redis_db.stamp_is_current(stamp.as_ref()) {
+                values
+                    .iter()
+                    .map(|opt| {
+                        opt.as_ref()
+                            .and_then(|bytes| bincode::deserialize(bytes).ok())
+                    })
+                    .collect()
+            } else {
+                // Condemned or foreign cache: every position is a miss.
+                vec![None; accounts.len()]
+            }
+        }
+        Ok(cached) => {
+            tracing::error!(
+                "Redis returned {} values for {} keys; treating the cache as unusable",
+                cached.len(),
+                accounts.len() + 1
+            );
+            vec![None; accounts.len()]
+        }
+        Err(e) => {
+            tracing::error!("Failed to read accounts from Redis: {}", e);
+            vec![None; accounts.len()]
+        }
+    };
+
+    // Every position the cache could not answer is a miss. Resolve just those
+    // against the source of truth, keeping the result aligned with `accounts`.
+    let missing: Vec<usize> = results
+        .iter()
+        .enumerate()
+        .filter(|(_, account)| account.is_none())
+        .map(|(position, _)| position)
+        .collect();
+    if missing.is_empty() {
+        return results;
     }
+
+    let missing_pubkeys: Vec<Pubkey> = missing.iter().map(|&position| accounts[position]).collect();
+    let resolved = get_accounts_postgres(&redis_db.fallback, &missing_pubkeys).await;
+    for (position, account) in missing.into_iter().zip(resolved) {
+        results[position] = account;
+    }
+    results
 }

--- a/core/src/accounts/get_block.rs
+++ b/core/src/accounts/get_block.rs
@@ -5,10 +5,9 @@ use {
         traits::{AccountsDB, BlockInfo},
     },
     anyhow::{Context, Result},
-    redis::AsyncCommands,
     sqlx::Row,
     std::sync::Arc,
-    tracing::debug,
+    tracing::{debug, warn},
 };
 
 /// `Ok(None)` means the slot genuinely holds no block on this node, which is
@@ -43,17 +42,26 @@ async fn get_block_postgres(db: &PostgresAccountsDB, slot: u64) -> Result<Option
 }
 
 async fn get_block_redis(db: &RedisAccountsDB, slot: u64) -> Result<Option<BlockInfo>> {
-    let mut conn = db.connection.clone();
     let key = format!("block:{}", slot);
-    let data: Option<Vec<u8>> = conn
-        .get(key)
-        .await
-        .with_context(|| format!("Failed to read block at slot {} from Redis", slot))?;
-
-    let Some(bytes) = data else {
-        return Ok(None);
+    let cached = match db.get_trusted::<Vec<u8>>(&key).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            warn!("Failed to read block at slot {} from Redis: {}", slot, e);
+            None
+        }
     };
-    let block_info = bincode::deserialize(&bytes)
-        .with_context(|| format!("Failed to deserialize block at slot {}", slot))?;
-    Ok(Some(block_info))
+
+    if let Some(bytes) = cached {
+        match bincode::deserialize(&bytes) {
+            Ok(block_info) => return Ok(Some(block_info)),
+            // Written by an older build whose BlockInfo had fewer fields. Falling
+            // through keeps the slot readable; failing here would make it error
+            // for as long as the entry sat in the cache.
+            Err(e) => warn!("Failed to deserialize cached block at slot {}: {}", slot, e),
+        }
+    }
+
+    // A slot missing or unreadable in the cache is a miss, not a pruned or
+    // skipped slot.
+    get_block_postgres(&db.fallback, slot).await
 }

--- a/core/src/accounts/get_blocks.rs
+++ b/core/src/accounts/get_blocks.rs
@@ -1,7 +1,6 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
     anyhow::{anyhow, Context, Result},
-    redis::AsyncCommands,
 };
 
 /// Maximum number of blocks that can be returned (per Solana spec)
@@ -16,7 +15,13 @@ pub async fn get_blocks(
         AccountsDB::Postgres(postgres_db) => {
             get_blocks_postgres(postgres_db, start_slot, end_slot).await
         }
-        AccountsDB::Redis(redis_db) => get_blocks_redis(redis_db, start_slot, end_slot).await,
+        // Served from the source of truth, never the cache. A range answered
+        // from a partial mirror is indistinguishable from a complete one, so a
+        // cached miss would silently drop finalized blocks instead of surfacing
+        // as a miss.
+        AccountsDB::Redis(redis_db) => {
+            get_blocks_postgres(&redis_db.fallback, start_slot, end_slot).await
+        }
     }
 }
 
@@ -57,45 +62,4 @@ async fn get_blocks_postgres(
 
     // Convert i64 slots to u64
     Ok(slots.into_iter().map(|s| s as u64).collect())
-}
-
-async fn get_blocks_redis(
-    db: &RedisAccountsDB,
-    start_slot: u64,
-    end_slot: Option<u64>,
-) -> Result<Vec<u64>> {
-    let mut conn = db.connection.clone();
-
-    let end_slot = match end_slot {
-        Some(end) => end,
-        None => {
-            let latest_slot: redis::RedisResult<Option<u64>> = conn.get("latest_slot").await;
-            latest_slot
-                .map_err(|e| anyhow!("Failed to get latest slot from Redis: {}", e))?
-                .context("No latest slot found in Redis")?
-        }
-    };
-
-    // Enforce maximum range constraint
-    if end_slot > start_slot && (end_slot - start_slot) > MAX_BLOCKS_RANGE {
-        return Err(anyhow!(
-            "Range too large: {} slots (max: {})",
-            end_slot - start_slot,
-            MAX_BLOCKS_RANGE
-        ));
-    }
-
-    // ZRANGE ... BYSCORE queries only the requested range in O(log N + M),
-    // where N is total slots indexed and M is the number of results returned.
-    // Results are returned in ascending score order (slot order) by default.
-    let slots: Vec<u64> = redis::cmd("ZRANGE")
-        .arg("block_slot_index")
-        .arg(start_slot)
-        .arg(end_slot)
-        .arg("BYSCORE")
-        .query_async(&mut conn)
-        .await
-        .map_err(|e| anyhow!("Failed to query block slot index in Redis: {}", e))?;
-
-    Ok(slots)
 }

--- a/core/src/accounts/get_blocks_in_range.rs
+++ b/core/src/accounts/get_blocks_in_range.rs
@@ -1,11 +1,9 @@
 use {
     super::{
         postgres::PostgresAccountsDB,
-        redis::RedisAccountsDB,
         traits::{AccountsDB, BlockInfo},
     },
     anyhow::{Context, Result},
-    redis::AsyncCommands,
     sqlx::Row,
 };
 
@@ -18,8 +16,11 @@ pub async fn get_blocks_in_range(
         AccountsDB::Postgres(postgres_db) => {
             get_blocks_in_range_postgres(postgres_db, start_slot, end_slot).await
         }
+        // Served from the source of truth. The cached form skipped slots it had
+        // no entry for, which silently shortened the range; this path feeds the
+        // dedup rebuild, where a dropped block means a replay slips through.
         AccountsDB::Redis(redis_db) => {
-            get_blocks_in_range_redis(redis_db, start_slot, end_slot).await
+            get_blocks_in_range_postgres(&redis_db.fallback, start_slot, end_slot).await
         }
     }
 }
@@ -49,57 +50,6 @@ async fn get_blocks_in_range_postgres(
         let block = bincode::deserialize::<BlockInfo>(&data)
             .context("Failed to deserialize block in range query (likely pre-upgrade block data; wipe the DB or add a migration shim)")?;
         blocks.push(block);
-    }
-
-    Ok(blocks)
-}
-
-/// Maximum number of keys per Redis MGET command.
-/// Keeps individual commands bounded regardless of how large max_blockhashes grows.
-const MGET_CHUNK_SIZE: u64 = 1000;
-
-async fn get_blocks_in_range_redis(
-    db: &RedisAccountsDB,
-    start_slot: u64,
-    end_slot: u64,
-) -> Result<Vec<BlockInfo>> {
-    if start_slot > end_slot {
-        return Ok(Vec::new());
-    }
-
-    let mut conn = db.connection.clone();
-    let mut blocks = Vec::new();
-
-    // Issue MGET in fixed-size chunks so a single command stays bounded
-    // regardless of how large the slot range is.
-    let mut chunk_start = start_slot;
-    while chunk_start <= end_slot {
-        let chunk_end = (chunk_start + MGET_CHUNK_SIZE - 1).min(end_slot);
-
-        let keys: Vec<String> = (chunk_start..=chunk_end)
-            .map(|slot| format!("block:{}", slot))
-            .collect();
-
-        let values: Vec<Option<Vec<u8>>> = conn
-            .mget(&keys)
-            .await
-            .context("Failed to MGET blocks from Redis")?;
-
-        for (slot, maybe_bytes) in (chunk_start..=chunk_end).zip(values) {
-            let Some(bytes) = maybe_bytes else {
-                continue;
-            };
-            // A trailing field was added to BlockInfo, so a decode failure here most
-            // likely means pre-upgrade block data. This path feeds the dedup rebuild,
-            // so we fail closed (propagate) rather than silently drop the block and
-            // seed an incomplete cache; wipe the DB or add a migration shim to recover.
-            let block = bincode::deserialize::<BlockInfo>(&bytes).with_context(|| {
-                format!("Failed to deserialize block {slot} from Redis (likely pre-upgrade block data; wipe the DB or add a migration shim)")
-            })?;
-            blocks.push(block);
-        }
-
-        chunk_start = chunk_end + 1;
     }
 
     Ok(blocks)

--- a/core/src/accounts/get_blocks_with_limit.rs
+++ b/core/src/accounts/get_blocks_with_limit.rs
@@ -1,5 +1,5 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
     anyhow::{anyhow, Context, Result},
 };
 
@@ -30,8 +30,11 @@ pub async fn get_blocks_with_limit(
         AccountsDB::Postgres(postgres_db) => {
             get_blocks_with_limit_postgres(postgres_db, start_slot, limit).await
         }
+        // Served from the source of truth, and no slot index is cached. One
+        // would hold only the blocks written since the cache attached, so the
+        // first `limit` members it could offer would not be the ledger's.
         AccountsDB::Redis(redis_db) => {
-            get_blocks_with_limit_redis(redis_db, start_slot, limit).await
+            get_blocks_with_limit_postgres(&redis_db.fallback, start_slot, limit).await
         }
     }
 }
@@ -53,28 +56,4 @@ async fn get_blocks_with_limit_postgres(
     .context("Failed to query blocks with limit")?;
 
     Ok(slots.into_iter().map(|s| s as u64).collect())
-}
-
-async fn get_blocks_with_limit_redis(
-    db: &RedisAccountsDB,
-    start_slot: u64,
-    limit: u64,
-) -> Result<Vec<u64>> {
-    let mut conn = db.connection.clone();
-
-    // ZRANGE ... BYSCORE returns ascending score (slot) order, and LIMIT stops the
-    // scan at `limit` members rather than walking to the end. Requires Redis 6.2+.
-    let slots: Vec<u64> = redis::cmd("ZRANGE")
-        .arg("block_slot_index")
-        .arg(start_slot)
-        .arg("+inf")
-        .arg("BYSCORE")
-        .arg("LIMIT")
-        .arg(0i64)
-        .arg(limit as i64)
-        .query_async(&mut conn)
-        .await
-        .map_err(|e| anyhow!("Failed to query block slot index in Redis: {}", e))?;
-
-    Ok(slots)
 }

--- a/core/src/accounts/get_epoch_info.rs
+++ b/core/src/accounts/get_epoch_info.rs
@@ -1,8 +1,7 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
     crate::rpc::api::EpochInfo,
     anyhow::{Context, Result},
-    redis::AsyncCommands,
 };
 
 // PrivateChannel doesn't have epochs like Solana - it has one massive epoch
@@ -13,7 +12,9 @@ const EPOCH: u64 = 0;
 pub async fn get_epoch_info(db: &AccountsDB) -> Result<EpochInfo> {
     match db {
         AccountsDB::Postgres(postgres_db) => get_epoch_info_postgres(postgres_db).await,
-        AccountsDB::Redis(redis_db) => get_epoch_info_redis(redis_db).await,
+        // Served from the source of truth: it reports the transaction count,
+        // which is not cached. See `get_transaction_count`.
+        AccountsDB::Redis(redis_db) => get_epoch_info_postgres(&redis_db.fallback).await,
     }
 }
 
@@ -38,28 +39,6 @@ async fn get_epoch_info_postgres(db: &PostgresAccountsDB) -> Result<EpochInfo> {
     .and_then(|bytes| {
         super::transaction_count::TransactionCount::from_bytes(&bytes).map(|tc| tc.count())
     });
-
-    Ok(EpochInfo {
-        absolute_slot: latest_slot,
-        block_height: latest_slot,
-        epoch: EPOCH,
-        slot_index: latest_slot,
-        slots_in_epoch: SLOTS_IN_EPOCH,
-        transaction_count,
-    })
-}
-
-async fn get_epoch_info_redis(db: &RedisAccountsDB) -> Result<EpochInfo> {
-    let mut conn = db.connection.clone();
-
-    // Get the latest slot
-    let latest_slot: u64 = conn
-        .get("latest_slot")
-        .await
-        .context("Failed to get latest slot from Redis")?;
-
-    // Get transaction count (optional)
-    let transaction_count: Option<u64> = conn.get("transaction_count").await.ok();
 
     Ok(EpochInfo {
         absolute_slot: latest_slot,

--- a/core/src/accounts/get_first_available_block.rs
+++ b/core/src/accounts/get_first_available_block.rs
@@ -1,13 +1,16 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
-    anyhow::{anyhow, Context, Result},
-    redis::AsyncCommands,
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
+    anyhow::{Context, Result},
 };
 
 pub async fn get_first_available_block(db: &AccountsDB) -> Result<u64> {
     match db {
         AccountsDB::Postgres(postgres_db) => get_first_available_block_postgres(postgres_db).await,
-        AccountsDB::Redis(redis_db) => get_first_available_block_redis(redis_db).await,
+        // Served from the source of truth, and no slot index is cached. One
+        // would only cover blocks written since the cache attached, so its
+        // minimum would be a cache artefact rather than the ledger's first
+        // available block.
+        AccountsDB::Redis(redis_db) => get_first_available_block_postgres(&redis_db.fallback).await,
     }
 }
 
@@ -39,22 +42,6 @@ async fn get_first_available_block_postgres(db: &PostgresAccountsDB) -> Result<u
 fn decode_first_available_block(value: &[u8]) -> Option<u64> {
     let bytes: [u8; 8] = value.try_into().ok()?;
     Some(u64::from_le_bytes(bytes))
-}
-
-async fn get_first_available_block_redis(db: &RedisAccountsDB) -> Result<u64> {
-    let mut conn = db.connection.clone();
-    // ZRANGE 0 0 returns the single member with the lowest score (earliest slot).
-    // Pairs with write_batch_redis which uses ZADD on block_slot_index for MIN semantics.
-    let result: redis::RedisResult<Vec<u64>> =
-        conn.zrange("block_slot_index", 0isize, 0isize).await;
-    result
-        .map_err(|e| anyhow!("Failed to get first available block from Redis: {}", e))
-        .and_then(|slots| {
-            slots
-                .into_iter()
-                .next()
-                .ok_or_else(|| anyhow!("No first available block found in Redis"))
-        })
 }
 
 #[cfg(test)]

--- a/core/src/accounts/get_latest_blockhash.rs
+++ b/core/src/accounts/get_latest_blockhash.rs
@@ -1,9 +1,9 @@
 use {
     super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
     anyhow::{anyhow, Context, Result},
-    redis::AsyncCommands,
     solana_sdk::hash::Hash,
     std::str::FromStr,
+    tracing::warn,
 };
 
 pub async fn get_latest_blockhash(db: &AccountsDB) -> Result<Hash> {
@@ -35,15 +35,18 @@ async fn get_latest_blockhash_postgres(db: &PostgresAccountsDB) -> Result<Hash> 
 }
 
 async fn get_latest_blockhash_redis(db: &RedisAccountsDB) -> Result<Hash> {
-    let mut conn = db.connection.clone();
-    let result: redis::RedisResult<Option<String>> = conn.get("latest_blockhash").await;
-    result
-        .map_err(|e| anyhow!("Failed to get latest blockhash from Redis: {}", e))
-        .and_then(|opt| {
-            opt.ok_or_else(|| anyhow!("No latest blockhash found in Redis"))
-                .and_then(|hash_str| {
-                    Hash::from_str(&hash_str)
-                        .map_err(|e| anyhow!("Invalid blockhash format: {}", e))
-                })
-        })
+    let cached = match db.get_trusted::<String>("latest_blockhash").await {
+        Ok(hash_str) => hash_str,
+        Err(e) => {
+            warn!("Failed to get latest blockhash from Redis: {}", e);
+            None
+        }
+    };
+
+    if let Some(hash_str) = cached {
+        return Hash::from_str(&hash_str).map_err(|e| anyhow!("Invalid blockhash format: {}", e));
+    }
+
+    // No cached blockhash is a miss, not a ledger without a tip.
+    get_latest_blockhash_postgres(&db.fallback).await
 }

--- a/core/src/accounts/get_latest_slot.rs
+++ b/core/src/accounts/get_latest_slot.rs
@@ -1,7 +1,7 @@
 use {
     super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
-    anyhow::{anyhow, Result},
-    redis::AsyncCommands,
+    anyhow::Result,
+    tracing::warn,
 };
 
 pub async fn get_latest_slot(db: &AccountsDB) -> Result<Option<u64>> {
@@ -29,7 +29,17 @@ async fn get_latest_slot_postgres(db: &PostgresAccountsDB) -> Result<Option<u64>
 }
 
 async fn get_latest_slot_redis(db: &RedisAccountsDB) -> Result<Option<u64>> {
-    let mut conn = db.connection.clone();
-    let result: redis::RedisResult<Option<u64>> = conn.get("latest_slot").await;
-    result.map_err(|e| anyhow!("Failed to get latest slot from Redis: {}", e))
+    let cached = match db.get_trusted::<u64>("latest_slot").await {
+        Ok(slot) => slot,
+        Err(e) => {
+            warn!("Failed to get latest slot from Redis: {}", e);
+            None
+        }
+    };
+
+    match cached {
+        Some(slot) => Ok(Some(slot)),
+        // No cached tip is a miss, not an empty ledger.
+        None => get_latest_slot_postgres(&db.fallback).await,
+    }
 }

--- a/core/src/accounts/get_recent_performance_samples.rs
+++ b/core/src/accounts/get_recent_performance_samples.rs
@@ -1,7 +1,6 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
     anyhow::{Context, Result},
-    redis::AsyncCommands,
     solana_rpc_client_types::response::RpcPerfSample,
 };
 
@@ -13,7 +12,13 @@ pub async fn get_recent_performance_samples(
         AccountsDB::Postgres(postgres_db) => {
             get_recent_performance_samples_postgres(postgres_db, limit).await
         }
-        AccountsDB::Redis(redis_db) => get_recent_performance_samples_redis(redis_db, limit).await,
+        // Served from the source of truth, and no samples are cached. A cached
+        // list would be trimmed to a fixed length and hold only samples written
+        // since the cache attached, so a short answer would read as a complete
+        // one.
+        AccountsDB::Redis(redis_db) => {
+            get_recent_performance_samples_postgres(&redis_db.fallback, limit).await
+        }
     }
 }
 
@@ -50,28 +55,6 @@ async fn get_recent_performance_samples_postgres(
             },
         )
         .collect();
-
-    Ok(performance_samples)
-}
-
-async fn get_recent_performance_samples_redis(
-    db: &RedisAccountsDB,
-    limit: usize,
-) -> Result<Vec<RpcPerfSample>> {
-    let mut conn = db.connection.clone();
-
-    // Get the most recent samples from the list (0 to limit-1)
-    let sample_jsons: Vec<String> = conn
-        .lrange("performance_samples", 0, (limit - 1) as isize)
-        .await
-        .context("Failed to get performance samples from Redis")?;
-
-    let mut performance_samples = Vec::new();
-    for sample_json in sample_jsons {
-        if let Ok(sample) = serde_json::from_str::<RpcPerfSample>(&sample_json) {
-            performance_samples.push(sample);
-        }
-    }
 
     Ok(performance_samples)
 }

--- a/core/src/accounts/get_signatures_for_address.rs
+++ b/core/src/accounts/get_signatures_for_address.rs
@@ -1,8 +1,7 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
     crate::accounts::types::StoredTransaction,
     anyhow::Result,
-    redis::AsyncCommands,
     solana_rpc_client_api::response::RpcConfirmedTransactionStatusWithSignature,
     solana_sdk::{pubkey::Pubkey, signature::Signature},
     solana_transaction_status::{extract_memos::extract_and_fmt_memos, TransactionWithStatusMeta},
@@ -10,14 +9,6 @@ use {
     sqlx::{PgPool, Row},
     std::sync::Arc,
 };
-
-/// Decodes a hex-encoded signature string into a base58 string.
-/// Signatures are stored as hex in Redis sorted sets to preserve byte ordering.
-fn hex_to_b58(hex_str: &str) -> Result<String> {
-    let bytes = hex::decode(hex_str)
-        .map_err(|e| anyhow::anyhow!("Invalid hex signature {}: {}", hex_str, e))?;
-    Ok(bs58::encode(bytes).into_string())
-}
 
 pub async fn get_signatures_for_address(
     db: &AccountsDB,
@@ -30,8 +21,13 @@ pub async fn get_signatures_for_address(
         AccountsDB::Postgres(postgres_db) => {
             get_signatures_for_address_postgres(postgres_db, address, limit, before, until).await
         }
+        // Served from the source of truth, and no address index is cached. One
+        // would hold only signatures written since the cache attached, so a
+        // short history would read as a complete one. The cached form also
+        // never supported before/until cursors.
         AccountsDB::Redis(redis_db) => {
-            get_signatures_for_address_redis(redis_db, address, limit, before, until).await
+            get_signatures_for_address_postgres(&redis_db.fallback, address, limit, before, until)
+                .await
         }
     }
 }
@@ -206,98 +202,6 @@ async fn get_signatures_for_address_postgres(
         results.push(RpcConfirmedTransactionStatusWithSignature {
             signature: signature.to_string(),
             slot: slot as u64,
-            err,
-            memo,
-            block_time: Some(stored_tx.block_time),
-            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
-        });
-    }
-
-    Ok(results)
-}
-
-async fn get_signatures_for_address_redis(
-    db: &RedisAccountsDB,
-    address: &Pubkey,
-    limit: usize,
-    before: Option<&Signature>,
-    until: Option<&Signature>,
-) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-    // before/until cursor pagination is not yet implemented for Redis.
-    // Clients hitting a Redis-backed node with cursor params will receive an error.
-    // Implementing cursors requires same-slot tiebreaking which is non-trivial
-    // with a score-only sorted set index — left as a TODO.
-    if before.is_some() || until.is_some() {
-        return Err(anyhow::anyhow!(
-            "before/until cursors are not yet supported by the Redis backend"
-        ));
-    }
-
-    let mut conn = db.connection.clone();
-    let key = format!("addr_sigs:{}", address);
-
-    // ZRANGE ... BYSCORE REV returns members with the highest score (most recent
-    // slot) first, matching the Postgres ORDER BY slot DESC behaviour.
-    // Requires Redis 6.2+. Members are hex-encoded so same-slot lex ordering
-    // matches Postgres's ORDER BY signature DESC (raw bytes).
-    let sig_strings: Vec<String> = redis::cmd("ZRANGE")
-        .arg(&key)
-        .arg("+inf")
-        .arg("-inf")
-        .arg("BYSCORE")
-        .arg("REV")
-        .arg("LIMIT")
-        .arg(0i64)
-        .arg(limit as i64)
-        .query_async(&mut conn)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to query addr_sigs for {}: {}", address, e))?;
-
-    if sig_strings.is_empty() {
-        return Ok(vec![]);
-    }
-
-    let sig_b58_strings: Vec<String> = sig_strings
-        .iter()
-        .map(|s| hex_to_b58(s))
-        .collect::<Result<Vec<String>>>()?;
-
-    // Fetch all transaction blobs in a single MGET to avoid N round trips.
-    let tx_keys: Vec<String> = sig_b58_strings
-        .iter()
-        .map(|s| format!("tx:{}", s))
-        .collect();
-    let tx_blobs: Vec<Option<Vec<u8>>> = conn
-        .mget(&tx_keys)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to MGET transactions for {}: {}", address, e))?;
-
-    let mut results = Vec::with_capacity(sig_b58_strings.len());
-    for (sig_str, blob) in sig_b58_strings.iter().zip(tx_blobs) {
-        let data = match blob {
-            Some(d) => d,
-            // addr_sigs and tx:{sig} are written in the same pipeline MULTI/EXEC,
-            // so a missing transaction blob indicates data corruption.
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Transaction data missing for signature {} — addr_sigs index is inconsistent",
-                    sig_str
-                ))
-            }
-        };
-
-        let stored_tx = bincode::deserialize::<StoredTransaction>(&data)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize transaction {}: {}", sig_str, e))?;
-
-        let err = stored_tx.meta.err.clone();
-        let memo = match stored_tx.transaction_with_status_meta() {
-            TransactionWithStatusMeta::Complete(versioned) => extract_and_fmt_memos(&versioned),
-            _ => None,
-        };
-
-        results.push(RpcConfirmedTransactionStatusWithSignature {
-            signature: sig_str.clone(),
-            slot: stored_tx.slot,
             err,
             memo,
             block_time: Some(stored_tx.block_time),

--- a/core/src/accounts/get_transaction.rs
+++ b/core/src/accounts/get_transaction.rs
@@ -2,11 +2,10 @@ use {
     super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
     crate::accounts::types::StoredTransaction,
     anyhow::{Context, Result},
-    redis::AsyncCommands,
     solana_sdk::signature::Signature,
     sqlx::Row,
     std::sync::Arc,
-    tracing::debug,
+    tracing::{debug, warn},
 };
 
 /// `Ok(None)` means the signature is genuinely absent from this node's history.
@@ -52,17 +51,28 @@ async fn get_transaction_redis(
     db: &RedisAccountsDB,
     signature: &Signature,
 ) -> Result<Option<StoredTransaction>> {
-    let mut conn = db.connection.clone();
     let key = format!("tx:{}", signature);
-    let data: Option<Vec<u8>> = conn
-        .get(key)
-        .await
-        .with_context(|| format!("Failed to read transaction {} from Redis", signature))?;
-
-    let Some(bytes) = data else {
-        return Ok(None);
+    let cached = match db.get_trusted::<Vec<u8>>(&key).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            warn!("Failed to read transaction {} from Redis: {}", signature, e);
+            None
+        }
     };
-    let tx = bincode::deserialize(&bytes)
-        .with_context(|| format!("Failed to deserialize transaction {}", signature))?;
-    Ok(Some(tx))
+
+    if let Some(bytes) = cached {
+        match bincode::deserialize(&bytes) {
+            Ok(tx) => return Ok(Some(tx)),
+            // Written by an older build whose StoredTransaction had a different
+            // layout. Falling through keeps the signature readable.
+            Err(e) => warn!(
+                "Failed to deserialize cached transaction {}: {}",
+                signature, e
+            ),
+        }
+    }
+
+    // A signature missing or unreadable in the cache is a miss, never proof the
+    // transaction did not land. Only the source of truth can answer that.
+    get_transaction_postgres(&db.fallback, signature).await
 }

--- a/core/src/accounts/get_transaction_count.rs
+++ b/core/src/accounts/get_transaction_count.rs
@@ -1,16 +1,18 @@
 use {
     super::{
-        postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB,
-        transaction_count::TransactionCount,
+        postgres::PostgresAccountsDB, traits::AccountsDB, transaction_count::TransactionCount,
     },
-    anyhow::{anyhow, Context, Result},
-    redis::AsyncCommands,
+    anyhow::{Context, Result},
 };
 
 pub async fn get_transaction_count(db: &AccountsDB) -> Result<u64> {
     match db {
         AccountsDB::Postgres(postgres_db) => get_transaction_count_postgres(postgres_db).await,
-        AccountsDB::Redis(redis_db) => get_transaction_count_redis(redis_db).await,
+        // Served from the source of truth, and no counter is cached at all. One
+        // could only be built by INCR, which is not idempotent: a single dropped
+        // cache write would leave it permanently short, with nothing to detect
+        // the gap against.
+        AccountsDB::Redis(redis_db) => get_transaction_count_postgres(&redis_db.fallback).await,
     }
 }
 
@@ -29,12 +31,4 @@ async fn get_transaction_count_postgres(db: &PostgresAccountsDB) -> Result<u64> 
         .unwrap_or_default();
 
     Ok(count.count())
-}
-
-async fn get_transaction_count_redis(db: &RedisAccountsDB) -> Result<u64> {
-    let mut conn = db.connection.clone();
-    let result: redis::RedisResult<Option<u64>> = conn.get("transaction_count").await;
-    result
-        .map_err(|e| anyhow!("Failed to get transaction count from Redis: {}", e))
-        .map(|opt| opt.unwrap_or(0))
 }

--- a/core/src/accounts/mod.rs
+++ b/core/src/accounts/mod.rs
@@ -22,6 +22,7 @@ pub mod get_transaction_count;
 pub mod postgres;
 pub mod precompiles;
 pub mod redis;
+pub mod redis_coherence;
 pub mod set_account;
 pub mod set_latest_slot;
 pub mod store_block;

--- a/core/src/accounts/postgres.rs
+++ b/core/src/accounts/postgres.rs
@@ -172,6 +172,18 @@ async fn create_tables(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> 
     .execute(pool)
     .await?;
 
+    // Identifies this database, so a Redis cache carrying another deployment's
+    // ledger keys can be recognised and purged instead of served. DO NOTHING
+    // keeps an existing database's identifier stable across restarts; a fresh
+    // database, or one restored from a different ledger, gets a different one.
+    sqlx::query(
+        "INSERT INTO metadata (key, value) VALUES ('deployment_id', $1)
+         ON CONFLICT (key) DO NOTHING",
+    )
+    .bind(&rand::random::<[u8; 16]>()[..])
+    .execute(pool)
+    .await?;
+
     sqlx::query(
         r#"
             CREATE TABLE IF NOT EXISTS performance_samples (
@@ -216,6 +228,29 @@ mod tests {
     use solana_svm_callback::TransactionProcessingCallback;
 
     const ENV_VAR: &str = "PRIVATE_CHANNEL_PG_MAX_CONNECTIONS";
+
+    /// `create_tables` runs on every boot, so the deployment id must be minted
+    /// once and then left alone. Re-minting it would make the Redis cache look
+    /// like it belonged to another ledger and purge it on every restart.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn deployment_id_survives_reopening_the_database() {
+        // Both handles point at the same database, and the second one re-runs
+        // create_tables, which is exactly what a restart does.
+        let (first, second, _pg) = start_test_postgres_with_new_instance().await;
+
+        let first_id = crate::accounts::redis_coherence::read_deployment_id(&first)
+            .await
+            .unwrap();
+        let second_id = crate::accounts::redis_coherence::read_deployment_id(&second)
+            .await
+            .unwrap();
+
+        assert_eq!(first_id.len(), 16, "deployment id must be 16 bytes");
+        assert_eq!(
+            first_id, second_id,
+            "re-running create_tables must not re-mint the deployment id"
+        );
+    }
 
     /// Snapshot the env var, run `body`, restore. `serial_test` prevents
     /// concurrent tests from racing on the shared process env.

--- a/core/src/accounts/redis.rs
+++ b/core/src/accounts/redis.rs
@@ -1,17 +1,40 @@
 use {
+    super::postgres::PostgresAccountsDB,
     anyhow::Result,
     redis::{aio::ConnectionManager, AsyncCommands, RedisResult},
     solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
     solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
+    std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 #[derive(Clone)]
 pub struct RedisAccountsDB {
     pub connection: ConnectionManager,
+    /// The Postgres source of truth this cache sits in front of. A key absent
+    /// from Redis is a cache miss to be resolved here, never an authoritative
+    /// "does not exist".
+    ///
+    /// Not optional: a cache with no source of truth behind it can only answer
+    /// a miss by claiming the data does not exist, which is the one answer it
+    /// must never give.
+    pub fallback: PostgresAccountsDB,
+    /// The deployment the cache must name for its contents to be usable, read
+    /// from Postgres once at construction because it never changes for a given
+    /// database. Held here so a read can check the stamp without a second
+    /// round trip.
+    deployment_id: Vec<u8>,
+    /// Counts how many times this cache has been taken out of service. A rebuild
+    /// carries the value it was started with and declines to stamp if it has
+    /// moved on, so a rebuild overtaken by a later condemnation cannot return a
+    /// cache to service whose purge predates the newer gap.
+    condemnations: Arc<AtomicU64>,
 }
 
 impl RedisAccountsDB {
-    pub async fn new(redis_url: &str) -> Result<Self, String> {
+    pub async fn new(redis_url: &str, fallback: PostgresAccountsDB) -> Result<Self, String> {
         // Parse URL to extract host/port without credentials for error messages
         let sanitized_url = if let Ok(parsed) = url::Url::parse(redis_url) {
             let host = parsed.host_str().unwrap_or("unknown");
@@ -27,8 +50,62 @@ impl RedisAccountsDB {
             .await
             .map_err(|_| format!("Failed to connect to Redis at {}", sanitized_url))?;
 
-        let db = Self { connection };
+        let deployment_id = super::redis_coherence::read_deployment_id(&fallback)
+            .await
+            .map_err(|e| format!("{e:#}"))?;
+
+        let db = Self {
+            connection,
+            fallback,
+            deployment_id,
+            condemnations: Arc::new(AtomicU64::new(0)),
+        };
         Ok(db)
+    }
+
+    /// How many times this cache has been taken out of service. Shared across
+    /// clones of the handle, so a rebuild running on one clone sees a
+    /// condemnation raised on another.
+    pub(crate) fn condemnation_generation(&self) -> u64 {
+        self.condemnations.load(Ordering::SeqCst)
+    }
+
+    /// Records that the cache has been taken out of service, superseding any
+    /// rebuild already in flight.
+    pub(crate) fn record_condemnation(&self) {
+        self.condemnations.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Reads a cached value and the deployment stamp in one round trip, yielding
+    /// the value only while the stamp still names this deployment. Checking the
+    /// stamp per read, rather than on a timer, is what makes a condemnation take
+    /// effect on the very next read. `MGET` of two keys costs what `GET` of one
+    /// costs.
+    ///
+    /// `None` covers a missing key, a missing stamp and a foreign stamp alike:
+    /// all three mean the cache cannot answer, and callers resolve that against
+    /// Postgres.
+    pub(crate) async fn get_trusted<T: redis::FromRedisValue>(
+        &self,
+        key: &str,
+    ) -> RedisResult<Option<T>> {
+        let mut conn = self.connection.clone();
+        let (stamp, value): (Option<Vec<u8>>, Option<T>) = redis::cmd("MGET")
+            .arg(super::redis_coherence::DEPLOYMENT_ID_KEY)
+            .arg(key)
+            .query_async(&mut conn)
+            .await?;
+
+        match stamp {
+            Some(stamp) if stamp == self.deployment_id => Ok(value),
+            _ => Ok(None),
+        }
+    }
+
+    /// Whether a stamp read alongside cached values still names this deployment.
+    /// For batch reads that fetch the stamp as part of their own `MGET`.
+    pub(crate) fn stamp_is_current(&self, stamp: Option<&Vec<u8>>) -> bool {
+        stamp.is_some_and(|stamp| *stamp == self.deployment_id)
     }
 
     pub async fn set_account(&mut self, pubkey: Pubkey, account: AccountSharedData) {

--- a/core/src/accounts/redis.rs
+++ b/core/src/accounts/redis.rs
@@ -5,7 +5,7 @@ use {
     solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
     solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
     std::sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -31,6 +31,10 @@ pub struct RedisAccountsDB {
     /// moved on, so a rebuild overtaken by a later condemnation cannot return a
     /// cache to service whose purge predates the newer gap.
     condemnations: Arc<AtomicU64>,
+    /// Whether a rebuild is already working on this cache. A condemned cache is
+    /// not mirrored to, so its tip stays frozen and every later batch sees the
+    /// same discontinuity; without this, each one would condemn again.
+    rebuilding: Arc<AtomicBool>,
 }
 
 impl RedisAccountsDB {
@@ -59,8 +63,15 @@ impl RedisAccountsDB {
             fallback,
             deployment_id,
             condemnations: Arc::new(AtomicU64::new(0)),
+            rebuilding: Arc::new(AtomicBool::new(false)),
         };
         Ok(db)
+    }
+
+    /// The deployment this cache must name to be readable. Renewing the lease
+    /// rewrites it, so the mirror path needs it without a Postgres round trip.
+    pub(crate) fn deployment_id(&self) -> &[u8] {
+        &self.deployment_id
     }
 
     /// How many times this cache has been taken out of service. Shared across
@@ -74,6 +85,22 @@ impl RedisAccountsDB {
     /// rebuild already in flight.
     pub(crate) fn record_condemnation(&self) {
         self.condemnations.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Claims the right to rebuild this cache, returning false when a rebuild
+    /// already holds it. Checking and claiming in one step, so two batches
+    /// cannot both decide they are the one to condemn.
+    pub(crate) fn try_begin_rebuild(&self) -> bool {
+        self.rebuilding
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    /// Releases the claim. Called however the rebuild ended: a failed one that
+    /// held the claim would leave the cache unmirrored and unable to condemn
+    /// again, so it would never recover.
+    pub(crate) fn finish_rebuild(&self) {
+        self.rebuilding.store(false, Ordering::SeqCst);
     }
 
     /// Reads a cached value and the deployment stamp in one round trip, yielding

--- a/core/src/accounts/redis_coherence.rs
+++ b/core/src/accounts/redis_coherence.rs
@@ -9,9 +9,14 @@
 //!
 //! Both are handled by one mechanism. Each Postgres database is stamped with an
 //! identifier at creation and the cache carries a copy, which every cached read
-//! checks against the identifier the handle was built with. Clearing that stamp
-//! therefore takes the cache out of service on the next read, with no window and
-//! nothing to notify:
+//! checks against the identifier the handle was built with. That copy is a lease
+//! rather than a flag: the settler renews it on every mirrored batch, so a cache
+//! nobody is maintaining falls out of service without anyone having to say so.
+//! This matters because the writer that should revoke may be the thing that
+//! failed, and it cannot revoke through a connection it has lost.
+//!
+//! Clearing the stamp does the same thing immediately, for the cases where the
+//! writer is healthy enough to say so:
 //!
 //! - [`staleness_reason`] compares a cache against Postgres at startup, where a
 //!   mismatch means another ledger's data or a tip that does not line up.
@@ -23,6 +28,7 @@ use {
     super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB},
     anyhow::{anyhow, Context, Result},
     redis::AsyncCommands,
+    std::time::Duration,
     tracing::{info, warn},
 };
 
@@ -31,6 +37,19 @@ use {
 /// absence from Redis means the cache has never been checked against a source of
 /// truth.
 pub(crate) const DEPLOYMENT_ID_KEY: &str = "deployment_id";
+
+/// How long the cache stays trusted without renewal.
+///
+/// The writer renews on every mirrored batch, so a writer that stops
+/// maintaining the cache stops extending it. Revoking would be faster, but
+/// revoking needs a working Redis connection and the cases that matter most are
+/// the ones where the writer has lost it or died outright. Expiry needs nothing.
+///
+/// Sized well above any tolerable settle latency. A settler stalled inside a
+/// slow Postgres write is not diverging from Postgres, so expiring there would
+/// shed no staleness and would land the whole read fleet on the database that is
+/// already the bottleneck.
+pub(crate) const CACHE_LEASE_TTL: Duration = Duration::from_secs(30);
 
 /// Cached ledger state, keyed by pubkey, signature, slot or address. `addr_sigs:`
 /// is no longer written, but a cache filled by an older build still holds it and
@@ -49,6 +68,20 @@ const LEDGER_FIXED_KEYS: [&str; 5] = [
 
 /// Keys per SCAN round. Bounds how long one round blocks the Redis event loop.
 const SCAN_COUNT: usize = 512;
+
+/// Whether the cache may still be written to and served.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CacheStatus {
+    /// Contiguous with the last batch mirrored into it. Mirror this one and
+    /// renew its lease.
+    InService,
+    /// A batch was missed, so every key in it is suspect. Already taken out of
+    /// service; the caller owes it a purge off the block-production path.
+    Condemned,
+    /// Out of service with a purge already running. Leave it alone: do not
+    /// mirror, do not renew its lease, do not start a second purge.
+    Rebuilding,
+}
 
 /// Reads the identifier Postgres was stamped with at schema creation.
 pub(crate) async fn read_deployment_id(db: &PostgresAccountsDB) -> Result<Vec<u8>> {
@@ -140,15 +173,13 @@ pub(crate) async fn staleness_reason(
 /// cache is suspect.
 ///
 /// The response is to clear the deployment stamp, which takes the cache out of
-/// service on the next read. Returns whether a rebuild is needed; the caller runs
-/// one off the block-production path, because a SCAN over a large keyspace costs
-/// far more than a blocktime allows.
-///
-/// Mirroring continues while the rebuild runs. Nothing is served from an
-/// unstamped cache, and `SCAN` returns every key present for the whole pass, so
-/// the rebuild clears the stale ones regardless of what is written alongside it.
-/// Keys written during the pass may be swept too, which only costs a miss.
-pub(crate) async fn ensure_cache_continuity(redis_db: &RedisAccountsDB, slot: u64) -> Result<bool> {
+/// service on the next read. The caller runs the purge off the block-production
+/// path, because a SCAN over a large keyspace costs far more than a blocktime
+/// allows.
+pub(crate) async fn ensure_cache_continuity(
+    redis_db: &RedisAccountsDB,
+    slot: u64,
+) -> Result<CacheStatus> {
     let mut conn = redis_db.connection.clone();
     let cached_slot: Option<u64> = conn
         .get("latest_slot")
@@ -158,10 +189,20 @@ pub(crate) async fn ensure_cache_continuity(redis_db: &RedisAccountsDB, slot: u6
     // No tip: an empty or freshly purged cache, with nothing to be contiguous
     // with and nothing to lose.
     let Some(cached_slot) = cached_slot else {
-        return Ok(false);
+        return Ok(CacheStatus::InService);
     };
     if cached_slot + 1 == slot {
-        return Ok(false);
+        return Ok(CacheStatus::InService);
+    }
+
+    // A condemned cache is not mirrored to, so its tip stays where it is and
+    // every later batch lands here too. The rebuild already running covers them
+    // all: nothing is written to the cache while it runs, so no new gap can open
+    // behind it. Condemning again would purge the whole keyspace once per block
+    // and, worse, would bump the generation and supersede that rebuild, leaving
+    // nothing to stamp the cache back into service.
+    if !redis_db.try_begin_rebuild() {
+        return Ok(CacheStatus::Rebuilding);
     }
 
     warn!(
@@ -171,8 +212,14 @@ pub(crate) async fn ensure_cache_continuity(redis_db: &RedisAccountsDB, slot: u6
     // Recorded before the stamp is cleared so a rebuild started for this
     // condemnation cannot be handed a generation that already looks stale.
     redis_db.record_condemnation();
-    clear_deployment_id(redis_db).await?;
-    Ok(true)
+    if let Err(e) = clear_deployment_id(redis_db).await {
+        // The caller only rebuilds on `Condemned`, so returning an error here
+        // would leave the claim held by a condemnation that never produced a
+        // rebuild, and nothing would ever purge the cache.
+        redis_db.finish_rebuild();
+        return Err(e);
+    }
+    Ok(CacheStatus::Condemned)
 }
 
 /// Empties a condemned cache and then stamps it, which puts it back into service.
@@ -187,17 +234,28 @@ pub(crate) async fn ensure_cache_continuity(redis_db: &RedisAccountsDB, slot: u6
 /// that only that later purge removes. So a superseded rebuild finishes its purge,
 /// which is never wasted work, and leaves the stamping to its successor.
 pub(crate) async fn rebuild_cache(redis_db: &RedisAccountsDB, generation: u64) -> Result<()> {
-    let deployment_id = read_deployment_id(&redis_db.fallback).await?;
-    purge_ledger_keys(redis_db).await?;
+    let outcome = async {
+        let deployment_id = read_deployment_id(&redis_db.fallback).await?;
+        purge_ledger_keys(redis_db).await?;
 
-    if redis_db.condemnation_generation() != generation {
-        info!("Redis cache was condemned again while rebuilding; a later rebuild will finish it");
-        return Ok(());
+        if redis_db.condemnation_generation() != generation {
+            info!(
+                "Redis cache was condemned again while rebuilding; a later rebuild will finish it"
+            );
+            return Ok(());
+        }
+
+        stamp_deployment_id(redis_db, &deployment_id).await?;
+        info!("Redis cache rebuilt and back in service");
+        Ok(())
     }
+    .await;
 
-    stamp_deployment_id(redis_db, &deployment_id).await?;
-    info!("Redis cache rebuilt and back in service");
-    Ok(())
+    // Released however the rebuild ended. A failed one that kept the claim would
+    // leave the cache unmirrored and unable to condemn again, so nothing would
+    // ever retry the purge and it would stay out of service until a restart.
+    redis_db.finish_rebuild();
+    outcome
 }
 
 /// Removes every cached ledger key, leaving the cache empty rather than wrong.
@@ -257,26 +315,30 @@ pub(crate) async fn purge_ledger_keys(redis_db: &RedisAccountsDB) -> Result<()> 
     Ok(())
 }
 
-/// Marks the cache as belonging to this deployment. Written only after the cache
-/// is known to be coherent, and cleared before a purge, so an interrupted purge
-/// leaves the cache unstamped rather than falsely stamped.
+/// Leases the cache to this deployment for [`CACHE_LEASE_TTL`]. Written only
+/// after the cache is known to be coherent, and cleared before a purge, so an
+/// interrupted purge leaves the cache unstamped rather than falsely stamped.
+///
+/// Also the renewal: the settler re-stamps after every mirrored batch, which is
+/// what ties trust to maintenance. Nothing else extends the lease, so a cache
+/// nobody is mirroring to falls out of service on its own.
 pub(crate) async fn stamp_deployment_id(
     redis_db: &RedisAccountsDB,
     deployment_id: &[u8],
 ) -> Result<()> {
     let mut conn = redis_db.connection.clone();
-    conn.set::<_, _, ()>(DEPLOYMENT_ID_KEY, deployment_id)
+    conn.set_ex::<_, _, ()>(DEPLOYMENT_ID_KEY, deployment_id, CACHE_LEASE_TTL.as_secs())
         .await
         .context("Failed to write deployment id to Redis")
 }
 
 /// Whether a read node should start against this cache.
 ///
-/// The write node aligns and stamps the cache; a read node has no business
-/// purging anything, so it only decides whether what it finds is usable. Usable
-/// means either the stamp for this deployment, or no ledger state at all, which
-/// cannot answer anything wrongly. Anything else is another ledger's data or the
-/// residue of an interrupted rebuild, and the two are indistinguishable here.
+/// Only a cache naming another deployment is refused, because that is a
+/// misconfiguration no amount of waiting fixes: the node has been pointed at the
+/// wrong Redis. An unstamped cache is fine to start against, stamped or not,
+/// since nothing is served from one and the lease lapsing is the ordinary state
+/// during a writer outage.
 ///
 /// A startup gate only. Individual reads check the stamp again for themselves, so
 /// this is about refusing to start against a misconfigured cache rather than
@@ -297,11 +359,15 @@ pub(crate) async fn verify_cache_stamp(redis_db: &RedisAccountsDB) -> Result<()>
             hex::encode(&cached_id),
             hex::encode(&deployment_id)
         )),
-        None if holds_ledger_keys(redis_db).await? => Err(anyhow!(
-            "Redis cache holds ledger keys but names no deployment; it has not been \
-             aligned with Postgres"
-        )),
-        None => Ok(()),
+        None => {
+            // Worth saying out loud: pointed at an idle deployment's Redis, this
+            // is the only symptom, since nothing there renews a lease to compare
+            // against.
+            if holds_ledger_keys(redis_db).await? {
+                warn!("Redis cache holds ledger keys but no live lease; serving from Postgres until a write node stamps it");
+            }
+            Ok(())
+        }
     }
 }
 
@@ -402,11 +468,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            !ensure_cache_continuity(&redis_db, cached_tip + 1)
+        assert_eq!(
+            ensure_cache_continuity(&redis_db, cached_tip + 1)
                 .await
                 .unwrap(),
-            "a contiguous batch needs no rebuild"
+            CacheStatus::InService,
+            "a contiguous batch leaves the cache in service"
         );
 
         let still_cached: bool = conn
@@ -442,9 +509,10 @@ mod tests {
             .unwrap();
 
         // Redis is back after missing slots 101..=200.
-        assert!(
+        assert_eq!(
             ensure_cache_continuity(&redis_db, 201).await.unwrap(),
-            "a missed batch must call for a rebuild"
+            CacheStatus::Condemned,
+            "a missed batch must condemn the cache"
         );
 
         let stamped: Option<Vec<u8>> = conn.get(DEPLOYMENT_ID_KEY).await.unwrap();
@@ -462,6 +530,42 @@ mod tests {
         );
     }
 
+    /// A condemned cache is not mirrored to, so its tip stays frozen and every
+    /// later batch sees the same discontinuity. Condemning again would spawn a
+    /// full-keyspace purge per block, and worse, would bump the generation and
+    /// supersede the rebuild already running, leaving nothing to stamp the cache
+    /// back into service.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_cache_already_rebuilding_is_not_condemned_again() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+        let deployment_id = read_deployment_id(&postgres_db).await.unwrap();
+        stamp_deployment_id(&redis_db, &deployment_id)
+            .await
+            .unwrap();
+
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("latest_slot", 100u64).await.unwrap();
+
+        assert_eq!(
+            ensure_cache_continuity(&redis_db, 201).await.unwrap(),
+            CacheStatus::Condemned
+        );
+        let generation = redis_db.condemnation_generation();
+
+        // The tip is still 100, because a condemned cache is not mirrored to, so
+        // this batch looks exactly like the one that condemned it.
+        assert_eq!(
+            ensure_cache_continuity(&redis_db, 202).await.unwrap(),
+            CacheStatus::Rebuilding,
+            "a rebuild already in flight covers this"
+        );
+        assert_eq!(
+            redis_db.condemnation_generation(),
+            generation,
+            "re-condemning would supersede the rebuild in flight"
+        );
+    }
+
     /// An empty or freshly purged cache has no tip to be contiguous with, and
     /// nothing to lose either way.
     #[tokio::test(flavor = "multi_thread")]
@@ -472,9 +576,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            !ensure_cache_continuity(&redis_db, 42).await.unwrap(),
-            "a cache with no tip needs no rebuild"
+        assert_eq!(
+            ensure_cache_continuity(&redis_db, 42).await.unwrap(),
+            CacheStatus::InService,
+            "a cache with no tip has nothing to be discontiguous with"
         );
 
         let stamped: Option<Vec<u8>> = conn_get_stamp(&redis_db).await;
@@ -543,7 +648,10 @@ mod tests {
         // Two gaps in a row: this rebuild carries the first generation while a
         // second condemnation has already happened.
         let superseded = redis_db.condemnation_generation();
-        assert!(ensure_cache_continuity(&redis_db, 200).await.unwrap());
+        assert_eq!(
+            ensure_cache_continuity(&redis_db, 200).await.unwrap(),
+            CacheStatus::Condemned
+        );
         let current = redis_db.condemnation_generation();
         assert_ne!(
             superseded, current,
@@ -565,6 +673,30 @@ mod tests {
         assert!(
             stamped.is_some(),
             "the newest rebuild must put the cache back in service"
+        );
+    }
+
+    /// Trust must decay on its own rather than wait to be revoked. A writer that
+    /// has lost Redis cannot announce it through the connection it just lost, so
+    /// the lease is what makes "nobody is maintaining this cache" and "stop
+    /// serving it" the same event.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stamping_leases_the_cache_rather_than_trusting_it_forever() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+        let deployment_id = read_deployment_id(&postgres_db).await.unwrap();
+
+        stamp_deployment_id(&redis_db, &deployment_id)
+            .await
+            .unwrap();
+
+        // TTL is -1 for a key with no expiry and -2 for one that is absent, so
+        // this fails on a plain SET. The upper bound catches a seconds/millis
+        // mixup, which would grant hours and still read as positive.
+        let mut conn = redis_db.connection.clone();
+        let ttl: i64 = conn.ttl(DEPLOYMENT_ID_KEY).await.unwrap();
+        assert!(
+            ttl > 0 && ttl <= CACHE_LEASE_TTL.as_secs() as i64,
+            "the stamp must carry a lease, got TTL {ttl}"
         );
     }
 
@@ -609,10 +741,14 @@ mod tests {
             .expect("an empty cache must be accepted");
     }
 
-    /// Ledger state with no stamp is what a failed or interrupted purge leaves
-    /// behind. It cannot be told apart from another ledger's data.
+    /// Ledger keys with no stamp is what a lapsed lease leaves behind, which is
+    /// the ordinary "no writer has mirrored lately" state rather than evidence
+    /// of anything wrong. A read node must still start, because it serves
+    /// nothing from an unstamped cache: every read resolves against Postgres, so
+    /// the answers are correct and only slower. Refusing to boot here would take
+    /// reads down for the length of a writer outage.
     #[tokio::test(flavor = "multi_thread")]
-    async fn verify_cache_stamp_rejects_unstamped_ledger_state() {
+    async fn verify_cache_stamp_accepts_unstamped_ledger_state() {
         let (redis_db, _postgres_db, _pg, _redis) = start_cache().await;
         let mut conn = redis_db.connection.clone();
         let _: () = conn
@@ -620,12 +756,8 @@ mod tests {
             .await
             .unwrap();
 
-        let error = verify_cache_stamp(&redis_db)
+        verify_cache_stamp(&redis_db)
             .await
-            .expect_err("unstamped ledger state must be rejected");
-        assert!(
-            format!("{error}").contains("deployment"),
-            "error should name the missing stamp, got: {error}"
-        );
+            .expect("a lapsed lease must not stop a read node from starting");
     }
 }

--- a/core/src/accounts/redis_coherence.rs
+++ b/core/src/accounts/redis_coherence.rs
@@ -1,0 +1,631 @@
+//! Decides when the Redis cache may be served from, and rebuilds it when not.
+//!
+//! Redis outlives the process that fills it. Point a write node at a fresh,
+//! restored or simply different Postgres database while reusing the same Redis
+//! instance and every key from the previous ledger is still there, indexed the
+//! same way, indistinguishable from current state. A cache can also fall behind
+//! the ledger it belongs to: mirroring is best-effort, so an outage leaves its
+//! keys holding values Postgres has already moved past.
+//!
+//! Both are handled by one mechanism. Each Postgres database is stamped with an
+//! identifier at creation and the cache carries a copy, which every cached read
+//! checks against the identifier the handle was built with. Clearing that stamp
+//! therefore takes the cache out of service on the next read, with no window and
+//! nothing to notify:
+//!
+//! - [`staleness_reason`] compares a cache against Postgres at startup, where a
+//!   mismatch means another ledger's data or a tip that does not line up.
+//! - [`ensure_cache_continuity`] watches for missed batches between blocks, where
+//!   the cached tip failing to advance by one slot is the evidence.
+//! - [`rebuild_cache`] empties a cache and stamps it, putting it back in service.
+
+use {
+    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB},
+    anyhow::{anyhow, Context, Result},
+    redis::AsyncCommands,
+    tracing::{info, warn},
+};
+
+/// Names the deployment the data belongs to. Lives in the Postgres `metadata`
+/// table and is mirrored to the same key in Redis once the cache is aligned. Its
+/// absence from Redis means the cache has never been checked against a source of
+/// truth.
+pub(crate) const DEPLOYMENT_ID_KEY: &str = "deployment_id";
+
+/// Cached ledger state, keyed by pubkey, signature, slot or address. `addr_sigs:`
+/// is no longer written, but a cache filled by an older build still holds it and
+/// a purge has to clear it.
+const LEDGER_KEY_PREFIXES: [&str; 4] = ["account:", "tx:", "block:", "addr_sigs:"];
+
+/// Cached ledger state under fixed keys: the chain tip, plus the slot index,
+/// transaction counter and performance-sample list that older builds wrote.
+const LEDGER_FIXED_KEYS: [&str; 5] = [
+    "block_slot_index",
+    "transaction_count",
+    "performance_samples",
+    "latest_slot",
+    "latest_blockhash",
+];
+
+/// Keys per SCAN round. Bounds how long one round blocks the Redis event loop.
+const SCAN_COUNT: usize = 512;
+
+/// Reads the identifier Postgres was stamped with at schema creation.
+pub(crate) async fn read_deployment_id(db: &PostgresAccountsDB) -> Result<Vec<u8>> {
+    sqlx::query_scalar::<_, Vec<u8>>("SELECT value FROM metadata WHERE key = $1")
+        .bind(DEPLOYMENT_ID_KEY)
+        .fetch_optional(db.pool.as_ref())
+        .await
+        .context("Failed to read deployment id from Postgres")?
+        .ok_or_else(|| anyhow!("Postgres has no deployment id; schema initialization did not run"))
+}
+
+/// Why the cache cannot be trusted, or `None` when it is coherent with
+/// Postgres.
+pub(crate) async fn staleness_reason(
+    redis_db: &RedisAccountsDB,
+    deployment_id: &[u8],
+    postgres_slot: Option<u64>,
+) -> Result<Option<String>> {
+    let mut conn = redis_db.connection.clone();
+
+    let cached_id: Option<Vec<u8>> = conn
+        .get(DEPLOYMENT_ID_KEY)
+        .await
+        .context("Failed to read deployment id from Redis")?;
+
+    // An empty cache cannot serve anything wrongly, so there is nothing to purge
+    // and nothing to check. This is the normal first attach.
+    if !holds_ledger_keys(redis_db).await? {
+        return Ok(None);
+    }
+
+    let Some(cached_id) = cached_id else {
+        // Ledger state filled in by something that never checked itself against
+        // a source of truth.
+        return Ok(Some(
+            "cache holds ledger keys but names no deployment".to_string(),
+        ));
+    };
+    if cached_id.as_slice() != deployment_id {
+        return Ok(Some(format!(
+            "cache belongs to deployment {} but Postgres is {}",
+            hex::encode(&cached_id),
+            hex::encode(deployment_id)
+        )));
+    }
+
+    // Postgres with no blocks cannot back any cached ledger state, whatever the
+    // tips say. Checked separately because two absent tips compare equal below,
+    // so a cache that lost only its tip key would otherwise survive a Postgres
+    // that was truncated or replaced.
+    if postgres_slot.is_none() {
+        return Ok(Some(
+            "Postgres holds no blocks but the cache holds ledger keys".to_string(),
+        ));
+    }
+
+    // The tips must match exactly, not merely not-run-ahead.
+    //
+    // A cache behind Postgres is not a cache with missing entries: its keys are
+    // present, holding the values they had at the cached tip. Reads hit them and
+    // never reach the fallback, so a stale balance is served as current. The
+    // settler commits to Postgres before mirroring to Redis, so a kill between
+    // the two, or a Redis outage, leaves exactly that state.
+    //
+    // Equality holds after a clean shutdown, so this costs nothing in the normal
+    // case and a cold cache otherwise. Cold is slow; behind is wrong.
+    let cached_slot: Option<u64> = conn
+        .get("latest_slot")
+        .await
+        .context("Failed to read cached tip from Redis")?;
+    if cached_slot != postgres_slot {
+        return Ok(Some(format!(
+            "cached tip {:?} does not match the Postgres tip {:?}",
+            cached_slot, postgres_slot
+        )));
+    }
+
+    Ok(None)
+}
+
+/// Detects that the cache has missed settled batches, and takes it out of
+/// service when it has.
+///
+/// Call before mirroring the batch for `slot`. The tip is written by the same
+/// best-effort pipeline as the data, so when that pipeline fails the tip stops
+/// advancing along with everything else, and the accounts that batch touched are
+/// left holding their pre-batch values. A cached tip that is not exactly one slot
+/// back is therefore evidence that batches were missed and that every key in the
+/// cache is suspect.
+///
+/// The response is to clear the deployment stamp, which takes the cache out of
+/// service on the next read. Returns whether a rebuild is needed; the caller runs
+/// one off the block-production path, because a SCAN over a large keyspace costs
+/// far more than a blocktime allows.
+///
+/// Mirroring continues while the rebuild runs. Nothing is served from an
+/// unstamped cache, and `SCAN` returns every key present for the whole pass, so
+/// the rebuild clears the stale ones regardless of what is written alongside it.
+/// Keys written during the pass may be swept too, which only costs a miss.
+pub(crate) async fn ensure_cache_continuity(redis_db: &RedisAccountsDB, slot: u64) -> Result<bool> {
+    let mut conn = redis_db.connection.clone();
+    let cached_slot: Option<u64> = conn
+        .get("latest_slot")
+        .await
+        .context("Failed to read cached tip from Redis")?;
+
+    // No tip: an empty or freshly purged cache, with nothing to be contiguous
+    // with and nothing to lose.
+    let Some(cached_slot) = cached_slot else {
+        return Ok(false);
+    };
+    if cached_slot + 1 == slot {
+        return Ok(false);
+    }
+
+    warn!(
+        "Redis cache missed at least one batch (cached tip {}, now settling {}), rebuilding it",
+        cached_slot, slot
+    );
+    // Recorded before the stamp is cleared so a rebuild started for this
+    // condemnation cannot be handed a generation that already looks stale.
+    redis_db.record_condemnation();
+    clear_deployment_id(redis_db).await?;
+    Ok(true)
+}
+
+/// Empties a condemned cache and then stamps it, which puts it back into service.
+///
+/// The order is load-bearing: stamping first would return stale keys to service
+/// for as long as the purge took. Runs off the block-production path, so the
+/// purge is free to walk the whole keyspace.
+///
+/// `generation` is the condemnation count this rebuild was started for. A cache
+/// condemned again while this one was purging has a newer rebuild behind it whose
+/// purge covers the newer gap, and stamping here would put keys back in service
+/// that only that later purge removes. So a superseded rebuild finishes its purge,
+/// which is never wasted work, and leaves the stamping to its successor.
+pub(crate) async fn rebuild_cache(redis_db: &RedisAccountsDB, generation: u64) -> Result<()> {
+    let deployment_id = read_deployment_id(&redis_db.fallback).await?;
+    purge_ledger_keys(redis_db).await?;
+
+    if redis_db.condemnation_generation() != generation {
+        info!("Redis cache was condemned again while rebuilding; a later rebuild will finish it");
+        return Ok(());
+    }
+
+    stamp_deployment_id(redis_db, &deployment_id).await?;
+    info!("Redis cache rebuilt and back in service");
+    Ok(())
+}
+
+/// Removes every cached ledger key, leaving the cache empty rather than wrong.
+/// Reads then miss and resolve against Postgres.
+pub(crate) async fn purge_ledger_keys(redis_db: &RedisAccountsDB) -> Result<()> {
+    let mut conn = redis_db.connection.clone();
+    let mut purged = 0usize;
+
+    for prefix in LEDGER_KEY_PREFIXES {
+        let pattern = format!("{}*", prefix);
+        let mut cursor = 0u64;
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(SCAN_COUNT)
+                .query_async(&mut conn)
+                .await
+                .with_context(|| format!("Failed to scan {} keys in Redis", pattern))?;
+
+            if !keys.is_empty() {
+                purged += keys.len();
+                // UNLINK reclaims memory on a background thread, so purging a
+                // large keyspace does not stall the Redis event loop.
+                let mut unlink = redis::cmd("UNLINK");
+                for key in &keys {
+                    unlink.arg(key);
+                }
+                let _: () = unlink
+                    .query_async(&mut conn)
+                    .await
+                    .with_context(|| format!("Failed to unlink {} keys in Redis", pattern))?;
+            }
+
+            cursor = next_cursor;
+            if cursor == 0 {
+                break;
+            }
+        }
+    }
+
+    let mut unlink = redis::cmd("UNLINK");
+    for key in LEDGER_FIXED_KEYS {
+        unlink.arg(key);
+    }
+    let _: () = unlink
+        .query_async(&mut conn)
+        .await
+        .context("Failed to unlink cached ledger metadata in Redis")?;
+
+    info!(
+        "Purged {} cached ledger keys",
+        purged + LEDGER_FIXED_KEYS.len()
+    );
+    Ok(())
+}
+
+/// Marks the cache as belonging to this deployment. Written only after the cache
+/// is known to be coherent, and cleared before a purge, so an interrupted purge
+/// leaves the cache unstamped rather than falsely stamped.
+pub(crate) async fn stamp_deployment_id(
+    redis_db: &RedisAccountsDB,
+    deployment_id: &[u8],
+) -> Result<()> {
+    let mut conn = redis_db.connection.clone();
+    conn.set::<_, _, ()>(DEPLOYMENT_ID_KEY, deployment_id)
+        .await
+        .context("Failed to write deployment id to Redis")
+}
+
+/// Whether a read node should start against this cache.
+///
+/// The write node aligns and stamps the cache; a read node has no business
+/// purging anything, so it only decides whether what it finds is usable. Usable
+/// means either the stamp for this deployment, or no ledger state at all, which
+/// cannot answer anything wrongly. Anything else is another ledger's data or the
+/// residue of an interrupted rebuild, and the two are indistinguishable here.
+///
+/// A startup gate only. Individual reads check the stamp again for themselves, so
+/// this is about refusing to start against a misconfigured cache rather than
+/// about keeping stale values out of responses.
+pub(crate) async fn verify_cache_stamp(redis_db: &RedisAccountsDB) -> Result<()> {
+    let deployment_id = read_deployment_id(&redis_db.fallback).await?;
+
+    let mut conn = redis_db.connection.clone();
+    let cached_id: Option<Vec<u8>> = conn
+        .get(DEPLOYMENT_ID_KEY)
+        .await
+        .context("Failed to read deployment id from Redis")?;
+
+    match cached_id {
+        Some(cached_id) if cached_id.as_slice() == deployment_id => Ok(()),
+        Some(cached_id) => Err(anyhow!(
+            "Redis cache belongs to deployment {} but Postgres is {}",
+            hex::encode(&cached_id),
+            hex::encode(&deployment_id)
+        )),
+        None if holds_ledger_keys(redis_db).await? => Err(anyhow!(
+            "Redis cache holds ledger keys but names no deployment; it has not been \
+             aligned with Postgres"
+        )),
+        None => Ok(()),
+    }
+}
+
+pub(crate) async fn clear_deployment_id(redis_db: &RedisAccountsDB) -> Result<()> {
+    let mut conn = redis_db.connection.clone();
+    conn.del::<_, ()>(DEPLOYMENT_ID_KEY)
+        .await
+        .context("Failed to clear deployment id in Redis")
+}
+
+/// Whether the cache holds any ledger state at all.
+async fn holds_ledger_keys(redis_db: &RedisAccountsDB) -> Result<bool> {
+    let mut conn = redis_db.connection.clone();
+
+    for key in LEDGER_FIXED_KEYS {
+        let exists: bool = conn
+            .exists(key)
+            .await
+            .with_context(|| format!("Failed to check {} in Redis", key))?;
+        if exists {
+            return Ok(true);
+        }
+    }
+
+    for prefix in LEDGER_KEY_PREFIXES {
+        let pattern = format!("{}*", prefix);
+        let mut cursor = 0u64;
+        // A single SCAN round may return nothing while keys still exist, so walk
+        // until the cursor wraps. Exits on the first hit, and an empty keyspace
+        // wraps immediately.
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(SCAN_COUNT)
+                .query_async(&mut conn)
+                .await
+                .with_context(|| format!("Failed to scan {} keys in Redis", pattern))?;
+
+            if !keys.is_empty() {
+                return Ok(true);
+            }
+
+            cursor = next_cursor;
+            if cursor == 0 {
+                break;
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        accounts::traits::AccountsDB,
+        test_helpers::{start_test_postgres, start_test_redis},
+    };
+    use solana_sdk::pubkey::Pubkey;
+
+    /// Returns a cache handle plus its Postgres source of truth, both throwaway.
+    /// The containers are returned so the caller keeps them alive.
+    async fn start_cache() -> (
+        RedisAccountsDB,
+        PostgresAccountsDB,
+        testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+        testcontainers::ContainerAsync<testcontainers_modules::redis::Redis>,
+    ) {
+        let (pg_db, pg_container) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, redis_container) = start_test_redis(postgres_db.clone()).await;
+        (redis_db, postgres_db, pg_container, redis_container)
+    }
+
+    /// The normal case: each batch follows the one the cache last recorded, so
+    /// nothing was missed and the cache keeps everything it holds.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn continuity_keeps_a_cache_whose_tip_is_one_slot_back() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+        let deployment_id = read_deployment_id(&postgres_db).await.unwrap();
+        stamp_deployment_id(&redis_db, &deployment_id)
+            .await
+            .unwrap();
+
+        let cached_pubkey = Pubkey::new_unique();
+        let cached_tip = 100u64;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("latest_slot", cached_tip).await.unwrap();
+        let _: () = conn
+            .set(format!("account:{}", cached_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+
+        assert!(
+            !ensure_cache_continuity(&redis_db, cached_tip + 1)
+                .await
+                .unwrap(),
+            "a contiguous batch needs no rebuild"
+        );
+
+        let still_cached: bool = conn
+            .exists(format!("account:{}", cached_pubkey))
+            .await
+            .unwrap();
+        assert!(still_cached, "a contiguous batch must not purge the cache");
+    }
+
+    /// The outage case: writes failed for a stretch, so the cached tip stopped
+    /// advancing while Postgres kept going. Every key in the cache may now be
+    /// stale, and the gap must be caught here: once the tip advances past it,
+    /// the startup check can no longer tell.
+    ///
+    /// The response is to condemn, not to repair: clearing the stamp is one
+    /// command, while purging is thousands of round-trips and this runs on the
+    /// block-production path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn continuity_condemns_a_cache_that_missed_batches() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+        let deployment_id = read_deployment_id(&postgres_db).await.unwrap();
+        stamp_deployment_id(&redis_db, &deployment_id)
+            .await
+            .unwrap();
+
+        let stale_pubkey = Pubkey::new_unique();
+        let cached_tip = 100u64;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("latest_slot", cached_tip).await.unwrap();
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+
+        // Redis is back after missing slots 101..=200.
+        assert!(
+            ensure_cache_continuity(&redis_db, 201).await.unwrap(),
+            "a missed batch must call for a rebuild"
+        );
+
+        let stamped: Option<Vec<u8>> = conn.get(DEPLOYMENT_ID_KEY).await.unwrap();
+        assert_eq!(
+            stamped, None,
+            "the stamp must be cleared so read nodes stop trusting the cache"
+        );
+        let still_cached: bool = conn
+            .exists(format!("account:{}", stale_pubkey))
+            .await
+            .unwrap();
+        assert!(
+            still_cached,
+            "purging is left to the next startup, off the block-production path"
+        );
+    }
+
+    /// An empty or freshly purged cache has no tip to be contiguous with, and
+    /// nothing to lose either way.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn continuity_accepts_a_cache_with_no_tip() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+        let deployment_id = read_deployment_id(&postgres_db).await.unwrap();
+        stamp_deployment_id(&redis_db, &deployment_id)
+            .await
+            .unwrap();
+
+        assert!(
+            !ensure_cache_continuity(&redis_db, 42).await.unwrap(),
+            "a cache with no tip needs no rebuild"
+        );
+
+        let stamped: Option<Vec<u8>> = conn_get_stamp(&redis_db).await;
+        assert_eq!(stamped, Some(deployment_id), "the stamp must be untouched");
+    }
+
+    async fn conn_get_stamp(redis_db: &RedisAccountsDB) -> Option<Vec<u8>> {
+        let mut conn = redis_db.connection.clone();
+        conn.get(DEPLOYMENT_ID_KEY).await.unwrap()
+    }
+
+    /// Rebuilding empties the cache and only then stamps it. The order is the
+    /// point: a stamp written over a half-purged cache would put stale keys back
+    /// into service.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rebuild_empties_the_cache_then_stamps_it() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+
+        let stale_pubkey = Pubkey::new_unique();
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", 100u64).await.unwrap();
+
+        // Nothing has condemned the cache since, so this rebuild is the current
+        // one and may stamp.
+        rebuild_cache(&redis_db, redis_db.condemnation_generation())
+            .await
+            .unwrap();
+
+        let stale_survived: bool = conn
+            .exists(format!("account:{}", stale_pubkey))
+            .await
+            .unwrap();
+        assert!(!stale_survived, "the rebuild must empty the cache");
+        let tip: Option<u64> = conn.get("latest_slot").await.unwrap();
+        assert_eq!(tip, None, "the rebuild must clear the cached tip too");
+        let stamped: Option<Vec<u8>> = conn.get(DEPLOYMENT_ID_KEY).await.unwrap();
+        assert_eq!(
+            stamped,
+            Some(read_deployment_id(&postgres_db).await.unwrap()),
+            "a rebuilt cache must be stamped so reads can use it again"
+        );
+    }
+
+    /// A rebuild that has been overtaken by a later condemnation must not stamp.
+    ///
+    /// With a flapping Redis two rebuilds can overlap, and the earlier one's purge
+    /// predates the second gap: stamping on its completion would return keys
+    /// written before that gap to service. Only the newest rebuild may stamp, and
+    /// the ones it superseded finish quietly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_superseded_rebuild_does_not_put_the_cache_back_in_service() {
+        let (redis_db, _postgres_db, _pg, _redis) = start_cache().await;
+
+        let stale_pubkey = Pubkey::new_unique();
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", 100u64).await.unwrap();
+
+        // Two gaps in a row: this rebuild carries the first generation while a
+        // second condemnation has already happened.
+        let superseded = redis_db.condemnation_generation();
+        assert!(ensure_cache_continuity(&redis_db, 200).await.unwrap());
+        let current = redis_db.condemnation_generation();
+        assert_ne!(
+            superseded, current,
+            "each condemnation must advance the generation"
+        );
+
+        rebuild_cache(&redis_db, superseded).await.unwrap();
+
+        let stamped: Option<Vec<u8>> = conn.get(DEPLOYMENT_ID_KEY).await.unwrap();
+        assert_eq!(
+            stamped, None,
+            "a superseded rebuild must leave the cache out of service"
+        );
+
+        // The rebuild that carries the current generation is the one that may
+        // finish the job.
+        rebuild_cache(&redis_db, current).await.unwrap();
+        let stamped: Option<Vec<u8>> = conn.get(DEPLOYMENT_ID_KEY).await.unwrap();
+        assert!(
+            stamped.is_some(),
+            "the newest rebuild must put the cache back in service"
+        );
+    }
+
+    /// A cache stamped for this deployment is the one a read node may serve.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_cache_stamp_accepts_a_matching_stamp() {
+        let (redis_db, postgres_db, _pg, _redis) = start_cache().await;
+        let deployment_id = read_deployment_id(&postgres_db).await.unwrap();
+        stamp_deployment_id(&redis_db, &deployment_id)
+            .await
+            .unwrap();
+
+        verify_cache_stamp(&redis_db)
+            .await
+            .expect("a cache stamped for this deployment must be accepted");
+    }
+
+    /// Another ledger's cache must never be served, which is the whole point of
+    /// the stamp.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_cache_stamp_rejects_a_foreign_stamp() {
+        let (redis_db, _postgres_db, _pg, _redis) = start_cache().await;
+        stamp_deployment_id(&redis_db, &[9u8; 16]).await.unwrap();
+
+        let error = verify_cache_stamp(&redis_db)
+            .await
+            .expect_err("a cache naming another deployment must be rejected");
+        assert!(
+            format!("{error}").contains("deployment"),
+            "error should name the mismatch, got: {error}"
+        );
+    }
+
+    /// An empty cache holds nothing to serve wrongly, so a read node may attach
+    /// to it before any write node has stamped it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_cache_stamp_accepts_an_empty_unstamped_cache() {
+        let (redis_db, _postgres_db, _pg, _redis) = start_cache().await;
+
+        verify_cache_stamp(&redis_db)
+            .await
+            .expect("an empty cache must be accepted");
+    }
+
+    /// Ledger state with no stamp is what a failed or interrupted purge leaves
+    /// behind. It cannot be told apart from another ledger's data.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_cache_stamp_rejects_unstamped_ledger_state() {
+        let (redis_db, _postgres_db, _pg, _redis) = start_cache().await;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn
+            .set(format!("account:{}", Pubkey::new_unique()), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+
+        let error = verify_cache_stamp(&redis_db)
+            .await
+            .expect_err("unstamped ledger state must be rejected");
+        assert!(
+            format!("{error}").contains("deployment"),
+            "error should name the missing stamp, got: {error}"
+        );
+    }
+}

--- a/core/src/accounts/store_performance_sample.rs
+++ b/core/src/accounts/store_performance_sample.rs
@@ -1,7 +1,6 @@
 use {
-    super::{postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::AccountsDB},
+    super::{postgres::PostgresAccountsDB, traits::AccountsDB},
     anyhow::{Context, Result},
-    redis::AsyncCommands,
     solana_rpc_client_types::response::RpcPerfSample,
 };
 
@@ -10,7 +9,13 @@ pub async fn store_performance_sample(db: &mut AccountsDB, sample: RpcPerfSample
         AccountsDB::Postgres(postgres_db) => {
             store_performance_sample_postgres(postgres_db, sample).await
         }
-        AccountsDB::Redis(redis_db) => store_performance_sample_redis(redis_db, sample).await,
+        // Written to the source of truth, not the cache: the read path serves
+        // samples from Postgres, because a trimmed list cannot express a cache
+        // miss, so caching them would only produce keys nothing reads.
+        AccountsDB::Redis(redis_db) => {
+            let mut postgres_db = redis_db.fallback.clone();
+            store_performance_sample_postgres(&mut postgres_db, sample).await
+        }
     }
 }
 
@@ -34,30 +39,6 @@ async fn store_performance_sample_postgres(
     .execute(pool.as_ref())
     .await
     .context("Failed to store performance sample")?;
-
-    Ok(())
-}
-
-async fn store_performance_sample_redis(
-    db: &mut RedisAccountsDB,
-    sample: RpcPerfSample,
-) -> Result<()> {
-    let mut conn = db.connection.clone();
-
-    // Serialize the performance sample as JSON
-    let sample_json =
-        serde_json::to_string(&sample).context("Failed to serialize performance sample")?;
-
-    // Store in a Redis list with a limited size (max 720 samples)
-    // Use LPUSH to add to the front and LTRIM to keep only the most recent samples
-    conn.lpush::<_, _, ()>("performance_samples", sample_json)
-        .await
-        .context("Failed to push performance sample to Redis")?;
-
-    // Keep only the most recent 720 samples
-    conn.ltrim::<_, ()>("performance_samples", 0, 719)
-        .await
-        .context("Failed to trim performance samples list")?;
 
     Ok(())
 }

--- a/core/src/accounts/traits.rs
+++ b/core/src/accounts/traits.rs
@@ -397,6 +397,15 @@ mod tests {
             panic!("expected Postgres variant")
         };
         let (redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        // A cache is only read from while it names this deployment. Unstamped,
+        // these reads would skip Redis instead of missing in it, which is not
+        // the path under test.
+        let deployment_id = crate::accounts::redis_coherence::read_deployment_id(postgres_db)
+            .await
+            .unwrap();
+        crate::accounts::redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
         let cache_db = AccountsDB::Redis(redis_raw);
 
         let pubkey = Pubkey::new_unique();
@@ -474,12 +483,23 @@ mod tests {
             panic!("expected Postgres variant")
         };
         let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        // A cache is only read from while it names this deployment, and this
+        // test needs the one cached entry to actually be served.
+        let deployment_id = crate::accounts::redis_coherence::read_deployment_id(postgres_db)
+            .await
+            .unwrap();
+        crate::accounts::redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
 
         let owner = Pubkey::new_unique();
         let first = (Pubkey::new_unique(), 100u64);
         let second = (Pubkey::new_unique(), 200u64);
         let third = (Pubkey::new_unique(), 300u64);
         let absent = Pubkey::new_unique();
+        // The cached balance differs from the row behind it, so the assertion
+        // can tell a cache hit from a fallback read at the same position.
+        let second_cached_lamports = 250u64;
 
         for (pubkey, lamports) in [first, second, third] {
             pg_db
@@ -490,7 +510,10 @@ mod tests {
         // Only the middle account is cached, so the batch is a hit sandwiched
         // between two misses.
         redis_raw
-            .set_account(second.0, AccountSharedData::new(second.1, 0, &owner))
+            .set_account(
+                second.0,
+                AccountSharedData::new(second_cached_lamports, 0, &owner),
+            )
             .await;
         let cache_db = AccountsDB::Redis(redis_raw);
 
@@ -504,7 +527,12 @@ mod tests {
             .collect();
         assert_eq!(
             lamports,
-            vec![Some(first.1), Some(second.1), Some(third.1), None],
+            vec![
+                Some(first.1),
+                Some(second_cached_lamports),
+                Some(third.1),
+                None
+            ],
             "each result must stay on the key it was asked for"
         );
     }

--- a/core/src/accounts/traits.rs
+++ b/core/src/accounts/traits.rs
@@ -31,15 +31,19 @@ pub struct BlockInfo {
     pub transaction_message_hashes: Vec<Hash>,
 }
 
-/// AccountsDB enum supporting multiple backend storage options
+/// How a node reaches stored state.
 ///
 /// # Variants
 ///
-/// * `Postgres` - PostgreSQL database only. Provides ACID transactions and is the
-///   source of truth for all finalized state.
+/// * `Postgres`: the source of truth for all finalized state, with ACID
+///   transactions. Every node has one.
 ///
-/// * `Redis` - Redis cache only. Fast in-memory storage but lacks true transaction
-///   support. Uses MULTI/EXEC which can fail partway through without rollback.
+/// * `Redis`: a cache in front of that same Postgres, which it carries so a key
+///   the cache cannot answer is resolved rather than reported absent. Only the
+///   reads where a miss is detectable are served from it: point lookups by
+///   pubkey, signature and slot, plus the chain tip. Ranges, history and counters
+///   go to Postgres, because a short answer from a partial mirror is
+///   indistinguishable from a complete one.
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum AccountsDB {
@@ -173,10 +177,13 @@ impl AccountsDB {
                     .map_err(|e| anyhow::anyhow!("Failed to create PostgresAccountsDB: {}", e))?,
             ))
         } else if accountsdb_connection_url.starts_with("redis://") {
-            Ok(AccountsDB::Redis(
-                RedisAccountsDB::new(accountsdb_connection_url)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create RedisAccountsDB: {}", e))?,
+            // Redis is a cache, never a source of truth: on its own it cannot
+            // tell a missing key from a deleted one, and nothing verifies its
+            // contents belong to this ledger. A caching node passes a Postgres
+            // URL here and its Redis URL separately.
+            Err(anyhow::anyhow!(
+                "Redis cannot be used as the accounts database; pass the Postgres URL here and \
+                 configure Redis as a cache in front of it"
             ))
         } else {
             Err(anyhow::anyhow!(
@@ -195,7 +202,8 @@ mod tests {
         create_test_block_info, create_test_sanitized_transaction, flush_address_signatures_sync,
         start_test_postgres, start_test_redis,
     };
-    use solana_sdk::account::AccountSharedData;
+    use redis::AsyncCommands;
+    use solana_sdk::account::{AccountSharedData, ReadableAccount};
     use solana_sdk::signature::{Keypair, Signer};
     use solana_svm::account_loader::LoadedTransaction;
     use solana_svm::transaction_execution_result::{
@@ -212,6 +220,20 @@ mod tests {
         assert!(
             msg.contains("Unsupported"),
             "expected unsupported scheme error, got: {msg}"
+        );
+    }
+
+    /// Redis on its own cannot tell a missing key from a deleted one, and
+    /// nothing verifies its contents belong to this ledger, so it is never the
+    /// accounts database. It is configured as a cache in front of Postgres.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn redis_rejected_as_the_accounts_database() {
+        let result = AccountsDB::new("redis://localhost:6379", true).await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.err().unwrap());
+        assert!(
+            msg.contains("Redis cannot be used as the accounts database"),
+            "expected Redis rejection, got: {msg}"
         );
     }
 
@@ -364,23 +386,398 @@ mod tests {
         assert_eq!(slots, vec![1, 3, 7, 10]);
     }
 
+    /// Point lookups resolve a cache miss against Postgres instead of reporting
+    /// the data absent. A key missing from the cache is indistinguishable from a
+    /// deleted one, which is how a cache-backed node could serve a real funded
+    /// account as nonexistent.
     #[tokio::test(flavor = "multi_thread")]
-    async fn get_blocks_redis_returns_slot_numbers_in_order() {
-        let (redis_raw, _redis) = start_test_redis().await;
-        let mut db = AccountsDB::Redis(redis_raw);
+    async fn point_lookups_through_cache_resolve_against_postgres() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        let cache_db = AccountsDB::Redis(redis_raw);
 
-        for slot in [3u64, 7, 1, 10] {
-            db.write_batch(
-                &[],
-                vec![],
-                Some(create_test_block_info(slot, Hash::new_unique())),
+        let pubkey = Pubkey::new_unique();
+        let lamports = 500;
+        let account = AccountSharedData::new(lamports, 0, &Pubkey::new_unique());
+        let keypair = Keypair::new();
+        let tx = create_test_sanitized_transaction(&keypair, &Pubkey::new_unique(), 1);
+        let processed = ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts: vec![],
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
+        }));
+        let slot = 7u64;
+        let blockhash = Hash::new_unique();
+
+        // Written to Postgres only, never to the cache.
+        pg_db
+            .write_batch(
+                &[(
+                    pubkey,
+                    AccountSettlement {
+                        account,
+                        deleted: false,
+                    },
+                )],
+                vec![(*tx.signature(), &tx, slot, 1_700_000_000, &processed)],
+                Some(create_test_block_info(slot, blockhash)),
             )
             .await
             .unwrap();
+
+        assert_eq!(
+            cache_db
+                .get_account_shared_data(&pubkey)
+                .await
+                .map(|account| account.lamports()),
+            Some(lamports),
+            "a cached miss must not read as a nonexistent account"
+        );
+        assert_eq!(
+            cache_db.get_accounts(&[pubkey]).await[0]
+                .as_ref()
+                .map(|account| account.lamports()),
+            Some(lamports)
+        );
+        assert!(cache_db
+            .get_transaction(tx.signature())
+            .await
+            .unwrap()
+            .is_some());
+        assert!(cache_db.get_block(slot).await.unwrap().is_some());
+        assert_eq!(cache_db.get_latest_slot().await.unwrap(), Some(slot));
+        assert_eq!(cache_db.get_latest_blockhash().await.unwrap(), blockhash);
+        assert_eq!(cache_db.get_transaction_count().await.unwrap(), 1);
+    }
+
+    /// A batch read where only some keys are cached must resolve the rest
+    /// against Postgres and keep every result on its original key. Distinct
+    /// balances make a positional mix-up visible: returning the right accounts
+    /// against the wrong keys is the failure this guards.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn partially_cached_batch_read_stays_aligned_with_its_keys() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let owner = Pubkey::new_unique();
+        let first = (Pubkey::new_unique(), 100u64);
+        let second = (Pubkey::new_unique(), 200u64);
+        let third = (Pubkey::new_unique(), 300u64);
+        let absent = Pubkey::new_unique();
+
+        for (pubkey, lamports) in [first, second, third] {
+            pg_db
+                .set_account(pubkey, AccountSharedData::new(lamports, 0, &owner))
+                .await;
         }
 
-        let slots = db.get_blocks(0, Some(20)).await.unwrap();
-        assert_eq!(slots, vec![1, 3, 7, 10]);
+        // Only the middle account is cached, so the batch is a hit sandwiched
+        // between two misses.
+        redis_raw
+            .set_account(second.0, AccountSharedData::new(second.1, 0, &owner))
+            .await;
+        let cache_db = AccountsDB::Redis(redis_raw);
+
+        let results = cache_db
+            .get_accounts(&[first.0, second.0, third.0, absent])
+            .await;
+
+        let lamports: Vec<Option<u64>> = results
+            .iter()
+            .map(|account| account.as_ref().map(|account| account.lamports()))
+            .collect();
+        assert_eq!(
+            lamports,
+            vec![Some(first.1), Some(second.1), Some(third.1), None],
+            "each result must stay on the key it was asked for"
+        );
+    }
+
+    /// The write node condemns a cache it has stopped maintaining by clearing the
+    /// deployment stamp. That only helps if read nodes look again: one that
+    /// checked at startup and never rechecked would keep serving the stale keys
+    /// until someone restarted it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_condemned_cache_stops_being_served() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let settled_lamports = 900;
+        let stale_lamports = 100;
+        pg_db
+            .set_account(pubkey, AccountSharedData::new(settled_lamports, 0, &owner))
+            .await;
+        redis_raw
+            .set_account(pubkey, AccountSharedData::new(stale_lamports, 0, &owner))
+            .await;
+
+        let deployment_id = crate::accounts::redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        crate::accounts::redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
+        let cache_db = AccountsDB::Redis(redis_raw);
+        assert_eq!(
+            cache_db
+                .get_account_shared_data(&pubkey)
+                .await
+                .map(|account| account.lamports()),
+            Some(stale_lamports),
+            "a stamped cache is served, stale value and all"
+        );
+
+        let AccountsDB::Redis(ref redis_db) = cache_db else {
+            panic!("expected Redis variant")
+        };
+        crate::accounts::redis_coherence::clear_deployment_id(redis_db)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cache_db
+                .get_account_shared_data(&pubkey)
+                .await
+                .map(|account| account.lamports()),
+            Some(settled_lamports),
+            "once condemned, reads must bypass the cache and reach Postgres"
+        );
+    }
+
+    /// A cache entry that will not deserialize is a miss, and it stays a miss
+    /// forever unless it is removed: every later read would pay both the Redis
+    /// hop and the Postgres hop. Reading it once must evict it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_corrupt_cache_entry_is_evicted_when_it_is_read() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        // A cache is only read from while it names this deployment, and this test
+        // needs the corrupt entry to actually be read.
+        let deployment_id = crate::accounts::redis_coherence::read_deployment_id(postgres_db)
+            .await
+            .unwrap();
+        crate::accounts::redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
+
+        let pubkey = Pubkey::new_unique();
+        let lamports = 700;
+        pg_db
+            .set_account(
+                pubkey,
+                AccountSharedData::new(lamports, 0, &Pubkey::new_unique()),
+            )
+            .await;
+
+        let key = format!("account:{}", pubkey);
+        let mut conn = redis_raw.connection.clone();
+        let _: () = conn.set(&key, vec![0xffu8; 8]).await.unwrap();
+
+        let cache_db = AccountsDB::Redis(redis_raw);
+        assert_eq!(
+            cache_db
+                .get_account_shared_data(&pubkey)
+                .await
+                .map(|account| account.lamports()),
+            Some(lamports),
+            "a corrupt entry must fall through to Postgres"
+        );
+
+        let still_cached: bool = conn.exists(&key).await.unwrap();
+        assert!(
+            !still_cached,
+            "a corrupt entry must be evicted, not re-read on every request"
+        );
+    }
+
+    /// A cached block or transaction that will not decode must read through to
+    /// Postgres, the same as a missing one.
+    ///
+    /// The stamp tracks the database, not the build, so adding a field to
+    /// BlockInfo or StoredTransaction leaves a correctly stamped cache full of
+    /// entries the new binary cannot read. Failing the request instead of
+    /// falling through would make those slots and signatures error for as long
+    /// as the entries sat there.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_cached_block_or_transaction_that_cannot_be_decoded_falls_through() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        // A cache is only read from while it names this deployment, and these
+        // entries have to actually be read for the fallthrough to be exercised.
+        let deployment_id = crate::accounts::redis_coherence::read_deployment_id(postgres_db)
+            .await
+            .unwrap();
+        crate::accounts::redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
+
+        let keypair = Keypair::new();
+        let tx = create_test_sanitized_transaction(&keypair, &Pubkey::new_unique(), 1);
+        let processed = ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts: vec![],
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
+        }));
+        let slot = 7u64;
+        let blockhash = Hash::new_unique();
+
+        pg_db
+            .write_batch(
+                &[],
+                vec![(*tx.signature(), &tx, slot, 1_700_000_000, &processed)],
+                Some(create_test_block_info(slot, blockhash)),
+            )
+            .await
+            .unwrap();
+
+        // Stand in for entries an older build wrote in a layout this one cannot
+        // read.
+        let mut conn = redis_raw.connection.clone();
+        let _: () = conn
+            .set(format!("block:{}", slot), vec![0xffu8; 8])
+            .await
+            .unwrap();
+        let _: () = conn
+            .set(format!("tx:{}", tx.signature()), vec![0xffu8; 8])
+            .await
+            .unwrap();
+
+        let cache_db = AccountsDB::Redis(redis_raw);
+        assert_eq!(
+            cache_db.get_block(slot).await.unwrap().map(|b| b.blockhash),
+            Some(blockhash),
+            "an undecodable cached block must fall through to Postgres"
+        );
+        assert!(
+            cache_db
+                .get_transaction(tx.signature())
+                .await
+                .unwrap()
+                .is_some(),
+            "an undecodable cached transaction must fall through to Postgres"
+        );
+    }
+
+    /// A failed cache write leaves account keys holding pre-batch balances.
+    /// Invalidating them turns a stale hit into a miss, which then resolves
+    /// against Postgres.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn invalidating_a_failed_batch_write_stops_serving_stale_balances() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let settled_lamports = 900u64;
+        let stale_lamports = 100u64;
+
+        // Postgres committed the batch; the cache still holds the pre-batch
+        // balance, which is what a failed cache write leaves behind.
+        pg_db
+            .set_account(pubkey, AccountSharedData::new(settled_lamports, 0, &owner))
+            .await;
+        redis_raw
+            .set_account(pubkey, AccountSharedData::new(stale_lamports, 0, &owner))
+            .await;
+
+        let settlement = AccountSettlement {
+            account: AccountSharedData::new(settled_lamports, 0, &owner),
+            deleted: false,
+        };
+        crate::accounts::write_batch::invalidate_batch_redis(
+            &mut redis_raw,
+            &[(pubkey, settlement)],
+        )
+        .await;
+
+        let cache_db = AccountsDB::Redis(redis_raw);
+        assert_eq!(
+            cache_db
+                .get_account_shared_data(&pubkey)
+                .await
+                .map(|account| account.lamports()),
+            Some(settled_lamports),
+            "the stale cached balance must no longer be served"
+        );
+    }
+
+    /// Range reads resolve against Postgres even when the cache holds nothing.
+    /// A cached slot index would cover only blocks written since the cache
+    /// attached, and a short range is indistinguishable from a complete one,
+    /// which is how a Redis-backed streamer could silently skip finalized
+    /// blocks.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn range_reads_through_cache_resolve_against_postgres() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        let cache_db = AccountsDB::Redis(redis_raw);
+
+        for slot in [3u64, 7, 1, 10] {
+            pg_db
+                .store_block(create_test_block_info(slot, Hash::new_unique()))
+                .await
+                .unwrap();
+        }
+
+        // Nothing was ever written to Redis, so every read below has to reach
+        // the source of truth rather than report an empty ledger.
+        assert_eq!(
+            cache_db.get_blocks(0, Some(20)).await.unwrap(),
+            vec![1, 3, 7, 10]
+        );
+        assert_eq!(
+            cache_db.get_blocks_with_limit(0, 10).await.unwrap(),
+            vec![1, 3, 7, 10]
+        );
+        assert_eq!(
+            cache_db.get_blocks_with_limit(0, 2).await.unwrap(),
+            vec![1, 3]
+        );
+        assert_eq!(cache_db.get_first_available_block().await.unwrap(), 1);
     }
 
     /// Postgres and Redis must agree exactly here: they are two hand-written
@@ -394,31 +791,6 @@ mod tests {
             db.store_block(create_test_block_info(slot, Hash::new_unique()))
                 .await
                 .unwrap();
-        }
-
-        assert_eq!(
-            db.get_blocks_with_limit(0, 10).await.unwrap(),
-            vec![1, 3, 7, 10]
-        );
-        assert_eq!(db.get_blocks_with_limit(0, 2).await.unwrap(), vec![1, 3]);
-        assert_eq!(db.get_blocks_with_limit(4, 10).await.unwrap(), vec![7, 10]);
-        assert!(db.get_blocks_with_limit(0, 0).await.unwrap().is_empty());
-        assert!(db.get_blocks_with_limit(11, 10).await.unwrap().is_empty());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn get_blocks_with_limit_redis_returns_slots_in_order() {
-        let (redis_raw, _redis) = start_test_redis().await;
-        let mut db = AccountsDB::Redis(redis_raw);
-
-        for slot in [3u64, 7, 1, 10] {
-            db.write_batch(
-                &[],
-                vec![],
-                Some(create_test_block_info(slot, Hash::new_unique())),
-            )
-            .await
-            .unwrap();
         }
 
         assert_eq!(
@@ -853,79 +1225,78 @@ mod tests {
             .contains("'until' is unavailable"));
     }
 
-    /// Verifies that Redis and Postgres return same-slot signatures in identical order.
-    /// Redis stores members as hex-encoded signatures so that sorted-set lex ordering
-    /// matches Postgres's `ORDER BY signature DESC` (raw bytes). This test catches
-    /// any regression where the member encoding no longer preserves byte ordering.
+    /// Address history resolves against Postgres even when the cache holds
+    /// nothing. The cached index only carries signatures written since the cache
+    /// attached, so a truncated history would read as a complete one.
     #[tokio::test(flavor = "multi_thread")]
-    async fn get_signatures_for_address_redis_same_slot_ordering_matches_postgres() {
+    async fn address_history_through_cache_resolves_against_postgres() {
         let (mut pg_db, _pg) = start_test_postgres().await;
-        let (redis_raw, _redis) = start_test_redis().await;
-        let mut redis_db = AccountsDB::Redis(redis_raw);
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("expected Postgres variant")
+        };
+        let (redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+        let cache_db = AccountsDB::Redis(redis_raw);
 
         let to = Pubkey::new_unique();
         let slot = 42u64;
         let block_time = 1_700_000_000;
 
-        let make_processed = || {
-            ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
-                loaded_transaction: LoadedTransaction {
-                    accounts: vec![],
-                    ..Default::default()
-                },
-                execution_details: TransactionExecutionDetails {
-                    status: Ok(()),
-                    log_messages: None,
-                    inner_instructions: None,
-                    return_data: None,
-                    executed_units: 0,
-                    accounts_data_len_delta: 0,
-                },
-                programs_modified_by_tx: HashMap::new(),
-            }))
-        };
-
         let txs: Vec<_> = (0..10)
             .map(|_| {
-                let kp = Keypair::new();
+                let keypair = Keypair::new();
+                let processed = ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+                    loaded_transaction: LoadedTransaction {
+                        accounts: vec![],
+                        ..Default::default()
+                    },
+                    execution_details: TransactionExecutionDetails {
+                        status: Ok(()),
+                        log_messages: None,
+                        inner_instructions: None,
+                        return_data: None,
+                        executed_units: 0,
+                        accounts_data_len_delta: 0,
+                    },
+                    programs_modified_by_tx: HashMap::new(),
+                }));
                 (
-                    create_test_sanitized_transaction(&kp, &to, 1),
-                    make_processed(),
+                    create_test_sanitized_transaction(&keypair, &to, 1),
+                    processed,
                 )
             })
             .collect();
 
         let batch_refs: Vec<_> = txs
             .iter()
-            .map(|(tx, p)| (*tx.signature(), tx, slot, block_time, p))
+            .map(|(tx, processed)| (*tx.signature(), tx, slot, block_time, processed))
             .collect();
 
+        // Written to Postgres only, never to the cache.
         let block = create_test_block_info(slot, Hash::new_unique());
         let pg_addr_sig_rows = pg_db
-            .write_batch(&[], batch_refs.clone(), Some(block.clone()))
-            .await
-            .unwrap();
-        flush_address_signatures_sync(&pg_db, &pg_addr_sig_rows).await;
-        redis_db
             .write_batch(&[], batch_refs, Some(block))
             .await
             .unwrap();
+        flush_address_signatures_sync(&pg_db, &pg_addr_sig_rows).await;
 
         let pg_sigs = pg_db
             .get_signatures_for_address(&to, 10, None, None)
             .await
             .unwrap();
-        let redis_sigs = redis_db
+        let cache_sigs = cache_db
             .get_signatures_for_address(&to, 10, None, None)
             .await
             .unwrap();
 
         assert_eq!(pg_sigs.len(), 10);
-        let pg_order: Vec<&str> = pg_sigs.iter().map(|s| s.signature.as_str()).collect();
-        let redis_order: Vec<&str> = redis_sigs.iter().map(|s| s.signature.as_str()).collect();
+        let pg_order: Vec<&str> = pg_sigs.iter().map(|sig| sig.signature.as_str()).collect();
+        let cache_order: Vec<&str> = cache_sigs
+            .iter()
+            .map(|sig| sig.signature.as_str())
+            .collect();
         assert_eq!(
-            pg_order, redis_order,
-            "Redis and Postgres must return same-slot signatures in identical order"
+            pg_order, cache_order,
+            "a cache-backed handle must return the full Postgres history"
         );
     }
 

--- a/core/src/accounts/write_batch.rs
+++ b/core/src/accounts/write_batch.rs
@@ -272,6 +272,35 @@ async fn write_batch_postgres(
     Ok(addr_sig_rows)
 }
 
+/// Drops the cache keys a failed `write_batch_redis` left holding pre-batch
+/// values, so reads miss and resolve against Postgres rather than being served
+/// something stale.
+///
+/// Only the account keys need it. A new `tx:` or `block:` key had no previous
+/// value, so a skipped write leaves it absent, which already reads as a miss.
+/// `latest_slot` and `latest_blockhash` are stale for at most one block, until
+/// the next successful write overwrites them. An account key, by contrast, keeps
+/// its pre-batch balance until that account is next touched, which may be never.
+///
+/// This narrows the window rather than being the only repair: the failed write
+/// also left the cached tip behind, so the next batch's continuity check takes
+/// the whole cache out of service and rebuilds it.
+pub(crate) async fn invalidate_batch_redis(
+    db: &mut RedisAccountsDB,
+    account_settlements: &[(Pubkey, AccountSettlement)],
+) {
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+
+    for (pubkey, _) in account_settlements {
+        pipe.del(format!("account:{}", pubkey));
+    }
+
+    if let Err(e) = pipe.query_async::<()>(&mut db.connection).await {
+        warn!("Failed to invalidate Redis keys after a failed cache write: {e}");
+    }
+}
+
 pub(crate) async fn write_batch_redis(
     db: &mut RedisAccountsDB,
     account_settlements: &[(Pubkey, AccountSettlement)],
@@ -300,30 +329,17 @@ pub(crate) async fn write_batch_redis(
         }
     }
 
-    // Store transactions and build the address→signatures index used by
-    // getSignaturesForAddress. For each account key touched by the transaction
-    // we ZADD one entry to a per-address sorted set:
-    //   key:    addr_sigs:{pubkey}
-    //   score:  tx_slot as f64  (enables ZRANGE BYSCORE REV ordering by recency)
-    //   member: hex-encoded signature (preserves byte ordering for same-slot DESC sort)
-    // Mirrors what address_signatures does in Postgres.
-    // redis-rs 0.27: zadd(key, member, score) — member first, score second.
-    let tx_count = transactions.len();
+    // Only the families a read can actually be served from are mirrored:
+    // point lookups by pubkey, signature and slot, plus the chain tip. The
+    // address index, slot index and transaction counter used to be written here
+    // too, but nothing reads them from the cache any more: a range, a history
+    // or a counter cannot express a cache miss, so those reads go straight to
+    // Postgres. Writing them was work whose only effect was to be purged later.
     for (signature, transaction, tx_slot, block_time, processed) in transactions {
         let stored_tx = get_stored_transaction(transaction, tx_slot, block_time, processed);
         let key = format!("tx:{}", signature);
         let serialized = bincode::serialize(&stored_tx).unwrap();
         pipe.set(key, serialized);
-
-        for pubkey in transaction.message().account_keys().iter() {
-            let addr_key = format!("addr_sigs:{}", pubkey);
-            pipe.zadd(addr_key, hex::encode(signature.as_ref()), tx_slot as f64);
-        }
-    }
-
-    // Increment transaction count
-    if tx_count > 0 {
-        pipe.incr("transaction_count", tx_count);
     }
 
     // Store block info and update latest slot
@@ -333,12 +349,6 @@ pub(crate) async fn write_batch_redis(
         let key = format!("block:{}", block.slot);
         let serialized = bincode::serialize(&block).unwrap();
         pipe.set(key, serialized);
-        // Index all slots in a sorted set (score = slot value) for two purposes:
-        // 1. getBlocks: ZRANGE block_slot_index start end BYSCORE for O(log N + M) range queries.
-        // 2. getFirstAvailableBlock: ZRANGE block_slot_index 0 0 returns the minimum slot.
-        // ZADD is idempotent for the same (member, score) pair, so replays are safe.
-        // redis-rs 0.27: zadd(key, member, score) — member first, score second.
-        pipe.zadd("block_slot_index", block.slot, block.slot as f64);
     }
 
     // Execute pipeline - explicitly specify the return type to fix type inference

--- a/core/src/bin/node.rs
+++ b/core/src/bin/node.rs
@@ -103,6 +103,11 @@ struct Args {
     #[arg(long, env = "PRIVATE_CHANNEL_ACCOUNTSDB_CONNECTION_URL")]
     accountsdb_connection_url: String,
 
+    /// Optional Redis cache in front of the read path. Misses fall through to
+    /// the accounts database.
+    #[arg(long, env = "PRIVATE_CHANNEL_REDIS_CACHE_URL")]
+    redis_cache_url: Option<String>,
+
     /// Admin public keys that can bypass certain restrictions (comma-separated base58 strings)
     /// Example: --admin-keys "11111111111111111111111111111111,22222222222222222222222222222222"
     #[arg(long, env = "PRIVATE_CHANNEL_ADMIN_KEYS", value_delimiter = ',')]
@@ -193,6 +198,9 @@ async fn run_node_with_args(args: Args) -> Result<(), Box<dyn std::error::Error>
         execution_results_capacity: args.execution_results_capacity,
         max_svm_workers: args.max_svm_workers,
         accountsdb_connection_url: args.accountsdb_connection_url,
+        // Blank means no cache. Without this the env var set to "" reads as a
+        // URL and the read node refuses to start.
+        redis_cache_url: args.redis_cache_url.filter(|url| !url.trim().is_empty()),
         admin_keys,
         transaction_expiration_ms: args.transaction_expiration_ms,
         blocktime_ms: args.blocktime_ms,

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -1,6 +1,9 @@
 use {
     crate::{
-        accounts::{address_index_repair::repair_address_signatures, AccountsDB},
+        accounts::{
+            address_index_repair::repair_address_signatures, postgres::PostgresAccountsDB,
+            redis::RedisAccountsDB, AccountsDB,
+        },
         rpc::{
             server::{start_rpc_service, RpcServiceConfig},
             ReadDeps, WriteDeps,
@@ -64,6 +67,9 @@ pub struct NodeConfig {
     /// batches ≥ `MIN_PARALLEL_BATCH_SIZE`; smaller batches always run sequentially.
     pub max_svm_workers: usize,
     pub accountsdb_connection_url: String,
+    /// Optional Redis cache in front of the read path. Reads consult Redis
+    /// first and fall through to `accountsdb_connection_url` on a miss.
+    pub redis_cache_url: Option<String>,
     pub admin_keys: Vec<Pubkey>, // Admin keys that can bypass SPL token program execution
     pub transaction_expiration_ms: u64,
     pub blocktime_ms: u64,
@@ -96,6 +102,7 @@ impl Default for NodeConfig {
             max_svm_workers: 8,
             accountsdb_connection_url: "postgresql://user:password@localhost:5432/private_channel"
                 .to_string(),
+            redis_cache_url: None,
             admin_keys: vec![],               // No admin keys by default
             transaction_expiration_ms: 15000, // 15 seconds default
             blocktime_ms: 100,                // 100ms default
@@ -123,6 +130,41 @@ impl WorkerHandle {
 pub struct NodeHandles {
     workers: Vec<WorkerHandle>,
     shutdown_token: CancellationToken,
+}
+
+/// How long a read node waits for a write node to stamp the cache before giving
+/// up. A cache the write node has not aligned yet is retried rather than fatal;
+/// one that names another deployment never becomes valid, but retrying it costs
+/// only this window and it fails closed either way.
+///
+/// This covers a cache the write node has not stamped yet, not a Postgres it has
+/// not created the schema in. That case fails earlier, when the cache handle
+/// reads the deployment id, and is not retried.
+///
+/// Serving is not gated on this: every cached read rechecks the stamp for itself,
+/// so a cache condemned later is dropped without waiting for a restart. Failing
+/// here is about not starting a node whose cache is misconfigured, rather than
+/// letting it come up and quietly serve every read from Postgres.
+const CACHE_VERIFY_TIMEOUT: Duration = Duration::from_secs(30);
+const CACHE_VERIFY_INTERVAL: Duration = Duration::from_secs(1);
+
+async fn wait_for_verified_cache(
+    redis: &crate::accounts::redis::RedisAccountsDB,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let deadline = tokio::time::Instant::now() + CACHE_VERIFY_TIMEOUT;
+    loop {
+        match crate::accounts::redis_coherence::verify_cache_stamp(redis).await {
+            Ok(()) => return Ok(()),
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                warn!(
+                    "Redis cache not usable yet ({}), waiting for a write node",
+                    e
+                );
+                tokio::time::sleep(CACHE_VERIFY_INTERVAL).await;
+            }
+            Err(e) => return Err(format!("Redis cache never became usable: {e:#}").into()),
+        }
+    }
 }
 
 pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::error::Error>> {
@@ -297,6 +339,7 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
                 settled_blockhashes_tx,
                 address_signatures_tx: addr_sig_tx,
                 accountsdb_connection_url: config.accountsdb_connection_url.clone(),
+                redis_cache_url: config.redis_cache_url.clone(),
                 blocktime_ms: config.blocktime_ms,
                 perf_sample_period_secs: config.perf_sample_period_secs,
                 shutdown_token: shutdown_token.clone(),
@@ -336,7 +379,30 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
 
     let read_deps = match config.mode {
         NodeMode::Read | NodeMode::Aio => {
-            let accounts_db = AccountsDB::new(&config.accountsdb_connection_url, true).await?;
+            let accounts_db = match config.redis_cache_url {
+                // Redis in front of Postgres. Postgres stays reachable so a
+                // key missing from the cache resolves against the source of
+                // truth instead of reading as an absence.
+                Some(ref redis_url) => {
+                    let postgres = PostgresAccountsDB::new(&config.accountsdb_connection_url, true)
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to create PostgresAccountsDB: {}", e)
+                        })?;
+                    let redis = RedisAccountsDB::new(redis_url, postgres)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to create RedisAccountsDB: {}", e))?;
+                    // Only a write node aligns the cache, so wait for one to
+                    // publish a stamp rather than serving whatever is there. An
+                    // empty cache verifies immediately. Foreign state verifies
+                    // only once a write node purges it, which in Aio is the
+                    // settler alongside this one.
+                    wait_for_verified_cache(&redis).await?;
+                    info!("Read path caching through Redis with Postgres fallback");
+                    AccountsDB::Redis(redis)
+                }
+                None => AccountsDB::new(&config.accountsdb_connection_url, true).await?,
+            };
             // Read nodes don't repair: the write node owns the address_signatures
             // index and repairs it on the primary; the read-only replica receives
             // it via replication (repair would write, which fails on a standby).

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -132,14 +132,15 @@ pub struct NodeHandles {
     shutdown_token: CancellationToken,
 }
 
-/// How long a read node waits for a write node to stamp the cache before giving
-/// up. A cache the write node has not aligned yet is retried rather than fatal;
-/// one that names another deployment never becomes valid, but retrying it costs
-/// only this window and it fails closed either way.
+/// How long a read node waits out a cache stamped for another deployment. Worth
+/// waiting for in Aio, where the settler alongside this node purges and re-stamps
+/// it moments later; a genuinely wrong Redis costs only this window and then
+/// fails closed. An unstamped cache is not waited for at all, since the node
+/// serves correctly from Postgres until a write node stamps one.
 ///
-/// This covers a cache the write node has not stamped yet, not a Postgres it has
-/// not created the schema in. That case fails earlier, when the cache handle
-/// reads the deployment id, and is not retried.
+/// This covers the cache, not a Postgres the write node has not created the
+/// schema in. That case fails earlier, when the cache handle reads the deployment
+/// id, and is not retried.
 ///
 /// Serving is not gated on this: every cached read rechecks the stamp for itself,
 /// so a cache condemned later is dropped without waiting for a restart. Failing

--- a/core/src/stage_metrics.rs
+++ b/core/src/stage_metrics.rs
@@ -48,6 +48,14 @@ pub trait StageMetrics: Send + Sync {
     fn settler_db_write_duration_ms(&self, ms: f64);
     fn settler_processing_duration_ms(&self, ms: f64);
 
+    // Redis cache (optional read-through cache in front of Postgres). These are
+    // the only signal that the cache has taken itself out of service; without
+    // them a node silently serves every read from Postgres.
+    fn redis_cache_purged(&self);
+    fn redis_cache_condemned(&self);
+    fn redis_cache_write_failed(&self);
+    fn redis_cache_disabled(&self);
+
     // Address-index writer (off-critical-path background worker)
     fn address_signatures_queue_depth(&self, depth: usize);
     fn address_signatures_send_blocked_ms(&self, ms: f64);
@@ -146,6 +154,18 @@ impl StageMetrics for NoopMetrics {
     fn settler_processing_duration_ms(&self, ms: f64) {
         debug!("settler: processing_duration={:.3}ms", ms);
     }
+    fn redis_cache_purged(&self) {
+        debug!("redis cache: purged");
+    }
+    fn redis_cache_condemned(&self) {
+        debug!("redis cache: condemned");
+    }
+    fn redis_cache_write_failed(&self) {
+        debug!("redis cache: write failed");
+    }
+    fn redis_cache_disabled(&self) {
+        debug!("redis cache: disabled");
+    }
     fn address_signatures_queue_depth(&self, depth: usize) {
         debug!("address_signatures: queue_depth={}", depth);
     }
@@ -170,6 +190,30 @@ impl StageMetrics for NoopMetrics {
 use private_channel_metrics::{counter_vec, gauge_vec, init_metrics};
 
 // Counters
+counter_vec!(
+    REDIS_CACHE_PURGED,
+    "private_channel_redis_cache_purged_total",
+    "Times the Redis cache was emptied because its contents could not be trusted",
+    &[]
+);
+counter_vec!(
+    REDIS_CACHE_CONDEMNED,
+    "private_channel_redis_cache_condemned_total",
+    "Times the Redis cache was taken out of service after missing a settled batch",
+    &[]
+);
+counter_vec!(
+    REDIS_CACHE_WRITE_FAILED,
+    "private_channel_redis_cache_write_failed_total",
+    "Best-effort Redis cache writes that failed after Postgres had committed",
+    &[]
+);
+counter_vec!(
+    REDIS_CACHE_DISABLED,
+    "private_channel_redis_cache_disabled_total",
+    "Times a node gave up on the Redis cache and continued Postgres-only",
+    &[]
+);
 counter_vec!(
     RPC_INGRESS_SHED,
     "private_channel_rpc_ingress_shed_total",
@@ -486,6 +530,22 @@ impl StageMetrics for PrometheusMetrics {
             .with_label_values(&[] as &[&str])
             .observe(ms);
     }
+    fn redis_cache_purged(&self) {
+        REDIS_CACHE_PURGED.with_label_values(&[] as &[&str]).inc();
+    }
+    fn redis_cache_condemned(&self) {
+        REDIS_CACHE_CONDEMNED
+            .with_label_values(&[] as &[&str])
+            .inc();
+    }
+    fn redis_cache_write_failed(&self) {
+        REDIS_CACHE_WRITE_FAILED
+            .with_label_values(&[] as &[&str])
+            .inc();
+    }
+    fn redis_cache_disabled(&self) {
+        REDIS_CACHE_DISABLED.with_label_values(&[] as &[&str]).inc();
+    }
     fn settler_processing_duration_ms(&self, ms: f64) {
         SETTLER_PROCESSING_DURATION
             .with_label_values(&[] as &[&str])
@@ -552,6 +612,10 @@ pub fn init_prometheus_metrics() {
         ADDRESS_SIGNATURES_FLUSH_ERRORS,
         ADDRESS_SIGNATURES_QUEUE_DEPTH,
         ADDRESS_SIGNATURES_SEND_BLOCKED,
-        ADDRESS_SIGNATURES_FLUSH_DURATION
+        ADDRESS_SIGNATURES_FLUSH_DURATION,
+        REDIS_CACHE_PURGED,
+        REDIS_CACHE_CONDEMNED,
+        REDIS_CACHE_WRITE_FAILED,
+        REDIS_CACHE_DISABLED
     );
 }

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
         accounts::{
-            postgres::PostgresAccountsDB, redis::RedisAccountsDB, traits::BlockInfo,
-            write_batch::AddressSignatureRow, AccountsDB,
+            postgres::PostgresAccountsDB, redis::RedisAccountsDB, redis_coherence,
+            traits::BlockInfo, write_batch::AddressSignatureRow, AccountsDB,
         },
         nodes::node::WorkerHandle,
         stage_metrics::SharedMetrics,
@@ -95,64 +95,73 @@ struct LastBlock {
     blockhash: Hash,
 }
 
-/// Warm the Redis cache by reading from Postgres and writing to Redis
-/// This is called on startup to ensure Redis has the latest state from Postgres
+/// Align the Redis cache with the Postgres source of truth at startup.
+///
+/// Redis outlives the process that filled it, so its contents are checked
+/// against Postgres before anything reads through them: a cache naming a
+/// different deployment, or whose tip does not match Postgres exactly, is
+/// emptied. A purged cache is empty rather than wrong, and reads then miss and
+/// resolve against Postgres.
+///
+/// `postgres_slot` and `postgres_blockhash` are the caller's view of the
+/// Postgres tip. The caller checks only that the two agree on being present or
+/// absent, and reads them in a way that maps a query failure to absent, so an
+/// unreachable Postgres arrives here as an empty ledger and purges the cache.
+/// Wrong in the safe direction, and worth tightening at the read rather than
+/// here.
+///
+/// This covers what a restart can see, including a cache left unstamped by an
+/// interrupted rebuild. Gaps that open while the settler keeps running are caught
+/// per batch by `ensure_cache_continuity` instead.
+///
+/// Returns whether the cache had to be emptied, which the caller records: a
+/// deployment that purges on every boot is two of them sharing one Redis.
 pub async fn warm_redis_cache(
     postgres_db: &PostgresAccountsDB,
     redis_db: &RedisAccountsDB,
-) -> Result<()> {
-    info!("Warming Redis cache from Postgres...");
+    postgres_slot: Option<u64>,
+    postgres_blockhash: Option<Hash>,
+) -> Result<bool> {
+    info!("Aligning Redis cache with Postgres...");
 
-    // Read latest_slot from Postgres
-    let pool = postgres_db.pool.clone();
-    let slot = sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(slot) FROM blocks")
-        .fetch_one(pool.as_ref())
-        .await
-        .context("Failed to query latest slot from Postgres")?;
+    let deployment_id = redis_coherence::read_deployment_id(postgres_db).await?;
 
-    if let Some(slot_value) = slot {
-        let slot_u64 = slot_value as u64;
+    let mut purged = false;
+    if let Some(reason) =
+        redis_coherence::staleness_reason(redis_db, &deployment_id, postgres_slot).await?
+    {
+        warn!(
+            "Purging Redis cache, it cannot serve this ledger: {}",
+            reason
+        );
+        // Cleared first: an interrupted purge leaves the cache unstamped, so the
+        // next startup purges again rather than trusting a half-emptied cache.
+        redis_coherence::clear_deployment_id(redis_db).await?;
+        redis_coherence::purge_ledger_keys(redis_db).await?;
+        purged = true;
+    }
 
-        // Write latest_slot to Redis
-        let mut conn = redis_db.connection.clone();
-        conn.set::<_, _, ()>("latest_slot", slot_u64)
+    let mut conn = redis_db.connection.clone();
+    if let Some(slot) = postgres_slot {
+        conn.set::<_, _, ()>("latest_slot", slot)
             .await
             .map_err(|e| anyhow!("Failed to write latest_slot to Redis: {}", e))?;
-
-        info!("Warmed Redis cache: latest_slot = {}", slot_u64);
-    } else {
-        warn!("No blocks found in Postgres - skipping latest_slot cache warming");
     }
-
-    // Read latest_blockhash from Postgres
-    let blockhash_bytes: Option<Vec<u8>> =
-        sqlx::query_scalar("SELECT value FROM metadata WHERE key = 'latest_blockhash'")
-            .fetch_optional(pool.as_ref())
-            .await
-            .context("Failed to query latest blockhash from Postgres")?;
-
-    if let Some(bytes) = blockhash_bytes {
-        // Convert bytes to Hash and then to string for Redis storage
-        let hash_array: [u8; 32] = bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| anyhow!("Invalid blockhash bytes length: {}", bytes.len()))?;
-        let hash = Hash::new_from_array(hash_array);
-        let hash_str = hash.to_string();
-
-        // Write latest_blockhash to Redis
-        let mut conn = redis_db.connection.clone();
-        conn.set::<_, _, ()>("latest_blockhash", hash_str.clone())
+    if let Some(blockhash) = postgres_blockhash {
+        conn.set::<_, _, ()>("latest_blockhash", blockhash.to_string())
             .await
             .map_err(|e| anyhow!("Failed to write latest_blockhash to Redis: {}", e))?;
-
-        info!("Warmed Redis cache: latest_blockhash = {}", hash_str);
-    } else {
-        warn!("No blockhash found in Postgres metadata - skipping latest_blockhash cache warming");
     }
 
-    info!("Redis cache warming completed successfully");
-    Ok(())
+    // Stamped last: the cache only names this deployment once it is coherent
+    // with it.
+    redis_coherence::stamp_deployment_id(redis_db, &deployment_id).await?;
+
+    info!(
+        "Redis cache aligned with Postgres: latest_slot = {:?}",
+        postgres_slot
+    );
+    Ok(purged)
 }
 
 pub struct SettleArgs {
@@ -162,6 +171,9 @@ pub struct SettleArgs {
     /// Bounded channel to the background `address_index_writer`.
     pub address_signatures_tx: mpsc::Sender<Vec<AddressSignatureRow>>,
     pub accountsdb_connection_url: String,
+    /// The cache the read path also attaches to. One knob for both, so a writer
+    /// cannot stop mirroring a cache that readers still trust.
+    pub redis_cache_url: Option<String>,
     pub blocktime_ms: u64,
     pub perf_sample_period_secs: u64,
     pub shutdown_token: CancellationToken,
@@ -176,6 +188,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
         settled_blockhashes_tx,
         address_signatures_tx,
         accountsdb_connection_url,
+        redis_cache_url,
         blocktime_ms,
         perf_sample_period_secs,
         shutdown_token,
@@ -190,6 +203,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
             settled_blockhashes_tx: mpsc::UnboundedSender<Hash>,
             address_signatures_tx: mpsc::Sender<Vec<AddressSignatureRow>>,
             accountsdb_connection_url: String,
+            redis_cache_url: Option<String>,
             blocktime_ms: u64,
             perf_sample_period_secs: u64,
             shutdown_token: CancellationToken,
@@ -202,11 +216,19 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                 .await
                 .unwrap();
 
-            let mut redis_db: Option<RedisAccountsDB> = match std::env::var("REDIS_URL") {
-                Ok(redis_url) => {
+            // The cache handle carries the Postgres source of truth so reads
+            // through it resolve a miss instead of reporting an absence. The
+            // settler itself only writes through it.
+            let AccountsDB::Postgres(ref postgres_db) = accounts_db else {
+                anyhow::bail!("Settle worker requires a Postgres accounts database");
+            };
+            let postgres_db = postgres_db.clone();
+
+            let mut redis_db: Option<RedisAccountsDB> = match redis_cache_url {
+                Some(ref redis_url) => {
                     match tokio::time::timeout(
                         Duration::from_secs(5),
-                        RedisAccountsDB::new(&redis_url),
+                        RedisAccountsDB::new(redis_url, postgres_db.clone()),
                     )
                     .await
                     {
@@ -224,23 +246,25 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                         }
                     }
                 }
-                Err(_) => {
-                    info!("REDIS_URL not set, running Postgres-only");
+                None => {
+                    info!("No Redis cache configured, running Postgres-only");
                     None
                 }
             };
 
-            // Warm Redis cache from Postgres on startup
-            if let (AccountsDB::Postgres(ref pg), Some(ref redis)) = (&accounts_db, &redis_db) {
-                if let Err(e) = warm_redis_cache(pg, redis).await {
-                    warn!("Cache warming failed (non-fatal): {}", e);
-                }
-            }
-
-            let last_slot = accounts_db.get_latest_slot().await.ok().flatten();
+            // Propagated, never mapped to "no blocks": an unreachable Postgres
+            // read as an empty ledger makes the settler believe it is at genesis
+            // and start writing slot 0 over a live chain. `Ok(None)` here means
+            // the ledger genuinely has no blocks.
+            let last_slot = accounts_db
+                .get_latest_slot()
+                .await
+                .context("Failed to read the latest slot at startup")?;
             let last_blockhash = accounts_db.get_latest_blockhash().await.ok();
 
-            // Validate that last_slot and last_blockhash are both present or both absent
+            // Validate that last_slot and last_blockhash are both present or both absent.
+            // Runs before the cache is aligned: an incoherent tip is not a
+            // baseline anything can be checked against.
             match (last_slot, last_blockhash) {
                 (Some(_), None) => {
                     anyhow::bail!("Invalid state: last_slot exists but last_blockhash is missing");
@@ -250,6 +274,37 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                 }
                 _ => {}
             }
+
+            // Align the cache with Postgres before the first dual-write. Failing
+            // to verify it means the cache cannot be trusted, so drop it and run
+            // Postgres-only rather than write a second ledger into it.
+            redis_db = match redis_db {
+                Some(redis) => {
+                    match warm_redis_cache(&postgres_db, &redis, last_slot, last_blockhash).await {
+                        Ok(purged) => {
+                            if purged {
+                                metrics.redis_cache_purged();
+                            }
+                            Some(redis)
+                        }
+                        Err(e) => {
+                            error!("Redis cache alignment failed, running Postgres-only: {}", e);
+                            metrics.redis_cache_disabled();
+                            // The failure may have come before the stamp was
+                            // cleared, leaving a stamped cache whose tip is about
+                            // to stop advancing. Nothing else will ever clear it:
+                            // dropping the handle here means no further continuity
+                            // checks run, so read nodes would serve those frozen
+                            // values indefinitely.
+                            if let Err(e) = redis_coherence::clear_deployment_id(&redis).await {
+                                error!("Could not take the Redis cache out of service: {}", e);
+                            }
+                            None
+                        }
+                    }
+                }
+                None => None,
+            };
 
             let mut last_block = match (last_slot, last_blockhash) {
                 (Some(last_slot), Some(last_blockhash)) => Some(LastBlock {
@@ -466,6 +521,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url,
+            redis_cache_url,
             blocktime_ms,
             perf_sample_period_secs,
             shutdown_token,
@@ -671,18 +727,60 @@ async fn settle_transactions(
     // Phase 3: Redis write best-effort (non-fatal)
     let t_redis_start = tokio::time::Instant::now();
     if let Some(redis) = redis_db {
-        if let Err(e) = crate::accounts::write_batch::write_batch_redis(
-            redis,
-            &accounts_vec,
-            transactions_for_db,
-            Some(block_info),
-        )
-        .await
-        {
-            warn!(
-                "Best-effort Redis cache write failed (non-fatal, Postgres succeeded): {}",
-                e
-            );
+        // Checked before the write, because the write advances the cached tip
+        // and the tip is what shows a batch was missed.
+        let mirror = match redis_coherence::ensure_cache_continuity(redis, next_slot).await {
+            // The check has already cleared the stamp, so nothing is served from
+            // the cache until the rebuild finishes and stamps it again. Spawned
+            // because purging a large keyspace costs far more than a blocktime,
+            // and mirroring continues meanwhile because reads are gated on the
+            // stamp rather than on what the cache holds.
+            Ok(true) => {
+                metrics.redis_cache_condemned();
+                let rebuilding = redis.clone();
+                let rebuild_metrics = Arc::clone(metrics);
+                let generation = redis.condemnation_generation();
+                tokio::spawn(async move {
+                    match redis_coherence::rebuild_cache(&rebuilding, generation).await {
+                        Ok(()) => rebuild_metrics.redis_cache_purged(),
+                        Err(e) => {
+                            warn!("Redis cache rebuild failed, it stays out of service: {}", e)
+                        }
+                    }
+                });
+                true
+            }
+            Ok(false) => true,
+            // Whether a batch was missed is now unknown, so this write must not
+            // happen: it would advance the cached tip over any gap that does
+            // exist, erasing the only evidence of it. Skipping leaves the tip
+            // where it is, so the next check that succeeds still sees the gap.
+            Err(e) => {
+                warn!("Skipping the Redis cache write, continuity unknown: {}", e);
+                false
+            }
+        };
+
+        if mirror {
+            if let Err(e) = crate::accounts::write_batch::write_batch_redis(
+                redis,
+                &accounts_vec,
+                transactions_for_db,
+                Some(block_info),
+            )
+            .await
+            {
+                warn!(
+                    "Best-effort Redis cache write failed (non-fatal, Postgres succeeded): {}",
+                    e
+                );
+                metrics.redis_cache_write_failed();
+                // The account keys this batch should have updated still hold
+                // pre-batch balances. Drop them now so reads miss and resolve
+                // against Postgres, rather than waiting for the next batch to
+                // notice the tip did not advance and rebuild the whole cache.
+                crate::accounts::write_batch::invalidate_batch_redis(redis, &accounts_vec).await;
+            }
         }
     }
     let t_redis_ms = t_redis_start.elapsed().as_secs_f64() * 1000.0;
@@ -1511,7 +1609,7 @@ mod tests {
         };
 
         // Create Redis connection
-        let redis_db = match RedisAccountsDB::new(&redis_url).await {
+        let redis_db = match RedisAccountsDB::new(&redis_url, postgres_db.clone()).await {
             Ok(db) => db,
             Err(e) => {
                 eprintln!("Skipping test: Cannot connect to test Redis: {}", e);
@@ -1564,7 +1662,13 @@ mod tests {
         }
 
         // Execute: Call warm_redis_cache
-        let result = warm_redis_cache(&postgres_db, &redis_db).await;
+        let result = warm_redis_cache(
+            &postgres_db,
+            &redis_db,
+            Some(test_slot),
+            Some(test_blockhash),
+        )
+        .await;
 
         // Verify: Function should succeed
         assert!(
@@ -1626,6 +1730,7 @@ mod tests {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url,
+            redis_cache_url: None,
             blocktime_ms: 100,
             perf_sample_period_secs: 60,
             shutdown_token: shutdown.clone(),
@@ -1657,6 +1762,7 @@ mod tests {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url,
+            redis_cache_url: None,
             blocktime_ms: 50, // fast for testing
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown.clone(),
@@ -1753,6 +1859,7 @@ mod tests {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url,
+            redis_cache_url: None,
             blocktime_ms: 50,
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown.clone(),
@@ -1792,6 +1899,7 @@ mod tests {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url,
+            redis_cache_url: None,
             blocktime_ms: 50,
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown.clone(),
@@ -1843,6 +1951,7 @@ mod tests {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url,
+            redis_cache_url: None,
             blocktime_ms: 50,
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown.clone(),
@@ -2161,7 +2270,11 @@ mod tests {
         // Test that warm_redis_cache reads latest_slot and latest_blockhash from Postgres
         // and writes them to Redis
         let (mut pg_db, _pg) = start_test_postgres().await;
-        let (redis_db, _redis) = start_test_redis().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
 
         // Seed Postgres via settle_transactions
         let from = Keypair::new();
@@ -2183,11 +2296,11 @@ mod tests {
         .await
         .unwrap();
 
-        // Get the PostgresAccountsDB variant for warm_redis_cache
-        let AccountsDB::Postgres(ref pg) = pg_db else {
-            panic!("Expected Postgres variant")
-        };
-        warm_redis_cache(pg, &redis_db).await.unwrap();
+        let slot = pg_db.get_latest_slot().await.unwrap();
+        let blockhash = pg_db.get_latest_blockhash().await.ok();
+        warm_redis_cache(&postgres_db, &redis_db, slot, blockhash)
+            .await
+            .unwrap();
 
         // Verify Redis was populated
         let mut conn = redis_db.connection.clone();
@@ -2197,25 +2310,469 @@ mod tests {
         assert!(bh.is_some(), "Redis latest_blockhash should be set");
     }
 
+    /// A cache filled before this check existed names no deployment. Holding
+    /// ledger state against a Postgres with no blocks, it can only be a previous
+    /// ledger's, so it must not survive into the new one.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_warm_redis_cache_empty_postgres() {
-        // Test that warm_redis_cache handles empty Postgres gracefully
+    async fn warm_redis_cache_purges_an_unstamped_cache_when_postgres_is_empty() {
         let (pg_db, _pg) = start_test_postgres().await;
-        let (redis_db, _redis) = start_test_redis().await;
-
-        let AccountsDB::Postgres(ref pg) = pg_db else {
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
             panic!("Expected Postgres variant")
         };
-        // Should succeed without panic — empty DB is gracefully handled
-        warm_redis_cache(pg, &redis_db).await.unwrap();
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
 
-        // No keys should be written when Postgres is empty
+        let stale_pubkey = Pubkey::new_unique();
+        let stale_slot = 4242u64;
         let mut conn = redis_db.connection.clone();
-        let slot: Option<u64> = conn.get("latest_slot").await.ok();
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", stale_slot).await.unwrap();
+
+        warm_redis_cache(&postgres_db, &redis_db, None, None)
+            .await
+            .unwrap();
+
+        let account_exists: bool = conn
+            .exists(format!("account:{}", stale_pubkey))
+            .await
+            .unwrap();
+        assert!(!account_exists, "stale account key must not survive");
+        let slot: Option<u64> = conn.get("latest_slot").await.unwrap();
+        assert_eq!(slot, None, "stale tip must not survive");
+    }
+
+    /// A reused Redis instance carrying another ledger's keys is the case the
+    /// deployment identifier exists to catch.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_purges_a_cache_from_another_deployment() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let stale_pubkey = Pubkey::new_unique();
+        let stale_slot = 9000u64;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &[9u8; 16][..]).await.unwrap();
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+        let _: () = conn
+            .set(format!("block:{}", stale_slot), vec![4u8, 5, 6])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", stale_slot).await.unwrap();
+
+        warm_redis_cache(&postgres_db, &redis_db, None, None)
+            .await
+            .unwrap();
+
+        let account_exists: bool = conn
+            .exists(format!("account:{}", stale_pubkey))
+            .await
+            .unwrap();
         assert!(
-            slot.is_none(),
-            "Redis should have no slot when Postgres is empty"
+            !account_exists,
+            "another ledger's accounts must not survive"
         );
+        let block_exists: bool = conn.exists(format!("block:{}", stale_slot)).await.unwrap();
+        assert!(!block_exists, "another ledger's blocks must not survive");
+
+        let stamped: Option<Vec<u8>> = conn.get("deployment_id").await.unwrap();
+        assert_eq!(
+            stamped,
+            Some(
+                redis_coherence::read_deployment_id(&postgres_db)
+                    .await
+                    .unwrap()
+            ),
+            "the cache must be re-stamped with this deployment"
+        );
+    }
+
+    /// Same deployment, but Postgres was restored to an earlier point: the cache
+    /// holds slots the source of truth no longer has.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_purges_a_cache_ahead_of_postgres() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        let cached_slot = 9000u64;
+        let postgres_slot = 10u64;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &deployment_id[..]).await.unwrap();
+        let _: () = conn
+            .set(format!("block:{}", cached_slot), vec![4u8, 5, 6])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", cached_slot).await.unwrap();
+
+        warm_redis_cache(
+            &postgres_db,
+            &redis_db,
+            Some(postgres_slot),
+            Some(Hash::new_unique()),
+        )
+        .await
+        .unwrap();
+
+        let block_exists: bool = conn.exists(format!("block:{}", cached_slot)).await.unwrap();
+        assert!(!block_exists, "slots ahead of Postgres must not survive");
+        let slot: Option<u64> = conn.get("latest_slot").await.unwrap();
+        assert_eq!(
+            slot,
+            Some(postgres_slot),
+            "the tip must be rewound to Postgres"
+        );
+    }
+
+    /// Every cached ledger key family has to go, not just the ones a read path
+    /// happens to consult today. A family left behind is exactly the kind of
+    /// unvalidated state that made a reused cache dangerous.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_purges_every_ledger_key_family() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let stale_pubkey = Pubkey::new_unique();
+        let stale_signature = Signature::new_unique();
+        let stale_slot = 9000u64;
+        let prefixed_keys = [
+            format!("account:{}", stale_pubkey),
+            format!("tx:{}", stale_signature),
+            format!("block:{}", stale_slot),
+        ];
+        let fixed_keys = [
+            "block_slot_index",
+            "transaction_count",
+            "performance_samples",
+            "latest_slot",
+            "latest_blockhash",
+        ];
+
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &[9u8; 16][..]).await.unwrap();
+        for key in &prefixed_keys {
+            let _: () = conn.set(key, vec![1u8, 2, 3]).await.unwrap();
+        }
+        // Written with the types an older build used, since the purge has to
+        // clear what those builds left behind.
+        let addr_sigs_key = format!("addr_sigs:{}", stale_pubkey);
+        let _: () = conn
+            .zadd(&addr_sigs_key, "deadbeef", stale_slot as f64)
+            .await
+            .unwrap();
+        let _: () = conn
+            .zadd("block_slot_index", stale_slot, stale_slot as f64)
+            .await
+            .unwrap();
+        let _: () = conn.set("transaction_count", 77u64).await.unwrap();
+        let _: () = conn.lpush("performance_samples", "{}").await.unwrap();
+        let _: () = conn.set("latest_slot", stale_slot).await.unwrap();
+        let _: () = conn
+            .set("latest_blockhash", Hash::new_unique().to_string())
+            .await
+            .unwrap();
+
+        warm_redis_cache(&postgres_db, &redis_db, None, None)
+            .await
+            .unwrap();
+
+        for key in prefixed_keys.iter().chain(std::iter::once(&addr_sigs_key)) {
+            let exists: bool = conn.exists(key).await.unwrap();
+            assert!(!exists, "{} must not survive the purge", key);
+        }
+        for key in fixed_keys {
+            let exists: bool = conn.exists(key).await.unwrap();
+            assert!(!exists, "{} must not survive the purge", key);
+        }
+    }
+
+    /// One SCAN round returns a bounded slice of the keyspace, so the purge has
+    /// to keep walking until the cursor wraps. With more keys than fit in a
+    /// round, a single-pass purge would leave most of them behind.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_purges_more_keys_than_one_scan_round_returns() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        // Comfortably more than the purge's per-round COUNT of 512.
+        let key_count = 1500;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &[9u8; 16][..]).await.unwrap();
+        let mut seed = redis::pipe();
+        for _ in 0..key_count {
+            seed.set(format!("account:{}", Pubkey::new_unique()), vec![1u8, 2, 3]);
+        }
+        let _: () = seed.query_async(&mut conn).await.unwrap();
+
+        warm_redis_cache(&postgres_db, &redis_db, None, None)
+            .await
+            .unwrap();
+
+        let mut survivors = 0usize;
+        let mut cursor = 0u64;
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg("account:*")
+                .arg("COUNT")
+                .arg(512)
+                .query_async(&mut conn)
+                .await
+                .unwrap();
+            survivors += keys.len();
+            cursor = next_cursor;
+            if cursor == 0 {
+                break;
+            }
+        }
+        assert_eq!(survivors, 0, "the purge must walk the whole keyspace");
+    }
+
+    /// Settling a batch far ahead of the cached tip is what an outage looks like
+    /// from the settler's side. The cache must be condemned and left untouched:
+    /// if this write advanced the tip, it would close the only gap the startup
+    /// check can see, and the accounts missed during the outage would be served
+    /// as current from then on.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_unstamps_a_cache_that_missed_batches() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        let cached_tip = 100u64;
+        let mut conn = redis_raw.connection.clone();
+        let _: () = conn.set("deployment_id", &deployment_id[..]).await.unwrap();
+        let _: () = conn.set("latest_slot", cached_tip).await.unwrap();
+
+        let from = Keypair::new();
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 100);
+        let executed = make_executed(vec![(
+            Pubkey::new_unique(),
+            AccountSharedData::new(500, 0, &Pubkey::new_unique()),
+        )]);
+        settle_transactions(
+            Some(LastBlock {
+                slot: 200,
+                blockhash: Hash::new_unique(),
+            }),
+            &mut pg_db,
+            Some(&mut redis_raw),
+            &[(Ok(executed), tx)],
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // The stamp is the durable evidence, and clearing it takes the cache out
+        // of service on the very next read. Writing carries on, so the tip
+        // advances; that is safe precisely because reads are gated on the stamp
+        // rather than on the tip.
+        let stamped: Option<Vec<u8>> = conn.get("deployment_id").await.unwrap();
+        assert_eq!(
+            stamped, None,
+            "a cache that missed batches must stop being served"
+        );
+    }
+
+    /// Postgres with no blocks cannot back any cached ledger state, whatever the
+    /// tips say. Both tips absent compares equal, so without an explicit guard a
+    /// correctly-stamped cache that lost only its `latest_slot` key, evicted
+    /// under `allkeys-lru` or removed by hand, would survive against a
+    /// truncated or replaced Postgres and keep serving its accounts.
+    ///
+    /// Stamped and tipless on purpose: an unstamped cache exits at the stamp
+    /// guard and never reaches this one.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_purges_a_stamped_tipless_cache_when_postgres_is_empty() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        let stale_pubkey = Pubkey::new_unique();
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &deployment_id[..]).await.unwrap();
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+
+        warm_redis_cache(&postgres_db, &redis_db, None, None)
+            .await
+            .unwrap();
+
+        let account_exists: bool = conn
+            .exists(format!("account:{}", stale_pubkey))
+            .await
+            .unwrap();
+        assert!(
+            !account_exists,
+            "cached accounts must not survive a Postgres with no blocks"
+        );
+    }
+
+    /// A cache left *behind* Postgres is the crash window: the settler commits to
+    /// Postgres before mirroring to Redis, so a kill between the two leaves the
+    /// cached tip short and every account the batch touched holding its
+    /// pre-batch value. Those keys are present, so reads hit them and never
+    /// reach the fallback. Being behind is not being incomplete, and the cache
+    /// must not survive it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_purges_a_cache_behind_postgres() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        let stale_pubkey = Pubkey::new_unique();
+        let cached_slot = 41u64;
+        let postgres_slot = 42u64;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &deployment_id[..]).await.unwrap();
+        // Right deployment, one batch behind: the pre-batch balance is still here.
+        let _: () = conn
+            .set(format!("account:{}", stale_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", cached_slot).await.unwrap();
+
+        warm_redis_cache(
+            &postgres_db,
+            &redis_db,
+            Some(postgres_slot),
+            Some(Hash::new_unique()),
+        )
+        .await
+        .unwrap();
+
+        let account_exists: bool = conn
+            .exists(format!("account:{}", stale_pubkey))
+            .await
+            .unwrap();
+        assert!(
+            !account_exists,
+            "a pre-batch balance must not survive a tip that fell behind"
+        );
+        let slot: Option<u64> = conn.get("latest_slot").await.unwrap();
+        assert_eq!(slot, Some(postgres_slot), "the tip must be Postgres's");
+    }
+
+    /// An empty cache is trivially coherent: nothing to purge, and the mismatch
+    /// between an absent cached tip and a real Postgres tip is a normal first
+    /// attach rather than a stale cache.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_accepts_an_empty_cache() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let slot = 42u64;
+        warm_redis_cache(
+            &postgres_db,
+            &redis_db,
+            Some(slot),
+            Some(Hash::new_unique()),
+        )
+        .await
+        .unwrap();
+
+        let mut conn = redis_db.connection.clone();
+        let cached_slot: Option<u64> = conn.get("latest_slot").await.unwrap();
+        assert_eq!(cached_slot, Some(slot), "the tip must be published");
+        let stamped: Option<Vec<u8>> = conn.get("deployment_id").await.unwrap();
+        assert_eq!(
+            stamped,
+            Some(
+                redis_coherence::read_deployment_id(&postgres_db)
+                    .await
+                    .unwrap()
+            ),
+            "an empty cache must be stamped for this deployment"
+        );
+    }
+
+    /// The counterweight to the purge tests: a cache that agrees with Postgres
+    /// keeps its contents.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn warm_redis_cache_keeps_a_coherent_cache() {
+        let (pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (redis_db, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        let cached_pubkey = Pubkey::new_unique();
+        let slot = 10u64;
+        let mut conn = redis_db.connection.clone();
+        let _: () = conn.set("deployment_id", &deployment_id[..]).await.unwrap();
+        let _: () = conn
+            .set(format!("account:{}", cached_pubkey), vec![1u8, 2, 3])
+            .await
+            .unwrap();
+        let _: () = conn.set("latest_slot", slot).await.unwrap();
+
+        warm_redis_cache(
+            &postgres_db,
+            &redis_db,
+            Some(slot),
+            Some(Hash::new_unique()),
+        )
+        .await
+        .unwrap();
+
+        let account_exists: bool = conn
+            .exists(format!("account:{}", cached_pubkey))
+            .await
+            .unwrap();
+        assert!(account_exists, "a coherent cache must be left intact");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2237,6 +2794,7 @@ mod tests {
             settled_blockhashes_tx: _settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url.clone(),
+            redis_cache_url: None,
             blocktime_ms: 50,
             perf_sample_period_secs: 1, // fires after 1s
             shutdown_token: shutdown.clone(),
@@ -2298,6 +2856,7 @@ mod tests {
             settled_blockhashes_tx,
             address_signatures_tx,
             accountsdb_connection_url: url,
+            redis_cache_url: None,
             blocktime_ms: 50,
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown.clone(),

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -729,13 +729,21 @@ async fn settle_transactions(
     if let Some(redis) = redis_db {
         // Checked before the write, because the write advances the cached tip
         // and the tip is what shows a batch was missed.
-        let mirror = match redis_coherence::ensure_cache_continuity(redis, next_slot).await {
+        let may_mirror = match redis_coherence::ensure_cache_continuity(redis, next_slot).await {
+            Ok(redis_coherence::CacheStatus::InService) => true,
+            // A purge is already walking this cache. Writing to it would renew
+            // the lease and put back into service the stale keys that purge has
+            // not reached yet, and starting a second one would supersede it.
+            Ok(redis_coherence::CacheStatus::Rebuilding) => false,
             // The check has already cleared the stamp, so nothing is served from
             // the cache until the rebuild finishes and stamps it again. Spawned
-            // because purging a large keyspace costs far more than a blocktime,
-            // and mirroring continues meanwhile because reads are gated on the
-            // stamp rather than on what the cache holds.
-            Ok(true) => {
+            // because purging a large keyspace costs far more than a blocktime.
+            //
+            // Mirroring stops until that rebuild is done. The purge would sweep
+            // most of what this wrote anyway, and a successful write renews the
+            // lease, which would put the stale keys the purge has not reached
+            // yet straight back into service.
+            Ok(redis_coherence::CacheStatus::Condemned) => {
                 metrics.redis_cache_condemned();
                 let rebuilding = redis.clone();
                 let rebuild_metrics = Arc::clone(metrics);
@@ -748,21 +756,28 @@ async fn settle_transactions(
                         }
                     }
                 });
-                true
+                false
             }
-            Ok(false) => true,
             // Whether a batch was missed is now unknown, so this write must not
             // happen: it would advance the cached tip over any gap that does
             // exist, erasing the only evidence of it. Skipping leaves the tip
             // where it is, so the next check that succeeds still sees the gap.
+            //
+            // Blocks keep being produced either way, so the cache has to stop
+            // being served now rather than whenever its lease runs out. This
+            // often fails too, since the check just failed against the same
+            // Redis, and the lease is what covers that.
             Err(e) => {
                 warn!("Skipping the Redis cache write, continuity unknown: {}", e);
+                if let Err(e) = redis_coherence::clear_deployment_id(redis).await {
+                    warn!("Could not take the Redis cache out of service: {}", e);
+                }
                 false
             }
         };
 
-        if mirror {
-            if let Err(e) = crate::accounts::write_batch::write_batch_redis(
+        if may_mirror {
+            match crate::accounts::write_batch::write_batch_redis(
                 redis,
                 &accounts_vec,
                 transactions_for_db,
@@ -770,16 +785,30 @@ async fn settle_transactions(
             )
             .await
             {
-                warn!(
-                    "Best-effort Redis cache write failed (non-fatal, Postgres succeeded): {}",
-                    e
-                );
-                metrics.redis_cache_write_failed();
-                // The account keys this batch should have updated still hold
-                // pre-batch balances. Drop them now so reads miss and resolve
-                // against Postgres, rather than waiting for the next batch to
-                // notice the tip did not advance and rebuild the whole cache.
-                crate::accounts::write_batch::invalidate_batch_redis(redis, &accounts_vec).await;
+                // Renewing only on a mirrored batch is what ties trust to
+                // maintenance: a writer that stops mirroring stops extending the
+                // lease, whether or not it is still able to reach Redis to say
+                // so.
+                Ok(()) => {
+                    if let Err(e) =
+                        redis_coherence::stamp_deployment_id(redis, redis.deployment_id()).await
+                    {
+                        warn!("Failed to renew the Redis cache lease: {}", e);
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Best-effort Redis cache write failed (non-fatal, Postgres succeeded): {}",
+                        e
+                    );
+                    metrics.redis_cache_write_failed();
+                    // The account keys this batch should have updated still hold
+                    // pre-batch balances. Drop them now so reads miss and resolve
+                    // against Postgres, rather than waiting for the next batch to
+                    // notice the tip did not advance and rebuild the whole cache.
+                    crate::accounts::write_batch::invalidate_batch_redis(redis, &accounts_vec)
+                        .await;
+                }
             }
         }
     }
@@ -2550,6 +2579,122 @@ mod tests {
             }
         }
         assert_eq!(survivors, 0, "the purge must walk the whole keyspace");
+    }
+
+    /// Mirroring a batch is what proves the cache is being maintained, so it has
+    /// to extend the lease. A settler that mirrored without renewing would let a
+    /// perfectly healthy cache lapse and send every read to Postgres.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_renews_the_cache_lease_after_mirroring() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let stamp_key = redis_coherence::DEPLOYMENT_ID_KEY;
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
+
+        // One slot behind the batch below, so continuity holds and the mirror
+        // actually runs.
+        let last_slot = 200u64;
+        let mut conn = redis_raw.connection.clone();
+        let _: () = conn.set("latest_slot", last_slot).await.unwrap();
+
+        // Stands in for a lease most of the way through its life, so a renewal
+        // shows up as the TTL climbing back rather than as a value we have to
+        // wait out.
+        let shortened_lease_secs = 5i64;
+        let _: () = conn
+            .pexpire(stamp_key, shortened_lease_secs * 1000)
+            .await
+            .unwrap();
+
+        let from = Keypair::new();
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 100);
+        let executed = make_executed(vec![(
+            Pubkey::new_unique(),
+            AccountSharedData::new(500, 0, &Pubkey::new_unique()),
+        )]);
+        settle_transactions(
+            Some(LastBlock {
+                slot: last_slot,
+                blockhash: Hash::new_unique(),
+            }),
+            &mut pg_db,
+            Some(&mut redis_raw),
+            &[(Ok(executed), tx)],
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ttl: i64 = conn.ttl(stamp_key).await.unwrap();
+        assert!(
+            ttl > shortened_lease_secs,
+            "a mirrored batch must renew the lease, got TTL {ttl}"
+        );
+    }
+
+    /// A cached tip that will not parse leaves the settler unable to tell whether
+    /// batches were missed, and this is the case where Redis is perfectly
+    /// reachable while the check still fails. Blocks keep being produced either
+    /// way, so the cache has to stop being served immediately rather than when
+    /// its lease eventually runs out.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_unstamps_a_cache_whose_continuity_cannot_be_checked() {
+        let (mut pg_db, _pg) = start_test_postgres().await;
+        let AccountsDB::Postgres(ref postgres_db) = pg_db else {
+            panic!("Expected Postgres variant")
+        };
+        let postgres_db = postgres_db.clone();
+        let (mut redis_raw, _redis) = start_test_redis(postgres_db.clone()).await;
+
+        let stamp_key = redis_coherence::DEPLOYMENT_ID_KEY;
+        let deployment_id = redis_coherence::read_deployment_id(&postgres_db)
+            .await
+            .unwrap();
+        redis_coherence::stamp_deployment_id(&redis_raw, &deployment_id)
+            .await
+            .unwrap();
+
+        // The tip is read as a u64, so a value that is not one fails the check
+        // without Redis being down.
+        let mut conn = redis_raw.connection.clone();
+        let _: () = conn.set("latest_slot", "not-a-slot").await.unwrap();
+
+        let from = Keypair::new();
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 100);
+        let executed = make_executed(vec![(
+            Pubkey::new_unique(),
+            AccountSharedData::new(500, 0, &Pubkey::new_unique()),
+        )]);
+        settle_transactions(
+            Some(LastBlock {
+                slot: 200,
+                blockhash: Hash::new_unique(),
+            }),
+            &mut pg_db,
+            Some(&mut redis_raw),
+            &[(Ok(executed), tx)],
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let stamped: Option<Vec<u8>> = conn.get(stamp_key).await.unwrap();
+        assert_eq!(
+            stamped, None,
+            "a cache whose continuity cannot be checked must stop being served"
+        );
     }
 
     /// Settling a batch far ahead of the cached tip is what an outage looks like

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -152,8 +152,17 @@ pub(crate) async fn start_test_postgres_with_new_instance() -> (
 
 /// Spin up a throwaway Redis container and return a `RedisAccountsDB` directly.
 /// Use this when testing `RedisAccountsDB`-specific methods or warm_redis_cache.
+///
+/// `fallback` is the Postgres source of truth the cache resolves misses
+/// against, so callers need a Postgres container too.
+///
+/// The cache comes back unstamped, which means reads bypass it entirely. A test
+/// that seeds keys directly and expects them to be served must stamp it first
+/// with `redis_coherence::stamp_deployment_id`.
 #[cfg(test)]
-pub(crate) async fn start_test_redis() -> (
+pub(crate) async fn start_test_redis(
+    fallback: crate::accounts::PostgresAccountsDB,
+) -> (
     crate::accounts::RedisAccountsDB,
     testcontainers::ContainerAsync<testcontainers_modules::redis::Redis>,
 ) {
@@ -167,7 +176,9 @@ pub(crate) async fn start_test_redis() -> (
     let host = container.get_host().await.unwrap();
     let port = container.get_host_port_ipv4(6379).await.unwrap();
     let url = format!("redis://{}:{}", host, port);
-    let db = crate::accounts::RedisAccountsDB::new(&url).await.unwrap();
+    let db = crate::accounts::RedisAccountsDB::new(&url, fallback)
+        .await
+        .unwrap();
     (db, container)
 }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -26,7 +26,8 @@ Reference for configuring, tuning, and operating Solana Private Channels service
 | `--blocktime-ms` | `PRIVATE_CHANNEL_BLOCKTIME_MS` | `100` | Settlement interval (ms) |
 | `--transaction-expiration-ms` | `PRIVATE_CHANNEL_TRANSACTION_EXPIRATION_MS` | `15000` | Transaction lifetime before dedup eviction |
 | `--admin-keys` | `PRIVATE_CHANNEL_ADMIN_KEYS` | — | Comma-separated base58 channel admin pubkeys, gating SPL `InitializeMint`. Not the escrow `Instance.admin`, which is a separate offline key |
-| `--accountsdb-connection-url` | `PRIVATE_CHANNEL_ACCOUNTSDB_CONNECTION_URL` | — | PostgreSQL connection string |
+| `--accountsdb-connection-url` | `PRIVATE_CHANNEL_ACCOUNTSDB_CONNECTION_URL` | — | PostgreSQL connection string. Must be PostgreSQL: Redis is a cache, never the accounts database |
+| `--redis-cache-url` | `PRIVATE_CHANNEL_REDIS_CACHE_URL` | — | Optional Redis cache in front of the read path. Misses resolve against PostgreSQL |
 | `--log-level` | `PRIVATE_CHANNEL_LOG_LEVEL` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error` |
 | `--json-logs` | `PRIVATE_CHANNEL_JSON_LOGS` | `false` | Structured JSON log output |
 | `--perf-sample-period-secs` | `PRIVATE_CHANNEL_PERF_SAMPLE_PERIOD_SECS` | `60` | Performance metrics sampling interval |
@@ -105,7 +106,9 @@ On restart, the write node recovers state from PostgreSQL before accepting trans
 
 2. **Settlement state**: Queries `latest_slot` and `latest_blockhash` from the database to resume block production from the correct point.
 
-3. **Redis cache warming** (optional): If `REDIS_URL` is configured, preloads the latest account state from PostgreSQL into Redis on startup.
+3. **Redis cache alignment** (optional): If `--redis-cache-url` is configured, checks that the cache belongs to this ledger before the first write to it. The same flag wires the read path, so a writer cannot stop mirroring a cache that readers still trust. Each PostgreSQL database is stamped with a `deployment_id` at creation and the cache carries a copy; a cache naming a different deployment, or whose tip does not match PostgreSQL exactly, is emptied. The chain tip is then published and the cache stamped. Account, block and transaction state is not preloaded: a key missing from the cache is a miss that resolves against PostgreSQL. The two node roles differ on failure: a write node that cannot verify the cache drops it and runs PostgreSQL-only rather than writing a second ledger into it, while a read node refuses to start, because it cannot purge the cache itself and has no business serving what it found.
+
+   The same stamp governs the cache while the node runs. Every cached read checks it, so clearing it takes the cache out of service on the next read. If a settled batch fails to reach the cache, the cached tip stops advancing; the next batch notices, clears the stamp and rebuilds the cache in the background, after which it is stamped again and serves normally. A cache purged on every startup usually means two deployments sharing one Redis instance. `private_channel_redis_cache_purged_total` is the signal.
 
 The write node does not use a WAL — all state is deterministically recoverable from the PostgreSQL block history.
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -129,10 +129,12 @@ Intercepts rent collection to prevent the runtime from debiting lamports from sy
 
 ### Stage 5: Settler
 
-Batches execution results every 100ms (configurable) and commits to your configured database (e.g., PostgreSQL, Redis). The settler writes:
+Batches execution results every 100ms (configurable) and commits to PostgreSQL, the source of truth, mirroring each batch to the Redis cache if one is configured. The settler writes:
 - Modified accounts
 - Transaction records
 - Block metadata (slot, blockhash, timestamp)
+
+The mirror is best-effort and covers only what the cache can serve: point lookups by pubkey, signature and slot, plus the chain tip. Ranges, history and counters are read from PostgreSQL, because a short answer from a partial mirror is indistinguishable from a complete one. A failed cache write drops the keys it would have updated so reads miss and resolve against PostgreSQL, and leaves the cached tip behind, which makes the next batch rebuild the cache.
 
 Finally, the settler notifies the executor's in-memory cache (BOB) of settled accounts, completing the feedback loop.
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -188,12 +188,12 @@ integration-coverage-private-channel:
 	@# Kept in sync with the integration-test group; runs the backpressure CI guards (RSS test stays #[ignore]).
 	@cargo llvm-cov test --no-report --workspace --test ingress_backpressure -- --nocapture
 
-# Redis-backend warm-cache + read-path coverage.
-# Runs a Postgres+Redis node and a Redis-only node to exercise settle.rs's
-# `REDIS_URL`/best-effort-write branches and the
-# `get_signatures_for_address_redis` dispatch arm. Runs independently of the
-# main private_channel_integration suite — its profraw aggregates into the same
-# `cargo llvm-cov report` output, so coverage accumulates naturally.
+# Redis cache coverage.
+# Runs Postgres+Redis nodes to cover the settle worker's cache setup, the
+# per-block cache write, the startup alignment, and the read path falling back
+# to Postgres. Runs on its own, apart from the main private_channel_integration
+# suite. Its coverage data merges into the same report, so running it separately
+# loses nothing.
 # CI should invoke this target in parallel with (or immediately after)
 # `integration-coverage-private-channel`.
 integration-coverage-private-channel-redis:

--- a/integration/tests/indexer/helpers/private_channel_node.rs
+++ b/integration/tests/indexer/helpers/private_channel_node.rs
@@ -86,6 +86,7 @@ pub async fn start_private_channel_node(
             private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 4,
         accountsdb_connection_url,
+        redis_cache_url: None,
         admin_keys: vec![admin_pubkey],
         transaction_expiration_ms: 15000,
         blocktime_ms: 100,

--- a/integration/tests/private-channel/integration.rs
+++ b/integration/tests/private-channel/integration.rs
@@ -258,6 +258,7 @@ async fn setup(accountsdb_connection_url: String) -> Result<TestContext> {
             private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 4,
         accountsdb_connection_url: accountsdb_connection_url.clone(),
+        redis_cache_url: None,
         admin_keys: vec![operator_key.pubkey()],
         transaction_expiration_ms: 15000,
         blocktime_ms: 100,

--- a/integration/tests/private-channel/integration.rs
+++ b/integration/tests/private-channel/integration.rs
@@ -81,7 +81,7 @@ async fn test_with_postgres() {
             node_host, node_port
         );
 
-        let test_context = setup(node_db_url.clone()).await.unwrap();
+        let test_context = setup(node_db_url.clone(), None).await.unwrap();
         test_suite(&test_context.private_channel_ctx, &test_context.solana_ctx).await;
         shutdown(test_context).await;
 
@@ -118,7 +118,7 @@ async fn test_signature_statuses_only_with_postgres() {
             node_host, node_port
         );
 
-        let test_context = setup(node_db_url).await.unwrap();
+        let test_context = setup(node_db_url, None).await.unwrap();
         run_get_signature_statuses_test(&test_context.private_channel_ctx).await;
         shutdown(test_context).await;
     })
@@ -131,7 +131,30 @@ async fn test_with_redis() {
     init_tracing();
 
     tokio::time::timeout(TEST_TIMEOUT, async {
-        // Start Redis container for private_channel accountsdb
+        // Redis is a cache in front of Postgres, never the accounts database, so
+        // the node needs both: the source of truth a cache miss resolves against,
+        // and the cache itself.
+        let node_postgres_container = Postgres::default()
+            .with_db_name("private_channel_node")
+            .with_user("postgres")
+            .with_password("password")
+            .start()
+            .await
+            .expect("Failed to start node PostgreSQL container");
+
+        let node_host = node_postgres_container
+            .get_host()
+            .await
+            .expect("Failed to get node host");
+        let node_port = node_postgres_container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get node port");
+        let node_db_url = format!(
+            "postgres://postgres:password@{}:{}/private_channel_node",
+            node_host, node_port
+        );
+
         let redis_container = Redis::default()
             .with_tag("7")
             .start()
@@ -150,7 +173,7 @@ async fn test_with_redis() {
 
         println!("Redis container started at: {}", redis_url);
 
-        let test_context = setup(redis_url).await.unwrap();
+        let test_context = setup(node_db_url, Some(redis_url)).await.unwrap();
         test_suite(&test_context.private_channel_ctx, &test_context.solana_ctx).await;
 
         shutdown(test_context).await;
@@ -163,7 +186,10 @@ async fn test_with_redis() {
 ///   1. Validator + both Postgres containers  (all independent)
 ///   2. Both indexers              (each has its own DB and datasource)
 ///   3. Both operators             (independent of each other)
-async fn setup(accountsdb_connection_url: String) -> Result<TestContext> {
+async fn setup(
+    accountsdb_connection_url: String,
+    redis_cache_url: Option<String>,
+) -> Result<TestContext> {
     // Acquire global setup lock to serialize test initialization.
     // With nextest each test runs in its own process so this never blocks across
     // tests; it only guards against concurrent calls within the same process.
@@ -258,7 +284,7 @@ async fn setup(accountsdb_connection_url: String) -> Result<TestContext> {
             private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 4,
         accountsdb_connection_url: accountsdb_connection_url.clone(),
-        redis_cache_url: None,
+        redis_cache_url,
         admin_keys: vec![operator_key.pubkey()],
         transaction_expiration_ms: 15000,
         blocktime_ms: 100,

--- a/integration/tests/private-channel/rpc/test_dedup_persistence.rs
+++ b/integration/tests/private-channel/rpc/test_dedup_persistence.rs
@@ -54,6 +54,7 @@ pub async fn run_dedup_persistence_test(db_url: String) {
             private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 4,
         accountsdb_connection_url: db_url,
+        redis_cache_url: None,
         admin_keys: vec![operator.pubkey()],
         transaction_expiration_ms: 15_000,
         blocktime_ms: 100,

--- a/integration/tests/private-channel/rpc/test_redis_cache_path.rs
+++ b/integration/tests/private-channel/rpc/test_redis_cache_path.rs
@@ -1,29 +1,31 @@
-//! Redis warm-cache + settle-write coverage test.
+//! Redis cache-alignment + settle-write coverage test.
 //!
-//! This standalone test exercises four regions by
-//! running a minimal PrivateChannel node with a Postgres `accountsdb_connection_url`
-//! **and** `REDIS_URL` set to a testcontainers-provided Redis instance.
-//! This is the only configuration that fires the hybrid path in
+//! Runs a minimal PrivateChannel node with a Postgres `accountsdb_connection_url`
+//! **and** `redis_cache_url` pointed at a testcontainers-provided Redis instance.
+//! That is the configuration which fires the cache path in
 //! `core/src/stages/settle.rs`:
 //!
-//! * The Redis init block in the settle worker (reads `REDIS_URL`, constructs
-//!   `Option<RedisAccountsDB>`).
+//! * The Redis init block in the settle worker.
+//! * The startup cache alignment against Postgres.
 //! * The best-effort Redis write on each settled batch.
 //!
-//! A second sub-test drives the `AccountsDB::Redis` read path with
-//! `accountsdb_connection_url=redis://...`, which exercises:
+//! The other two tests cover the read side end to end: a read node refusing to
+//! start against a cache stamped for another deployment, and a node answering
+//! reads whose key families are never mirrored, which only the Postgres fallback
+//! can do.
 //!
-//! * The `hex_to_b58` helper in `accounts/get_signatures_for_address`.
-//! * `get_signatures_for_address_redis` (the Redis backend dispatch arm).
+//! Redis as the accounts database itself is rejected at startup, so there is no
+//! Redis-only variant to cover here; see `accounts::traits` for that.
 //!
 //! This file is intentionally standalone (its own `[[test]]` target) so that
 //! it runs independently of the broader `private_channel_integration` suite.
 
 use anyhow::Result;
+use private_channel_core::accounts::postgres::PostgresAccountsDB;
 use private_channel_core::nodes::node::{run_node, NodeConfig, NodeMode};
 use private_channel_core::stage_metrics::NoopMetrics;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer};
+use solana_sdk::{signature::Keypair, signer::Signer};
 use std::{net::TcpListener, sync::Arc, time::Duration};
 use testcontainers::{runners::AsyncRunner, ImageExt};
 use testcontainers_modules::{postgres::Postgres, redis::Redis};
@@ -58,6 +60,7 @@ fn minimal_node_config(accountsdb_connection_url: String, port: u16) -> NodeConf
             private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 2,
         accountsdb_connection_url,
+        redis_cache_url: None,
         admin_keys: vec![dummy_admin],
         transaction_expiration_ms: 15000,
         blocktime_ms: 100,
@@ -79,12 +82,12 @@ async fn wait_for_first_block(url: &str) {
     panic!("node never produced a block at {url}");
 }
 
-/// Exercise the settle worker's Redis init block + the per-batch
-/// best-effort Redis write by running a Postgres-backed node with
-/// `REDIS_URL` pointed at a live Redis testcontainer. The settle worker will
-/// warm the cache on startup and attempt the Redis write on every block.
+/// Exercise the settle worker's Redis init block + the per-batch best-effort
+/// Redis write by running a Postgres-backed node with `redis_cache_url` pointed
+/// at a live Redis testcontainer. The settle worker aligns the cache on startup
+/// and attempts the Redis write on every block.
 #[tokio::test(flavor = "multi_thread")]
-async fn settle_worker_uses_redis_warm_cache_when_env_set() -> Result<()> {
+async fn settle_worker_mirrors_to_the_configured_redis_cache() -> Result<()> {
     // 1. Start Postgres (primary accountsdb).
     let pg = Postgres::default()
         .with_db_name("private_channel_node")
@@ -97,9 +100,8 @@ async fn settle_worker_uses_redis_warm_cache_when_env_set() -> Result<()> {
     let pg_port = pg.get_host_port_ipv4(5432).await.expect("pg port");
     let pg_url = format!("postgres://postgres:password@{pg_host}:{pg_port}/private_channel_node");
 
-    // 2. Start Redis (optional warm cache).
-    // Pin Redis 7 — the default image tag is 5.0 which lacks the
-    // `ZRANGE ... BYSCORE REV LIMIT` syntax used by the backend helper.
+    // 2. Start Redis (optional cache). Pin Redis 7, the default image tag is
+    // 5.0 and predates commands this path relies on.
     let redis = Redis::default()
         .with_tag("7")
         .start()
@@ -109,30 +111,19 @@ async fn settle_worker_uses_redis_warm_cache_when_env_set() -> Result<()> {
     let redis_port = redis.get_host_port_ipv4(6379).await.expect("redis port");
     let redis_url = format!("redis://{redis_host}:{redis_port}");
 
-    // 3. Set REDIS_URL so the settle worker's env-var branch fires. We keep
-    //    this set for the duration of the test and rely on process isolation
-    //    (nextest runs each test in its own process) so we don't clobber any
-    //    parallel test.
-    //
-    //    SAFETY: env mutation in a test — nextest process isolation keeps this
-    //    confined. Wrapped in `unsafe` for Rust 2024/recent std semantics.
-    // We use the older API here for compatibility with the project's Rust
-    // edition (2021) — `set_var` is still safe to call in single-threaded
-    // test startup.
-    std::env::set_var("REDIS_URL", &redis_url);
-
-    // 4. Start the node pointed at Postgres.
+    // 3. Start the node pointed at Postgres, with the cache configured.
     let port = get_free_port();
-    let config = minimal_node_config(pg_url.clone(), port);
+    let mut config = minimal_node_config(pg_url.clone(), port);
+    config.redis_cache_url = Some(redis_url.clone());
     let handles = run_node(config).await.expect("run_node");
     let url = format!("http://127.0.0.1:{port}");
 
-    // 5. Wait for the settle worker to produce at least one block. This
+    // 4. Wait for the settle worker to produce at least one block. This
     //    guarantees both the Redis init branch and the per-batch Redis
     //    write branch were taken.
     wait_for_first_block(&url).await;
 
-    // 6. Issue a handful of `getLatestBlockhash` calls to ensure multiple
+    // 5. Issue a handful of `getLatestBlockhash` calls to ensure multiple
     //    settle cycles run and the Redis best-effort write path is hit
     //    repeatedly.
     let client = RpcClient::new(url.clone());
@@ -144,10 +135,9 @@ async fn settle_worker_uses_redis_warm_cache_when_env_set() -> Result<()> {
         sleep(Duration::from_millis(150)).await;
     }
 
-    // 7. Sanity-probe Redis itself — the warm cache must have published
-    //    `latest_slot` at least once (set by `warm_redis_cache`). This is a
-    //    direct assertion that the REDIS_URL branch actually produced
-    //    observable side-effects, not just compiled code.
+    // 6. Sanity-probe Redis itself: the cache must have published `latest_slot`
+    //    at least once. Direct evidence the configured cache produced
+    //    observable side effects, not just compiled code.
     let redis_client = redis::Client::open(redis_url.as_str()).expect("redis client");
     let mut conn = redis_client
         .get_multiplexed_async_connection()
@@ -174,21 +164,29 @@ async fn settle_worker_uses_redis_warm_cache_when_env_set() -> Result<()> {
     );
 
     handles.shutdown().await;
-    std::env::remove_var("REDIS_URL");
     Ok(())
 }
 
-/// Exercise `hex_to_b58` and `get_signatures_for_address_redis`
-/// by running a node with `accountsdb_connection_url=redis://...` and issuing
-/// a `getSignaturesForAddress` RPC. With no indexed signatures the response
-/// is an empty list, but that still dispatches through the Redis-backend arm
-/// and through the `ZRANGE ... BYSCORE REV` query — enough to cover the
-/// entry point and the empty-result early-return branch.
+/// A read node must refuse to start against a cache carrying another ledger's
+/// deployment stamp. Only the write node aligns and purges the cache; a read node
+/// that finds foreign state can only decline to serve it, because serving it is
+/// exactly the harm the stamp exists to prevent.
+///
+/// Read mode on purpose. An Aio node runs a settler, which now shares the cache
+/// URL and would purge the foreign stamp before the read path ever inspected it.
 #[tokio::test(flavor = "multi_thread")]
-async fn get_signatures_for_address_dispatches_to_redis_backend() -> Result<()> {
-    // Start Redis (used as the sole accountsdb).
-    // Pin Redis 7 — the default image tag is 5.0 which lacks the
-    // `ZRANGE ... BYSCORE REV LIMIT` syntax used by the backend helper.
+async fn read_node_refuses_a_cache_from_another_deployment() -> Result<()> {
+    let pg = Postgres::default()
+        .with_db_name("private_channel_node")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("start postgres");
+    let pg_host = pg.get_host().await.expect("pg host");
+    let pg_port = pg.get_host_port_ipv4(5432).await.expect("pg port");
+    let pg_url = format!("postgres://postgres:password@{pg_host}:{pg_port}/private_channel_node");
+
     let redis = Redis::default()
         .with_tag("7")
         .start()
@@ -198,67 +196,121 @@ async fn get_signatures_for_address_dispatches_to_redis_backend() -> Result<()> 
     let redis_port = redis.get_host_port_ipv4(6379).await.expect("redis port");
     let redis_url = format!("redis://{redis_host}:{redis_port}");
 
-    // Make sure REDIS_URL is NOT set — we're exercising the
-    // `AccountsDB::Redis` read-path branch, not the Postgres+Redis hybrid.
-    std::env::remove_var("REDIS_URL");
-
-    let port = get_free_port();
-    let config = minimal_node_config(redis_url.clone(), port);
-    let handles = run_node(config).await.expect("run_node");
-    let url = format!("http://127.0.0.1:{port}");
-
-    // Wait for the node to be ready.
-    wait_for_first_block(&url).await;
-
-    // Ask for signatures on an arbitrary address — routes through
-    // `AccountsDB::Redis` → `get_signatures_for_address_redis`. With no
-    // indexed transactions, the query must return an empty vec. This
-    // dispatches into the `ZRANGE` call and exits via the
-    // `if sig_strings.is_empty()` early-return branch of
-    // `get_signatures_for_address_redis`.
-    let client = RpcClient::new(url);
-    let arbitrary = Pubkey::new_unique();
-    let sigs = client
-        .get_signatures_for_address(&arbitrary)
+    // A read node never creates the schema, so mint it here as a write node
+    // would. Without it the node fails on a missing deployment id instead of on
+    // the foreign stamp this test is about.
+    PostgresAccountsDB::new(&pg_url, false)
         .await
-        .expect("getSignaturesForAddress");
-    assert!(
-        sigs.is_empty(),
-        "fresh Redis backend must return empty signature list, got {} entries",
-        sigs.len()
-    );
+        .expect("initialize schema");
 
-    // Seed a couple of fake entries in `addr_sigs:{pubkey}` so the
-    // non-empty-result branch (which calls `hex_to_b58` + `MGET`) is
-    // also exercised. A valid blob is required because the helper
-    // deserializes `StoredTransaction` and returns `Err` on corruption.
-    // Rather than fabricate a valid blob, we insert entries with no
-    // matching `tx:{sig}` and expect the helper to return a `Transaction
-    // data missing` error — that still traverses the `hex_to_b58` loop
-    // plus MGET, hitting `hex_to_b58` and the `missing blob` error arm
-    // inside `get_signatures_for_address_redis`.
     use redis::AsyncCommands;
     let redis_client = redis::Client::open(redis_url.as_str()).expect("redis client");
     let mut conn = redis_client
         .get_multiplexed_async_connection()
         .await
         .expect("redis conn");
-    let key = format!("addr_sigs:{arbitrary}");
-    // 64-byte dummy signature, hex-encoded. Score = slot = 1.
-    let dummy_sig_hex = "00".repeat(64);
     let _: () = conn
-        .zadd(&key, &dummy_sig_hex, 1i64)
+        .set("deployment_id", &[9u8; 16][..])
         .await
-        .expect("zadd dummy sig");
+        .expect("stamp a foreign deployment");
+    let _: () = conn
+        .set(
+            format!("account:{}", Keypair::new().pubkey()),
+            vec![1u8, 2, 3],
+        )
+        .await
+        .expect("seed foreign ledger state");
 
-    let result = client.get_signatures_for_address(&arbitrary).await;
-    // `get_signatures_for_address_redis` returns `Err("Transaction data
-    // missing...")` when the `tx:{sig}` key is absent, and the RPC handler
-    // propagates it via `?` — so the client must always see an error here.
+    let port = get_free_port();
+    let mut config = minimal_node_config(pg_url.clone(), port);
+    config.mode = NodeMode::Read;
+    config.redis_cache_url = Some(redis_url.clone());
+    let result = run_node(config).await;
+
+    let error = result.err().expect("node must refuse the foreign cache");
+    let message = format!("{error:#}");
+    // The exact mismatch, not just the word "deployment", which a missing
+    // deployment id would also produce.
     assert!(
-        result.is_err(),
-        "Redis backend must return an error for a missing tx blob, got Ok({:?})",
-        result.ok()
+        message.contains("belongs to deployment"),
+        "error should name the deployment mismatch, got: {message}"
+    );
+    Ok(())
+}
+
+/// Drive the read path through a configured Redis cache.
+///
+/// Every read below is from a family the cache never holds: ranges, address
+/// history and counters are not mirrored, because a short answer from a partial
+/// mirror cannot be told from a complete one. They can only be answered by
+/// Postgres, which makes this the end-to-end proof that the cache sits in front
+/// of the source of truth rather than in place of it.
+///
+/// One `redis_cache_url` drives both paths, so the tail also asserts the settler
+/// mirrored to the same instance the read path attached to.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_path_serves_through_a_redis_cache() -> Result<()> {
+    let pg = Postgres::default()
+        .with_db_name("private_channel_node")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("start postgres");
+    let pg_host = pg.get_host().await.expect("pg host");
+    let pg_port = pg.get_host_port_ipv4(5432).await.expect("pg port");
+    let pg_url = format!("postgres://postgres:password@{pg_host}:{pg_port}/private_channel_node");
+
+    let redis = Redis::default()
+        .with_tag("7")
+        .start()
+        .await
+        .expect("start redis");
+    let redis_host = redis.get_host().await.expect("redis host");
+    let redis_port = redis.get_host_port_ipv4(6379).await.expect("redis port");
+    let redis_url = format!("redis://{redis_host}:{redis_port}");
+
+    let port = get_free_port();
+    let mut config = minimal_node_config(pg_url.clone(), port);
+    config.redis_cache_url = Some(redis_url.clone());
+    let handles = run_node(config).await.expect("run_node");
+    let url = format!("http://127.0.0.1:{port}");
+
+    wait_for_first_block(&url).await;
+
+    // Each of these reads goes through AccountsDB::Redis. None of their key
+    // families is mirrored, so every one is resolved by the Postgres fallback.
+    let client = RpcClient::new(url.clone());
+    client
+        .get_latest_blockhash()
+        .await
+        .expect("getLatestBlockhash through the cache");
+    let slot = client.get_slot().await.expect("getSlot");
+    client
+        .get_blocks(0, Some(slot))
+        .await
+        .expect("getBlocks through the cache");
+    client
+        .get_transaction_count()
+        .await
+        .expect("getTransactionCount through the cache");
+    client
+        .get_signatures_for_address(&Keypair::new().pubkey())
+        .await
+        .expect("getSignaturesForAddress through the cache");
+
+    // One knob drives both paths, so the settler must have mirrored to the same
+    // instance the read path attached to.
+    use redis::AsyncCommands;
+    let redis_client = redis::Client::open(redis_url.as_str()).expect("redis client");
+    let mut conn = redis_client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("redis conn");
+    let cached_slot: Option<u64> = conn.get("latest_slot").await.expect("redis get");
+    assert!(
+        cached_slot.is_some(),
+        "the settler must mirror to the cache the read path uses"
     );
 
     handles.shutdown().await;

--- a/integration/tests/private-channel/test_ingress_backpressure.rs
+++ b/integration/tests/private-channel/test_ingress_backpressure.rs
@@ -58,6 +58,7 @@ fn load_config(db_url: String, port: u16, prometheus: bool) -> NodeConfig {
         execution_results_capacity: RESULTS_CAP,
         max_svm_workers: 2,
         accountsdb_connection_url: db_url,
+        redis_cache_url: None,
         admin_keys: vec![],
         transaction_expiration_ms: 15_000,
         blocktime_ms: 100,

--- a/integration/tests/private-channel/test_node_config_validation.rs
+++ b/integration/tests/private-channel/test_node_config_validation.rs
@@ -34,6 +34,7 @@ fn base_config(mode: NodeMode) -> NodeConfig {
             private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 1,
         accountsdb_connection_url: "postgres://unused/private_channel".to_string(),
+        redis_cache_url: None,
         admin_keys: vec![Keypair::new().pubkey()],
         transaction_expiration_ms: 1_000,
         blocktime_ms: 100,


### PR DESCRIPTION
Redis was a selectable accounts backend. It is now a read-through cache with Postgres behind it, and it can no longer be selected as the source of truth.

## issue-178: cached misses read as authoritative absence

Fixed by removing the premise rather than extending the warmup.

  Every `RedisAccountsDB` carries the `PostgresAccountsDB` it sits in front of, so a key the cache cannot answer is resolved instead of reported missing.

  - Point lookups (account, transaction, block, chain tip) treat absent, unreadable or undecodable entries as a miss and fall through to Postgres.
  - Reads that cannot express a miss go to Postgres directly: `getBlocks`, `getBlocksWithLimit`, `getFirstAvailableBlock`, `getSignaturesForAddress`, `getTransactionCount`, `getEpochInfo`, `getRecentPerformanceSamples`, plus the internal `get_blocks_in_range` that feeds the dedup rebuild. A truncated range or history is indistinguishable from a complete one, which is what let a streamer skip finalized blocks.
  - `write_batch_redis` stopped writing `addr_sigs:`, `block_slot_index` and the transaction counter, since nothing reads them from the cache any more.
  - `AccountsDB::new` rejects `redis://`. A caching node passes the Postgres URL and configures Redis separately.

## issue-179: a reused Redis served a previous ledger

Each Postgres database mints a `deployment_id` into `metadata` at schema creation. The cache carries a copy, written only once the cache is known coherent.

  - At startup `warm_redis_cache` purges on a foreign stamp, ledger keys with no stamp, an empty Postgres, or any tip mismatch. The stamp is cleared before the purge, so an interrupted purge leaves the cache unstamped rather than falsely valid.
  - Every cached read checks the stamp in the same `MGET` that fetches the value, so clearing it takes the cache out of service on the next read, with no restart and no window.
  - While the settler runs, `ensure_cache_continuity` checks before each mirror that the cached tip is exactly one slot back. A gap means batches were missed, so the stamp is cleared and a rebuild runs off the block production path.
  - A read node verifies the stamp at startup and refuses to serve a cache stamped for another deployment.

## Also fixed

  - One `--redis-cache-url` wires both the settler and the read path. The settler previously read a separate `REDIS_URL`, so a writer could stop mirroring a cache that readers still trusted.
  - A cached block or transaction that fails to decode falls through to Postgres instead of erroring permanently. The stamp tracks the database, not the build, so a field added to `BlockInfo` or `StoredTransaction` would otherwise make those slots error for as long as the entries sat there.
  - A failed tip read at settler startup no longer reads as an empty ledger. It did, and an empty ledger makes the settler restart block production from slot 0 over a live chain. Pre-existing, surfaced because that value now also authorises the cache purge.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 15,299 | 16,962 | 90.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32274014232) |
| Indexer | 36,726 | 40,337 | 91.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32274014232) |
| Gateway | 1,630 | 1,887 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32274014232) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32274014232) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,596 | 18,674 | 78.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32274014232) |
| **Total** | **69,563** | **79,366** | **87.6%** | |

> Last updated: 2026-08-19 18:43:45 UTC by E2E Integration