### PR TITLE
fix(indexer): start the transaction processor before a one-shot backfill (issue-266)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ ci-integration-test-prebuilt:
 	@echo "=== prod-feature indexer group ==="
 	@cd integration && cargo test --test reconciliation_integration -- --nocapture
 	@cd integration && cargo test --test gap_detection_integration -- --nocapture
+	@cd integration && cargo test --test backfill_only_e2e -- --nocapture
 	@cd integration && cargo test --test truncate_integration -- --nocapture
 	@cd integration && cargo test --test pausable_mint_integration -- --nocapture
 	@cd integration && cargo test --test permanent_delegate_mint_integration -- --nocapture
@@ -220,6 +221,7 @@ ci-integration-test-indexer:
 	@echo "=== prod-feature indexer group ==="
 	@cd integration && cargo test --test reconciliation_integration -- --nocapture
 	@cd integration && cargo test --test gap_detection_integration -- --nocapture
+	@cd integration && cargo test --test backfill_only_e2e -- --nocapture
 	@cd integration && cargo test --test truncate_integration -- --nocapture
 	@cd integration && cargo test --test pausable_mint_integration -- --nocapture
 	@cd integration && cargo test --test permanent_delegate_mint_integration -- --nocapture

--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -48,6 +48,47 @@ Recovers missed slots on indexer restart or network issues:
 
 **Location**: [`indexer/src/indexer/backfill.rs`](../indexer/src/indexer/backfill.rs)
 
+#### Backfill-only mode
+
+Setting `indexer.backfill.backfill_only = true` (alongside `backfill.enabled`) turns the
+indexer into a one-shot repair: it fills the resolved slot range and exits instead of
+starting a live datasource. This is the tool to run when finalized deposits or withdrawals
+are known to be missing from the database.
+
+The mode runs the same pipeline as normal indexing (backfill producer, transaction
+processor, checkpoint writer), so the rows it recovers land exactly as a live run would
+have written them: deposits enter as `pending` for the operator to service. Startup
+reconciliation is deliberately skipped, because the database is known-incomplete and
+reconciling it would block the very repair that fixes it. An escrow instance id is still
+required: without it every escrow instruction is filtered out as out of scope.
+
+The exit code is the contract:
+
+- **Exit 0** means every slot in the resolved range is durably recorded *and* the committed
+  checkpoint reached the top of that range. The checkpoint is re-read from the database
+  after the pipeline drains, so a stalled or failed checkpoint write cannot be reported as
+  success.
+- **Non-zero** means the range was not fully recorded. The checkpoint is left at the last
+  slot that was completely stored, so re-running the repair resumes from there rather than
+  redoing work that already committed.
+
+Re-running a completed repair is safe: the range is resolved from the committed checkpoint,
+and every write is idempotent, so no rows are duplicated.
+
+**The range never reaches below the committed checkpoint.** It is resolved as
+`(max(start_slot - 1, last_committed_slot), tip]`, so `backfill.start_slot` can only move
+the floor *up*. If the hole sits below the checkpoint (the indexer has since streamed past
+it), setting `start_slot` to the hole does nothing: the repair refills slots that were never
+missing and exits 0 with the hole intact. Lower the checkpoint first, then run the repair:
+
+```sql
+UPDATE indexer_state SET last_committed_slot = <slot before the hole>
+WHERE program_type = 'escrow';
+```
+
+Everything between that slot and the tip is then re-indexed. That is safe but not free, so
+pick the highest slot that still sits below the hole.
+
 ### Transaction Identity & CPI Indexing
 
 Each indexed instruction is keyed on the triple **`(signature, instruction_index, inner_index)`**:

--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -89,6 +89,15 @@ WHERE program_type = 'escrow';
 Everything between that slot and the tip is then re-indexed. That is safe but not free, so
 pick the highest slot that still sits below the hole.
 
+**Raising `start_slot` above the checkpoint is refused.** The floor would land above slots
+that were never indexed, and because the checkpoint writer is gated from that floor it would
+walk to the top of the range and commit a checkpoint over them. Nothing would go back for
+them afterwards: the next run resolves its floor from that higher checkpoint. The run stops
+with `StartSlotAheadOfCheckpoint` instead. A configured `start_slot` may set the floor only
+on a database that has never been indexed, where there is no checkpoint to skip past. If a
+skip is genuinely intended, drop the checkpoint with a destructive resync rather than
+raising the start slot.
+
 ### Transaction Identity & CPI Indexing
 
 Each indexed instruction is keyed on the triple **`(signature, instruction_index, inner_index)`**:

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -244,6 +244,13 @@ impl IndexerConfig {
             }
         }
 
+        // The one-shot repair only runs when backfill is also enabled. Without this the
+        // pair reads as a typo that starts a normal live indexer, which for a job the
+        // operator expects to exit means it silently never does.
+        if self.backfill.exit_after_backfill && !self.backfill.enabled {
+            return Err("backfill.backfill_only requires backfill.enabled to be true".to_string());
+        }
+
         Ok(())
     }
 }
@@ -523,6 +530,27 @@ mod tests {
             let result = config.validate();
             assert!(result.is_ok());
         }
+    }
+
+    /// backfill_only on its own would start a live indexer that never exits, which is the
+    /// opposite of the one-shot repair the flag names, so the pair is rejected up front.
+    #[cfg(feature = "datasource-rpc")]
+    #[test]
+    fn validate_rejects_backfill_only_without_backfill_enabled() {
+        let mut config = create_indexer_config();
+        config.backfill.enabled = false;
+        config.backfill.exit_after_backfill = true;
+
+        let err = config
+            .validate()
+            .expect_err("backfill_only without enabled must not validate");
+        assert!(
+            err.contains("backfill.enabled"),
+            "error must name the missing flag, got: {err}"
+        );
+
+        config.backfill.enabled = true;
+        assert!(config.validate().is_ok(), "the enabled pair must validate");
     }
 
     // ── operator operational commitment floor ───────────────────────────

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -36,6 +36,20 @@ pub enum IndexerError {
 
     #[error("Reconciliation failed: {0}")]
     Reconciliation(#[from] ReconciliationError),
+
+    /// A backfill-only run finished without durably recording its whole range.
+    /// `committed` is `None` when no checkpoint was ever written, which is not
+    /// the same as a checkpoint that stalled part way and must stay
+    /// distinguishable in the logs an operator reads after a failed repair.
+    #[error(
+        "backfill for {program_type} left the committed checkpoint at {committed:?}, short of \
+         target slot {target}; the range was not fully recorded"
+    )]
+    BackfillIncomplete {
+        program_type: String,
+        committed: Option<u64>,
+        target: u64,
+    },
 }
 
 /// Errors from startup reconciliation against on-chain state

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -212,4 +212,19 @@ pub enum CheckpointError {
         target: u64,
         waited_secs: u64,
     },
+
+    /// `setting` names the offending config key so the message points at the knob to
+    /// change, since the two keys that can trigger this need different remedies.
+    #[error(
+        "Configured {setting} {start_slot} is ahead of the durable checkpoint {checkpoint} \
+         for {program_type}: the slots after {checkpoint} and below {start_slot} have never \
+         been indexed and would be skipped. Lower {setting} to {checkpoint} or below, unset \
+         it, or run a destructive resync if the skip is intended."
+    )]
+    StartSlotAheadOfCheckpoint {
+        setting: &'static str,
+        program_type: String,
+        start_slot: u64,
+        checkpoint: u64,
+    },
 }

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -50,6 +50,22 @@ pub enum IndexerError {
         committed: Option<u64>,
         target: u64,
     },
+
+    /// The checkpoint writer had to be cancelled before it confirmed its final flush, so the
+    /// run cannot prove it finished even though its slots may all be stored. Kept apart from
+    /// `BackfillIncomplete` because the operator action differs: this one points at a slow or
+    /// wedged database, not at a slot the pipeline failed to record.
+    #[error(
+        "backfill for {program_type} could not confirm its checkpoint: the writer was still \
+         running after {waited_secs}s and was cancelled, leaving the durable checkpoint at \
+         {committed:?} against target {target}. Re-run the repair once the database is healthy"
+    )]
+    BackfillCheckpointUnconfirmed {
+        program_type: String,
+        committed: Option<u64>,
+        target: u64,
+        waited_secs: u64,
+    },
 }
 
 /// Errors from startup reconciliation against on-chain state

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -1,5 +1,5 @@
 use crate::config::{ProgramType, ReconciliationConfig};
-use crate::error::{DataSourceError, IndexerError, ReconciliationError};
+use crate::error::{CheckpointError, DataSourceError, IndexerError, ReconciliationError};
 use crate::{
     indexer::{
         checkpoint::{CheckpointMsg, CheckpointWriter},
@@ -21,7 +21,8 @@ use crate::{
     indexer::{
         backfill::{BackfillService, StartupRange},
         checkpoint::{
-            get_last_checkpoint, wait_for_checkpoint_commit, CHECKPOINT_COMMIT_TIMEOUT_SECS,
+            get_last_checkpoint, program_key, wait_for_checkpoint_commit,
+            CHECKPOINT_COMMIT_TIMEOUT_SECS,
         },
     },
     operator::escrow_sweep::CustodySnapshot,
@@ -269,9 +270,28 @@ async fn run_backfill_only(
     storage: Arc<Storage>,
     program_type: ProgramType,
     escrow_instance_id: Option<Pubkey>,
+    configured_start_slot: Option<u64>,
 ) -> Result<(), IndexerError> {
     // Resolve first and fail closed: with no live stream there is no ungated fallback.
     let range = backfill_service.resolve_range().await?;
+
+    // A floor above the durable checkpoint means the slots in between are outside the
+    // fill, yet the gated writer seeds its frontier at that floor and would walk it to
+    // the target, committing a checkpoint over slots nothing ever fetched. Absence of a
+    // checkpoint is the one case a configured start slot may set the floor: it is
+    // initializing a ledger, not skipping one.
+    if let Some(committed) = get_last_checkpoint(&storage, program_type).await? {
+        if range.anchor > committed {
+            return Err(IndexerError::Checkpoint(
+                CheckpointError::StartSlotAheadOfCheckpoint {
+                    setting: "indexer.backfill.start_slot",
+                    program_type: program_key(program_type),
+                    start_slot: configured_start_slot.unwrap_or(range.anchor + 1),
+                    checkpoint: committed,
+                },
+            ));
+        }
+    }
 
     let (instruction_tx, instruction_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
     let (checkpoint_tx, checkpoint_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
@@ -419,6 +439,7 @@ pub async fn run(
                 storage.clone(),
                 common_config.program_type,
                 common_config.escrow_instance_id,
+                indexer_config.backfill.start_slot,
             )
             .await;
         }
@@ -1026,6 +1047,34 @@ mod tests {
             )
         }
 
+        /// Escrow backfill service with a configured start slot, which is what pushes the
+        /// resolved floor above the durable checkpoint.
+        fn service_starting_at(
+            server: &Server,
+            storage: Arc<Storage>,
+            start_slot: u64,
+        ) -> BackfillService {
+            let poller = Arc::new(RpcPoller::new(
+                server.url(),
+                UiTransactionEncoding::Json,
+                CommitmentLevel::Finalized,
+            ));
+            BackfillService::new(
+                storage,
+                poller,
+                ProgramType::Escrow,
+                BackfillConfig {
+                    enabled: true,
+                    exit_after_backfill: true,
+                    rpc_url: server.url(),
+                    batch_size: 10,
+                    max_gap_slots: u64::MAX,
+                    start_slot: Some(start_slot),
+                },
+                None,
+            )
+        }
+
         /// Escrow checkpoint currently held by the mock store.
         fn checkpoint_of(mock: &MockStorage) -> Option<u64> {
             mock.committed_checkpoints
@@ -1033,6 +1082,84 @@ mod tests {
                 .unwrap()
                 .get("escrow")
                 .copied()
+        }
+
+        /// A start slot above the durable checkpoint would leave the slots in between
+        /// unfetched while the gated writer walked its frontier to the target, committing
+        /// a checkpoint over them. The run must refuse instead.
+        #[tokio::test]
+        async fn backfill_only_refuses_start_slot_above_checkpoint() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 6000);
+            let (mock, storage) = seeded_storage(100);
+
+            let backfill = service_starting_at(&server, storage.clone(), 5000);
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, Some(5000)).await;
+
+            let err = result.expect_err("a start slot past the checkpoint must refuse");
+            assert!(
+                matches!(
+                    err,
+                    IndexerError::Checkpoint(CheckpointError::StartSlotAheadOfCheckpoint {
+                        setting: "indexer.backfill.start_slot",
+                        start_slot: 5000,
+                        checkpoint: 100,
+                        ..
+                    })
+                ),
+                "expected a start-slot refusal naming the backfill key, got {err:?}"
+            );
+            assert_eq!(
+                checkpoint_of(&mock),
+                Some(100),
+                "a refused run must leave the checkpoint exactly where it was"
+            );
+        }
+
+        /// The one legitimate use of the knob: a ledger that has never been indexed has no
+        /// checkpoint to skip past, so the configured slot sets the floor.
+        #[tokio::test]
+        async fn backfill_only_allows_start_slot_on_an_unindexed_ledger() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 5002);
+            let _blocks = chain(
+                &mut server,
+                5000,
+                5002,
+                &[(5000, 4999), (5001, 5000), (5002, 5001)],
+            );
+            let mock = MockStorage::new();
+            let storage: Arc<Storage> = Arc::new(Storage::Mock(mock.clone()));
+
+            let backfill = service_starting_at(&server, storage.clone(), 5000);
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, Some(5000)).await;
+
+            assert!(
+                result.is_ok(),
+                "an unindexed ledger may be initialised from a configured start slot: {result:?}"
+            );
+        }
+
+        /// The floor is exclusive and the configured slot inclusive, so an ordinary restart
+        /// that passes the checkpoint back in lands exactly on it. That must not be refused.
+        #[tokio::test]
+        async fn backfill_only_allows_start_slot_resuming_at_the_checkpoint() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 102);
+            let _blocks = chain(&mut server, 101, 102, &[(101, 100), (102, 101)]);
+            let (mock, storage) = seeded_storage(100);
+
+            let backfill = service_starting_at(&server, storage.clone(), 101);
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, Some(101)).await;
+
+            assert!(
+                result.is_ok(),
+                "a start slot resolving to the checkpoint itself must not refuse: {result:?}"
+            );
+            assert_eq!(checkpoint_of(&mock), Some(102));
         }
 
         /// Every slot in the range is consumed, so the checkpoint lands on the target.
@@ -1044,7 +1171,8 @@ mod tests {
             let (mock, storage) = seeded_storage(100);
 
             let backfill = service(&server, storage.clone(), 10, 1000, None);
-            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, None).await;
 
             assert!(result.is_ok(), "clean backfill must succeed: {result:?}");
             assert_eq!(
@@ -1070,7 +1198,7 @@ mod tests {
             let backfill = service(&server, storage.clone(), 10_000, u64::MAX, None);
             let outcome = tokio::time::timeout(
                 Duration::from_secs(60),
-                run_backfill_only(backfill, storage, ProgramType::Escrow, None),
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, None),
             )
             .await;
 
@@ -1093,7 +1221,8 @@ mod tests {
 
             let instance = Some(deposit_fixture_instance());
             let backfill = service(&server, storage.clone(), 10, 1000, instance);
-            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, instance).await;
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, instance, None).await;
 
             assert!(result.is_ok(), "deposit backfill must succeed: {result:?}");
             let rows: Vec<_> = mock
@@ -1127,7 +1256,8 @@ mod tests {
             let (mock, storage) = seeded_storage(100);
 
             let backfill = service(&server, storage.clone(), 2, 1000, None);
-            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, None).await;
 
             assert!(result.is_err(), "a failed fetch must fail the run");
             assert_eq!(
@@ -1148,7 +1278,8 @@ mod tests {
             mock.set_should_fail("escrow", true);
 
             let backfill = service(&server, storage.clone(), 10, 1000, None);
-            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, None).await;
 
             match result {
                 Err(IndexerError::BackfillIncomplete {
@@ -1176,7 +1307,8 @@ mod tests {
             let (mock, storage) = seeded_storage(100);
 
             let backfill = service(&server, storage.clone(), 10, 1000, None);
-            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+            let result =
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None, None).await;
 
             assert!(result.is_ok(), "an empty range must succeed: {result:?}");
             no_blocks.assert();

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -22,11 +22,16 @@ use crate::indexer::datasource::rpc_polling::{rpc::RpcPoller, RpcPollingSource};
 #[cfg(feature = "datasource-yellowstone")]
 use crate::indexer::datasource::yellowstone::YellowstoneSource;
 use private_channel_metrics::HealthState;
+#[cfg(feature = "datasource-rpc")]
+use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
 use tokio::signal;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
+
+/// Buffer depth for both pipeline channels, shared so the two creation sites cannot drift.
+const PIPELINE_CHANNEL_CAPACITY: usize = 1000;
 
 /// Which side of the processor-vs-shutdown race fired.
 enum Supervision {
@@ -50,6 +55,93 @@ async fn supervise(
         res = &mut *processor_handle => Supervision::ProcessorEnded(res),
         sig = shutdown => Supervision::ShutdownSignalled(sig),
     }
+}
+
+/// Run a one-shot backfill and exit, with no live datasource behind it.
+///
+/// This owns the whole short-lived pipeline. The processor is the only component that
+/// writes rows and the only source of checkpoint updates, so it has to be running before
+/// the fill starts: with nothing draining the instruction channel the fill either fills
+/// the buffer and parks forever or finishes and has its whole output dropped unread.
+#[cfg(feature = "datasource-rpc")]
+async fn run_backfill_only(
+    backfill_service: BackfillService,
+    storage: Arc<Storage>,
+    program_type: ProgramType,
+    escrow_instance_id: Option<Pubkey>,
+) -> Result<(), IndexerError> {
+    // Resolve first and fail closed: with no live stream there is no ungated fallback.
+    let range = backfill_service.resolve_range().await?;
+
+    let (instruction_tx, instruction_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
+    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
+
+    // Gating to the fill range keeps a failed slot from being leapfrogged by a later one.
+    let mut checkpoint_writer = CheckpointWriter::new(storage.clone());
+    if let Some((from_slot, target)) = range.gap {
+        checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
+    }
+    let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
+    info!("CheckpointWriter service started");
+
+    let mut transaction_processor =
+        TransactionProcessor::new(storage.clone(), checkpoint_tx.clone());
+    // An unset instance scope makes the processor drop every escrow instruction.
+    if let Some(instance_id) = escrow_instance_id {
+        transaction_processor = transaction_processor.with_escrow_instance_id(instance_id);
+    }
+    // Health is deliberately left unwired. The indexer health contract demands continuous
+    // progress on a 30 second window, which fits a live stream but not a one-shot job:
+    // an ordinary slow stretch here, such as a block fetch riding out its retries, would
+    // report the process unhealthy and invite a supervisor to restart a repair that is
+    // still making progress. A run that never reports progress stays healthy instead.
+    let processor_handle = tokio::spawn(transaction_processor.start(instruction_rx));
+    info!("TransactionProcessor task spawned");
+
+    // Held, not propagated, so the drain below still runs and a partial fill keeps its slots.
+    let fill_result = match range.gap {
+        Some((from_slot, target)) => {
+            backfill_service
+                .run_range(from_slot, target, instruction_tx.clone())
+                .await
+        }
+        None => {
+            info!("No backfill gap to fill");
+            Ok(())
+        }
+    };
+
+    // Releasing the last sender is what ends the processor's receive loop.
+    drop(instruction_tx);
+    let processor_result = match processor_handle.await {
+        Ok(result) => result,
+        Err(join_err) => {
+            error!("TransactionProcessor task panicked: {:?}", join_err);
+            Err(IndexerError::ProcessorPanicked)
+        }
+    };
+
+    info!("Backfill completed, performing graceful cleanup...");
+    // The processor is joined above rather than here for a reason worth stating: it holds
+    // a clone of the checkpoint sender, so the writer cannot see its channel close while
+    // the processor is alive. Draining first would burn the full drain timeout and then
+    // flush a frontier missing every slot the processor had not finished writing yet.
+    let cleanup_result = cleanup_after_backfill(
+        checkpoint_handle,
+        checkpoint_tx,
+        storage,
+        range.gap.map(|(_, target)| (program_type, target)),
+    )
+    .await;
+
+    // Order of reporting matters because these failures cause one another. A processor
+    // that gives up on a write drops the instruction receiver, which the fill then sees
+    // as a send failure, and both leave the checkpoint short of its target. Reporting the
+    // processor first names the database error that actually started it, instead of
+    // pointing an operator at the channel or at the completeness check downstream of it.
+    processor_result?;
+    fill_result?;
+    cleanup_result
 }
 
 pub async fn run(
@@ -85,6 +177,21 @@ pub async fn run(
     // runs reconciliation because the live datasource is about to start.
     let backfill_only =
         indexer_config.backfill.enabled && indexer_config.backfill.exit_after_backfill;
+    // Checked in every mode, not just the reconciling one. The instance scope is what
+    // the processor filters escrow instructions by, and an unset scope drops all of
+    // them, so a backfill without it would record nothing while still marking the range
+    // done. Refusing to start is the only outcome that leaves the gap repairable.
+    if common_config.program_type == ProgramType::Escrow
+        && common_config.escrow_instance_id.is_none()
+    {
+        return Err(IndexerError::Reconciliation(
+            ReconciliationError::InvalidPubkey {
+                pubkey: "<missing>".to_string(),
+                reason: "escrow_instance_id is required for the escrow indexer".to_string(),
+            },
+        ));
+    }
+
     if !backfill_only {
         match (common_config.program_type, common_config.escrow_instance_id) {
             (ProgramType::Escrow, Some(seed)) => {
@@ -100,15 +207,6 @@ pub async fn run(
                 )
                 .await?;
             }
-            (ProgramType::Escrow, None) => {
-                return Err(IndexerError::Reconciliation(
-                    ReconciliationError::InvalidPubkey {
-                        pubkey: "<missing>".to_string(),
-                        reason: "escrow_instance_id is required for escrow reconciliation"
-                            .to_string(),
-                    },
-                ));
-            }
             _ => {
                 info!("Startup reconciliation skipped (non-escrow program)");
             }
@@ -118,8 +216,8 @@ pub async fn run(
     }
 
     // 3. Create channels
-    let (instruction_tx, instruction_rx) = mpsc::channel(1000);
-    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(1000);
+    let (instruction_tx, instruction_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
+    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
 
     // 4. Resolve the backfill range, gate the checkpoint writer to it, then start
     //    the writer. Checkpoint updates only begin once the processor starts further
@@ -167,29 +265,13 @@ pub async fn run(
             );
 
             if indexer_config.backfill.exit_after_backfill {
-                // Backfill-only: gate the writer to the fill range so a withheld
-                // (failed-write) slot stalls the checkpoint instead of being
-                // leapfrogged by a later one. No live stream, so a resolve failure
-                // fails closed rather than falling back to ungated.
-                let range = backfill_service.resolve_range().await?;
-                if let Some((from_slot, target)) = range.gap {
-                    checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
-                }
-                let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
-                info!("CheckpointWriter service started");
-                if let Some((from_slot, target)) = range.gap {
-                    backfill_service
-                        .run_range(from_slot, target, instruction_tx.clone())
-                        .await?;
-                }
-                info!("Backfill completed, performing graceful cleanup...");
-                if let Err(e) =
-                    cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage).await
-                {
-                    error!("Cleanup after backfill failed: {}", e);
-                    return Err(IndexerError::ShutdownChannelSend);
-                }
-                return Ok(());
+                return run_backfill_only(
+                    backfill_service,
+                    storage.clone(),
+                    common_config.program_type,
+                    common_config.escrow_instance_id,
+                )
+                .await;
             } else {
                 // Gate the writer to the range backfill will fill. resolve_range retries
                 // transient RPC failures; a persistent failure fails closed (see below).
@@ -480,5 +562,224 @@ mod tests {
         let outcome = supervise(&mut handle, std::future::pending::<std::io::Result<()>>()).await;
 
         assert!(matches!(outcome, Supervision::ProcessorEnded(Err(_))));
+    }
+
+    /// One-shot backfill: every slot recorded, and the checkpoint only reaching the target
+    /// once the whole range is durably stored.
+    ///
+    /// Each case scripts a mock RPC and a mock store, then drives the real pipeline, so
+    /// what is under test is the wiring between the fill, the processor and the writer
+    /// rather than any one of them in isolation.
+    #[cfg(feature = "datasource-rpc")]
+    mod backfill_only {
+        use super::*;
+        use crate::config::BackfillConfig;
+        use crate::storage::common::storage::mock::MockStorage;
+        use crate::test_utils::rpc_mocks::{
+            chain, deposit_fixture_instance, mock_get_block_at, mock_get_block_error,
+            mock_get_block_with_deposit, mock_get_blocks, mock_get_blocks_with_limit,
+            mock_get_slot,
+        };
+        use mockito::Server;
+        use solana_sdk::commitment_config::CommitmentLevel;
+        use solana_transaction_status::UiTransactionEncoding;
+        use std::time::Duration;
+
+        /// Store seeded with an escrow checkpoint, plus the handle tests assert against.
+        fn seeded_storage(checkpoint: u64) -> (MockStorage, Arc<Storage>) {
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", checkpoint);
+            (mock.clone(), Arc::new(Storage::Mock(mock)))
+        }
+
+        /// Escrow backfill service pointed at the mock RPC.
+        fn service(
+            server: &Server,
+            storage: Arc<Storage>,
+            batch_size: usize,
+            max_gap_slots: u64,
+            escrow_instance_id: Option<Pubkey>,
+        ) -> BackfillService {
+            let poller = Arc::new(RpcPoller::new(
+                server.url(),
+                UiTransactionEncoding::Json,
+                CommitmentLevel::Finalized,
+            ));
+            BackfillService::new(
+                storage,
+                poller,
+                ProgramType::Escrow,
+                BackfillConfig {
+                    enabled: true,
+                    exit_after_backfill: true,
+                    rpc_url: server.url(),
+                    batch_size,
+                    max_gap_slots,
+                    start_slot: None,
+                },
+                escrow_instance_id,
+            )
+        }
+
+        /// Escrow checkpoint currently held by the mock store.
+        fn checkpoint_of(mock: &MockStorage) -> Option<u64> {
+            mock.committed_checkpoints
+                .lock()
+                .unwrap()
+                .get("escrow")
+                .copied()
+        }
+
+        /// Every slot in the range is consumed, so the checkpoint lands on the target.
+        #[tokio::test]
+        async fn backfill_only_records_slots_and_advances_checkpoint() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 103);
+            let _blocks = chain(&mut server, 101, 103, &[(101, 100), (102, 101), (103, 102)]);
+            let (mock, storage) = seeded_storage(100);
+
+            let backfill = service(&server, storage.clone(), 10, 1000, None);
+            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+
+            assert!(result.is_ok(), "clean backfill must succeed: {result:?}");
+            assert_eq!(
+                checkpoint_of(&mock),
+                Some(103),
+                "the checkpoint must reach the fill target, which only happens if a \
+                 processor consumed every SlotComplete"
+            );
+        }
+
+        /// A range larger than the channel buffer must still drain rather than deadlock.
+        #[tokio::test]
+        async fn backfill_only_drains_more_slots_than_channel_capacity() {
+            let tip = 100 + PIPELINE_CHANNEL_CAPACITY as u64 + 500;
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, tip);
+            // No producers plus a witness past the range proves every slot empty in one batch.
+            let _blocks = mock_get_blocks(&mut server, 101, tip, &[]);
+            let _witness = mock_get_blocks_with_limit(&mut server, tip + 1, &[tip + 1]);
+            let _witness_block = mock_get_block_at(&mut server, tip + 1, 100);
+            let (mock, storage) = seeded_storage(100);
+
+            let backfill = service(&server, storage.clone(), 10_000, u64::MAX, None);
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(60),
+                run_backfill_only(backfill, storage, ProgramType::Escrow, None),
+            )
+            .await;
+
+            let result = outcome.expect(
+                "a backfill wider than the channel buffer must not park forever waiting \
+                 for a consumer",
+            );
+            assert!(result.is_ok(), "wide backfill must succeed: {result:?}");
+            assert_eq!(checkpoint_of(&mock), Some(tip));
+        }
+
+        /// Parsed instructions, not just slot markers, have to reach storage.
+        #[tokio::test]
+        async fn backfill_only_writes_deposit_rows_for_configured_instance() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 101);
+            let _blocks = mock_get_blocks(&mut server, 101, 101, &[101]);
+            let _block = mock_get_block_with_deposit(&mut server, 101, 100, 4242);
+            let (mock, storage) = seeded_storage(100);
+
+            let instance = Some(deposit_fixture_instance());
+            let backfill = service(&server, storage.clone(), 10, 1000, instance);
+            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, instance).await;
+
+            assert!(result.is_ok(), "deposit backfill must succeed: {result:?}");
+            let rows: Vec<_> = mock
+                .inserted_transactions
+                .lock()
+                .unwrap()
+                .iter()
+                .flatten()
+                .cloned()
+                .collect();
+            assert_eq!(
+                rows.len(),
+                1,
+                "the backfilled deposit must be written; an unscoped processor drops it"
+            );
+            assert_eq!(rows[0].amount.value(), 4242);
+            assert_eq!(checkpoint_of(&mock), Some(101));
+        }
+
+        /// A fill that dies part way still persists the contiguous prefix it completed.
+        #[tokio::test]
+        async fn backfill_only_persists_partial_frontier_when_fill_fails() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 103);
+            // batch_size 2 splits the range so the first batch lands before the second fails.
+            let _first = mock_get_blocks(&mut server, 101, 102, &[101, 102]);
+            let _b1 = mock_get_block_at(&mut server, 101, 100);
+            let _b2 = mock_get_block_at(&mut server, 102, 101);
+            let _second = mock_get_blocks(&mut server, 103, 103, &[103]);
+            let _b3 = mock_get_block_error(&mut server, 103, -32600, "Invalid request");
+            let (mock, storage) = seeded_storage(100);
+
+            let backfill = service(&server, storage.clone(), 2, 1000, None);
+            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+
+            assert!(result.is_err(), "a failed fetch must fail the run");
+            assert_eq!(
+                checkpoint_of(&mock),
+                Some(102),
+                "the slots that were stored must still be checkpointed so a retry resumes"
+            );
+        }
+
+        /// A checkpoint that never reaches the target must not report success.
+        #[tokio::test]
+        async fn backfill_only_reports_incomplete_when_checkpoint_flush_fails() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 103);
+            let _blocks = chain(&mut server, 101, 103, &[(101, 100), (102, 101), (103, 102)]);
+            let (mock, storage) = seeded_storage(100);
+            // Every checkpoint write fails; the writer only warns, so the run must catch it.
+            mock.set_should_fail("escrow", true);
+
+            let backfill = service(&server, storage.clone(), 10, 1000, None);
+            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+
+            match result {
+                Err(IndexerError::BackfillIncomplete {
+                    committed, target, ..
+                }) => {
+                    assert_eq!(committed, Some(100));
+                    assert_eq!(target, 103);
+                }
+                other => panic!("a stalled checkpoint must fail the run, got: {other:?}"),
+            }
+        }
+
+        /// Nothing to fill is a clean exit that touches neither RPC blocks nor the checkpoint.
+        #[tokio::test]
+        async fn backfill_only_no_gap_is_a_clean_noop() {
+            let mut server = Server::new_async().await;
+            let _slot = mock_get_slot(&mut server, 100);
+            let no_blocks = server
+                .mock("POST", "/")
+                .match_body(mockito::Matcher::PartialJson(
+                    serde_json::json!({ "method": "getBlocks" }),
+                ))
+                .expect(0)
+                .create();
+            let (mock, storage) = seeded_storage(100);
+
+            let backfill = service(&server, storage.clone(), 10, 1000, None);
+            let result = run_backfill_only(backfill, storage, ProgramType::Escrow, None).await;
+
+            assert!(result.is_ok(), "an empty range must succeed: {result:?}");
+            no_blocks.assert();
+            assert_eq!(
+                checkpoint_of(&mock),
+                Some(100),
+                "no gap means no slot was processed, so the checkpoint stands still"
+            );
+        }
     }
 }

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -400,12 +400,8 @@ pub async fn run(
         reconcile_escrow(&indexer_config.reconciliation, &common_config, &storage).await?;
     }
 
-    // 3. Create channels
-    let (instruction_tx, instruction_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
-    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
-
-    // 4a. Backfill-only mode is self-contained: it gates the writer to the fill range,
-    //     runs the fill and exits. Nothing below this point applies to it.
+    // 3. Backfill-only mode is self-contained: it gates the writer to the fill range,
+    //    runs the fill and exits. Nothing below this point applies to it.
     if backfill_only {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -427,6 +423,11 @@ pub async fn run(
             .await;
         }
     }
+
+    // 4a. Create channels. Below the block above because backfill-only returns without
+    //     them: it owns a short-lived pipeline and builds its own pair.
+    let (instruction_tx, instruction_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
+    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(PIPELINE_CHANNEL_CAPACITY);
 
     // 4b. Start the checkpoint writer ungated. When a fill runs below it arms the gate
     //     in-band with a Regate that rides ahead of the slots it protects, which also

--- a/indexer/src/indexer/resync.rs
+++ b/indexer/src/indexer/resync.rs
@@ -117,7 +117,23 @@ impl ResyncService {
         // future-slot, an unreachable channel, or a legacy-scheme memo can never leave a
         // half-wiped database.
 
-        // Pre-flight 1: genesis_slot must not be ahead of the chain tip.
+        // Pre-flight 1: an escrow rebuild needs its instance scope. The processor filters
+        // escrow instructions by it and an unset scope drops every one of them, so a rebuild
+        // without it would empty the tables, refill them with nothing, and still advance the
+        // checkpoint to the tip. That leaves no gap for a later run to detect, which makes it
+        // the one failure here that is not recoverable by repeating the operation.
+        if self.program_type == ProgramType::Escrow && self.escrow_instance_id.is_none() {
+            error!("Refusing to resync the escrow indexer with no escrow instance id");
+            return Err(IndexerError::Reconciliation(
+                ReconciliationError::InvalidPubkey {
+                    pubkey: "<missing>".to_string(),
+                    reason: "escrow_instance_id is required to resync the escrow indexer"
+                        .to_string(),
+                },
+            ));
+        }
+
+        // Pre-flight 2: genesis_slot must not be ahead of the chain tip.
         let current_slot = self.rpc_poller.get_latest_slot().await.map_err(|e| {
             error!("Failed to fetch current slot before resync backfill: {}", e);
             IndexerError::DataSource(e.into())
@@ -135,7 +151,7 @@ impl ResyncService {
             }));
         }
 
-        // Pre-flight 2+3: channel reachability + consumed-set completeness + cross-scheme
+        // Pre-flight 3+4: channel reachability + consumed-set completeness + cross-scheme
         // guard, all inside build_consumed_set, which returns Err on any of them.
         let consumed = self.build_consumed_set().await?;
 
@@ -236,16 +252,22 @@ impl ResyncService {
             }
         }
 
-        // Perform cleanup after backfill
+        // Perform cleanup after backfill, with no completeness target to check. A rebuild
+        // resolves its range inside the backfill service and never surfaces the top slot,
+        // so there is nothing to compare against here. Leaving it unchecked is acceptable
+        // because a stale checkpoint after a rebuild heals itself: the next live start
+        // detects the gap below the tip and fills it.
         if let Err(e) = crate::shutdown_utils::cleanup_after_backfill(
             checkpoint_handle,
             checkpoint_tx,
             self.storage.clone(),
+            None,
         )
         .await
         {
             error!("Cleanup after resync backfill failed: {}", e);
-            return Err(IndexerError::ShutdownChannelSend);
+            // Returned as-is so the operator sees which stage failed, not a generic one.
+            return Err(e);
         }
 
         info!(
@@ -297,5 +319,49 @@ mod tests {
         assert_eq!(service.program_type, ProgramType::Withdraw);
         assert_eq!(service.escrow_instance_id, Some(instance_id));
         assert_eq!(service.backfill_config_base.start_slot, Some(1000));
+    }
+
+    /// An escrow rebuild with no instance scope would drop every table and refill them with
+    /// nothing, so it must abort before the drop rather than after it.
+    ///
+    /// The RPC points at a dead port, which is what makes the ordering observable: the tip
+    /// fetch sits between this guard and the drop, so an `InvalidPubkey` here can only mean
+    /// the guard ran first. Had it run later, the unreachable node would have produced a
+    /// datasource error instead, and the tables would already be gone.
+    #[tokio::test]
+    async fn run_refuses_escrow_resync_without_instance_id_before_dropping_tables() {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let rpc_poller = Arc::new(RpcPoller::new(
+            "http://127.0.0.1:1".to_string(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        ));
+        let backfill_config = BackfillConfig {
+            enabled: true,
+            exit_after_backfill: false,
+            rpc_url: "http://127.0.0.1:1".to_string(),
+            batch_size: 50,
+            max_gap_slots: 500,
+            start_slot: None,
+        };
+
+        let service = ResyncService::new(
+            storage,
+            rpc_poller,
+            ProgramType::Escrow,
+            backfill_config,
+            None,
+        );
+
+        match service.run(100).await {
+            Err(IndexerError::Reconciliation(ReconciliationError::InvalidPubkey {
+                reason,
+                ..
+            })) => assert!(
+                reason.contains("escrow_instance_id"),
+                "reason must name the missing scope, got: {reason}"
+            ),
+            other => panic!("escrow resync with no instance id must fail closed, got: {other:?}"),
+        }
     }
 }

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -7,11 +7,13 @@
 //! - Forced exit on timeout (configurable)
 //! - Buffer time before storage closure
 
+use crate::config::ProgramType;
 use crate::error::IndexerError;
-use crate::indexer::checkpoint::CheckpointMsg;
+use crate::indexer::checkpoint::{get_last_checkpoint, CheckpointMsg};
 use crate::indexer::datasource::common::datasource::DataSource;
 use crate::indexer::datasource::common::types::ProcessorMessage;
 use crate::storage::Storage;
+use private_channel_metrics::MetricLabel;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -525,12 +527,18 @@ async fn perform_operator_shutdown_stages(
     Ok(())
 }
 
-/// Graceful cleanup after backfill completion
+/// Graceful cleanup after backfill completion.
+///
+/// `verify` names the program and the inclusive top slot a one-shot backfill was asked
+/// to reach. When set, the durable checkpoint is re-read after the writer has drained
+/// and the run only succeeds if it got that far. Pass `None` to keep the drain-and-close
+/// behaviour with no completeness claim.
 pub async fn cleanup_after_backfill(
     checkpoint_handle: tokio::task::JoinHandle<()>,
     checkpoint_tx: mpsc::Sender<CheckpointMsg>,
     storage: Arc<Storage>,
-) -> Result<(), Box<dyn std::error::Error>> {
+    verify: Option<(ProgramType, u64)>,
+) -> Result<(), IndexerError> {
     info!("Cleaning up after backfill completion...");
 
     let config = ShutdownConfig::default();
@@ -550,7 +558,18 @@ pub async fn cleanup_after_backfill(
         Err(_) => warn!("Checkpoint writer drain timed out"),
     }
 
-    // Stage 2: Close storage connections
+    // Stage 2: Confirm the range was recorded, after the drain flushed the last batch and
+    // before stage 3 closes the pool the read needs. A drained writer proves nothing on its
+    // own: a stalled gate holds the frontier short of the target, and a failed final write
+    // is only logged, so the sole trustworthy signal is the checkpoint the database holds.
+    let verdict = match verify {
+        Some((program_type, target)) => verify_checkpoint_reached(&storage, program_type, target)
+            .await
+            .inspect_err(|e| error!("Backfill completeness check failed: {}", e)),
+        None => Ok(()),
+    };
+
+    // Stage 3: Close storage connections
     info!("Closing storage connections...");
     match tokio::time::timeout(
         Duration::from_secs(config.storage_close_timeout_secs),
@@ -563,8 +582,32 @@ pub async fn cleanup_after_backfill(
         Err(_) => warn!("Storage close timed out"),
     }
 
+    verdict?;
     info!("Backfill cleanup complete");
     Ok(())
+}
+
+/// Fail unless the durable checkpoint for `program_type` reached `target`.
+///
+/// Compared with `>=` so a live indexer that pushed the checkpoint on cannot fail a repair.
+async fn verify_checkpoint_reached(
+    storage: &Arc<Storage>,
+    program_type: ProgramType,
+    target: u64,
+) -> Result<(), IndexerError> {
+    let committed = get_last_checkpoint(storage, program_type).await?;
+    if committed.is_some_and(|slot| slot >= target) {
+        info!(
+            "Backfill verified for {:?}: checkpoint {:?} reached target {}",
+            program_type, committed, target
+        );
+        return Ok(());
+    }
+    Err(IndexerError::BackfillIncomplete {
+        program_type: program_type.as_label().to_string(),
+        committed,
+        target,
+    })
 }
 
 async fn wait_with_progress<T>(
@@ -669,20 +712,105 @@ mod tests {
     // cleanup_after_backfill
     // ====================================================================
 
-    #[tokio::test]
-    async fn cleanup_after_backfill_ok() {
-        let mock = MockStorage::new();
-        let storage = Arc::new(Storage::Mock(mock));
+    /// Drain-only checkpoint writer plus the channel that feeds it.
+    fn drained_writer() -> (tokio::task::JoinHandle<()>, mpsc::Sender<CheckpointMsg>) {
         let (checkpoint_tx, checkpoint_rx) = mpsc::channel::<CheckpointMsg>(10);
-
-        // Start a simple checkpoint writer that just drains
-        let checkpoint_handle = tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut rx = checkpoint_rx;
             while rx.recv().await.is_some() {}
         });
+        (handle, checkpoint_tx)
+    }
 
-        let result = cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage).await;
-        assert!(result.is_ok());
+    /// No target means no verification, which is what the resync rebuild relies on.
+    #[tokio::test]
+    async fn cleanup_after_backfill_without_target_skips_verification() {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let (checkpoint_handle, checkpoint_tx) = drained_writer();
+
+        let result = cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage, None).await;
+
+        assert!(
+            result.is_ok(),
+            "an absent checkpoint must not fail a run that asked for no verification"
+        );
+    }
+
+    /// A frontier level with or ahead of the target is a complete run.
+    #[tokio::test]
+    async fn cleanup_after_backfill_accepts_frontier_at_or_past_target() {
+        // A live indexer running alongside a repair can push the checkpoint past the target.
+        for committed in [150u64, 151] {
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", committed);
+            let storage = Arc::new(Storage::Mock(mock));
+            let (checkpoint_handle, checkpoint_tx) = drained_writer();
+
+            let result = cleanup_after_backfill(
+                checkpoint_handle,
+                checkpoint_tx,
+                storage,
+                Some((ProgramType::Escrow, 150)),
+            )
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "committed {committed} must pass: {result:?}"
+            );
+        }
+    }
+
+    /// A frontier short of the target means the range was not fully recorded.
+    #[tokio::test]
+    async fn cleanup_after_backfill_rejects_frontier_below_target() {
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", 149);
+        let storage = Arc::new(Storage::Mock(mock));
+        let (checkpoint_handle, checkpoint_tx) = drained_writer();
+
+        let result = cleanup_after_backfill(
+            checkpoint_handle,
+            checkpoint_tx,
+            storage,
+            Some((ProgramType::Escrow, 150)),
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::BackfillIncomplete {
+                program_type,
+                committed,
+                target,
+            }) => {
+                assert_eq!(program_type, "escrow");
+                assert_eq!(committed, Some(149));
+                assert_eq!(target, 150);
+            }
+            other => panic!("a short frontier must be reported, got: {other:?}"),
+        }
+    }
+
+    /// An unreadable checkpoint is not evidence of success.
+    #[tokio::test]
+    async fn cleanup_after_backfill_surfaces_checkpoint_read_failure() {
+        let mock = MockStorage::new();
+        mock.set_should_fail("get_committed_checkpoint", true);
+        let storage = Arc::new(Storage::Mock(mock));
+        let (checkpoint_handle, checkpoint_tx) = drained_writer();
+
+        let result = cleanup_after_backfill(
+            checkpoint_handle,
+            checkpoint_tx,
+            storage,
+            Some((ProgramType::Escrow, 150)),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a checkpoint read that fails must fail the run rather than pass it"
+        );
     }
 
     // ====================================================================

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -27,6 +27,21 @@ pub const SHUTDOWN_DATASOURCE_TIMEOUT_SECS: u64 = 10;
 pub const SHUTDOWN_DATASOURCE_COMPLETION_TIMEOUT_SECS: u64 = 5;
 pub const SHUTDOWN_PROCESSOR_DRAIN_TIMEOUT_SECS: u64 = 20;
 pub const SHUTDOWN_CHECKPOINT_DRAIN_TIMEOUT_SECS: u64 = 10;
+/// Drain bound for a one-shot backfill's final flush, which is deliberately far longer than
+/// the live-shutdown one above.
+///
+/// That flush has to be allowed to finish, because the checkpoint it writes is what the
+/// completeness check then reads. The pool waits up to 30 seconds for a connection before it
+/// gives up on its own, so anything below that cancels writers that were never stuck and
+/// turns a finished repair into a reported failure. Nothing else is running by this point,
+/// so the only cost of waiting is a slower exit on a database that is already in trouble.
+pub const SHUTDOWN_BACKFILL_DRAIN_TIMEOUT_SECS: u64 = 45;
+
+/// How long the pool waits for a connection before giving up on its own.
+const POOL_ACQUIRE_TIMEOUT_SECS: u64 = 30;
+/// Enforced at build time: below this line the cancellation above stops being a backstop for a
+/// stuck writer and starts cutting off healthy ones.
+const _: () = assert!(SHUTDOWN_BACKFILL_DRAIN_TIMEOUT_SECS > POOL_ACQUIRE_TIMEOUT_SECS);
 
 pub const SHUTDOWN_SENDER_BASE_TIMEOUT_SECS: u64 = 10;
 pub const SHUTDOWN_SENDER_TIME_PER_TX_SECS: u64 = 2;
@@ -53,6 +68,8 @@ pub struct ShutdownConfig {
     pub processor_drain_timeout_secs: u64,
     /// Timeout for checkpoint writer to drain (seconds)
     pub checkpoint_drain_timeout_secs: u64,
+    /// Timeout for a one-shot backfill's final checkpoint flush (seconds)
+    pub backfill_drain_timeout_secs: u64,
 
     // Operator-specific timeouts
     /// Base timeout for sender to complete in-flight transactions (seconds)
@@ -84,6 +101,7 @@ impl Default for ShutdownConfig {
             datasource_completion_timeout_secs: SHUTDOWN_DATASOURCE_COMPLETION_TIMEOUT_SECS,
             processor_drain_timeout_secs: SHUTDOWN_PROCESSOR_DRAIN_TIMEOUT_SECS,
             checkpoint_drain_timeout_secs: SHUTDOWN_CHECKPOINT_DRAIN_TIMEOUT_SECS,
+            backfill_drain_timeout_secs: SHUTDOWN_BACKFILL_DRAIN_TIMEOUT_SECS,
 
             // Operator defaults
             sender_base_timeout_secs: SHUTDOWN_SENDER_BASE_TIMEOUT_SECS,
@@ -548,7 +566,7 @@ pub async fn cleanup_after_backfill(
     drop(checkpoint_tx);
 
     match tokio::time::timeout(
-        Duration::from_secs(config.checkpoint_drain_timeout_secs),
+        Duration::from_secs(config.backfill_drain_timeout_secs),
         &mut checkpoint_handle,
     )
     .await
@@ -561,7 +579,13 @@ pub async fn cleanup_after_backfill(
             // moments later and call a finished backfill incomplete, and the close would
             // pull the pool out from under a write still in flight. Cancelling first makes
             // the checkpoint read afterwards a settled fact rather than a snapshot.
-            warn!("Checkpoint writer drain timed out; cancelling it before verifying");
+            //
+            // The bound above is set so that reaching here means the writer is genuinely
+            // stuck rather than slow, which is what makes cancelling it the right call.
+            warn!(
+                "Checkpoint writer still running after {}s; cancelling it before verifying",
+                config.backfill_drain_timeout_secs
+            );
             checkpoint_handle.abort();
             let _ = checkpoint_handle.await;
         }
@@ -693,6 +717,10 @@ mod tests {
         assert_eq!(
             config.checkpoint_drain_timeout_secs,
             SHUTDOWN_CHECKPOINT_DRAIN_TIMEOUT_SECS
+        );
+        assert_eq!(
+            config.backfill_drain_timeout_secs,
+            SHUTDOWN_BACKFILL_DRAIN_TIMEOUT_SECS
         );
         assert_eq!(
             config.sender_base_timeout_secs,

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -565,6 +565,8 @@ pub async fn cleanup_after_backfill(
     info!("Draining checkpoint writer...");
     drop(checkpoint_tx);
 
+    // Set when the writer had to be cancelled, which changes what a short checkpoint means.
+    let mut cancelled_after_secs = None;
     match tokio::time::timeout(
         Duration::from_secs(config.backfill_drain_timeout_secs),
         &mut checkpoint_handle,
@@ -582,12 +584,16 @@ pub async fn cleanup_after_backfill(
             //
             // The bound above is set so that reaching here means the writer is genuinely
             // stuck rather than slow, which is what makes cancelling it the right call.
+            // Waiting without a bound is not the alternative it looks like: a connection that
+            // never answers would hold a one-shot job open forever, so the wait stays bounded
+            // and the shortfall is reported under its own error instead.
             warn!(
                 "Checkpoint writer still running after {}s; cancelling it before verifying",
                 config.backfill_drain_timeout_secs
             );
             checkpoint_handle.abort();
             let _ = checkpoint_handle.await;
+            cancelled_after_secs = Some(config.backfill_drain_timeout_secs);
         }
     }
 
@@ -596,9 +602,11 @@ pub async fn cleanup_after_backfill(
     // own: a stalled gate holds the frontier short of the target, and a failed final write
     // is only logged, so the sole trustworthy signal is the checkpoint the database holds.
     let verdict = match verify {
-        Some((program_type, target)) => verify_checkpoint_reached(&storage, program_type, target)
-            .await
-            .inspect_err(|e| error!("Backfill completeness check failed: {}", e)),
+        Some((program_type, target)) => {
+            verify_checkpoint_reached(&storage, program_type, target, cancelled_after_secs)
+                .await
+                .inspect_err(|e| error!("Backfill completeness check failed: {}", e))
+        }
         None => Ok(()),
     };
 
@@ -623,10 +631,15 @@ pub async fn cleanup_after_backfill(
 /// Fail unless the durable checkpoint for `program_type` reached `target`.
 ///
 /// Compared with `>=` so a live indexer that pushed the checkpoint on cannot fail a repair.
+/// `cancelled_after_secs` carries how long the writer was given before it was stopped, which
+/// separates a checkpoint that is short because a slot never made it from one that is short
+/// only because the flush never got to confirm. Both still fail, since a cancelled writer
+/// leaves the two indistinguishable in the database, but they need different operator action.
 async fn verify_checkpoint_reached(
     storage: &Arc<Storage>,
     program_type: ProgramType,
     target: u64,
+    cancelled_after_secs: Option<u64>,
 ) -> Result<(), IndexerError> {
     let committed = get_last_checkpoint(storage, program_type).await?;
     if committed.is_some_and(|slot| slot >= target) {
@@ -636,11 +649,19 @@ async fn verify_checkpoint_reached(
         );
         return Ok(());
     }
-    Err(IndexerError::BackfillIncomplete {
-        program_type: program_type.as_label().to_string(),
-        committed,
-        target,
-    })
+    match cancelled_after_secs {
+        Some(waited_secs) => Err(IndexerError::BackfillCheckpointUnconfirmed {
+            program_type: program_type.as_label().to_string(),
+            committed,
+            target,
+            waited_secs,
+        }),
+        None => Err(IndexerError::BackfillIncomplete {
+            program_type: program_type.as_label().to_string(),
+            committed,
+            target,
+        }),
+    }
 }
 
 async fn wait_with_progress<T>(
@@ -802,6 +823,42 @@ mod tests {
             1,
             "the writer must be cancelled before the checkpoint is read and the pool closed"
         );
+    }
+
+    /// A cancelled writer is reported apart from a genuinely short frontier.
+    ///
+    /// Both leave the same stale checkpoint behind, so the database cannot tell them apart and
+    /// both have to fail. What differs is what the operator does next: chase a slot the
+    /// pipeline could not store, or wait for the database to recover and run it again.
+    #[tokio::test(start_paused = true)]
+    async fn cleanup_after_backfill_names_a_cancelled_writer_rather_than_a_missing_slot() {
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", 100);
+        let storage = Arc::new(Storage::Mock(mock));
+        let (checkpoint_tx, _checkpoint_rx) = mpsc::channel::<CheckpointMsg>(1);
+        let checkpoint_handle = tokio::spawn(std::future::pending::<()>());
+
+        let result = cleanup_after_backfill(
+            checkpoint_handle,
+            checkpoint_tx,
+            storage,
+            Some((ProgramType::Escrow, 150)),
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::BackfillCheckpointUnconfirmed {
+                committed,
+                target,
+                waited_secs,
+                ..
+            }) => {
+                assert_eq!(committed, Some(100));
+                assert_eq!(target, 150);
+                assert_eq!(waited_secs, SHUTDOWN_BACKFILL_DRAIN_TIMEOUT_SECS);
+            }
+            other => panic!("a cancelled writer must not read as a missing slot, got: {other:?}"),
+        }
     }
 
     /// A frontier level with or ahead of the target is a complete run.

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -534,7 +534,7 @@ async fn perform_operator_shutdown_stages(
 /// and the run only succeeds if it got that far. Pass `None` to keep the drain-and-close
 /// behaviour with no completeness claim.
 pub async fn cleanup_after_backfill(
-    checkpoint_handle: tokio::task::JoinHandle<()>,
+    mut checkpoint_handle: tokio::task::JoinHandle<()>,
     checkpoint_tx: mpsc::Sender<CheckpointMsg>,
     storage: Arc<Storage>,
     verify: Option<(ProgramType, u64)>,
@@ -549,13 +549,22 @@ pub async fn cleanup_after_backfill(
 
     match tokio::time::timeout(
         Duration::from_secs(config.checkpoint_drain_timeout_secs),
-        checkpoint_handle,
+        &mut checkpoint_handle,
     )
     .await
     {
         Ok(Ok(_)) => info!("Checkpoint writer drained successfully"),
         Ok(Err(e)) => warn!("Checkpoint writer error: {:?}", e),
-        Err(_) => warn!("Checkpoint writer drain timed out"),
+        Err(_) => {
+            // Timing out only stops waiting; the task keeps running unless it is cancelled.
+            // Both stages below would then race it: the read could miss a flush that lands
+            // moments later and call a finished backfill incomplete, and the close would
+            // pull the pool out from under a write still in flight. Cancelling first makes
+            // the checkpoint read afterwards a settled fact rather than a snapshot.
+            warn!("Checkpoint writer drain timed out; cancelling it before verifying");
+            checkpoint_handle.abort();
+            let _ = checkpoint_handle.await;
+        }
     }
 
     // Stage 2: Confirm the range was recorded, after the drain flushed the last batch and
@@ -733,6 +742,37 @@ mod tests {
         assert!(
             result.is_ok(),
             "an absent checkpoint must not fail a run that asked for no verification"
+        );
+    }
+
+    /// A writer that outlasts the drain timeout is cancelled, not left running.
+    ///
+    /// Waiting on a task and stopping it are different things, and only the second one makes
+    /// the stages that follow safe. The probe is an `Arc` the task owns: a cancelled task is
+    /// dropped and releases its clone, while a merely detached one keeps it alive, so the
+    /// strong count separates the two cases that otherwise look identical from out here.
+    #[tokio::test(start_paused = true)]
+    async fn cleanup_after_backfill_cancels_a_writer_that_overruns_the_drain_timeout() {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let (checkpoint_tx, _checkpoint_rx) = mpsc::channel::<CheckpointMsg>(1);
+
+        let probe = Arc::new(());
+        let held = probe.clone();
+        let checkpoint_handle = tokio::spawn(async move {
+            let _held = held;
+            std::future::pending::<()>().await;
+        });
+        // Let the task reach its await point so it really owns the clone.
+        tokio::task::yield_now().await;
+        assert_eq!(Arc::strong_count(&probe), 2, "task must hold the probe");
+
+        let result = cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage, None).await;
+
+        assert!(result.is_ok(), "a drain timeout alone is not a failed run");
+        assert_eq!(
+            Arc::strong_count(&probe),
+            1,
+            "the writer must be cancelled before the checkpoint is read and the pool closed"
         );
     }
 

--- a/indexer/src/test_utils.rs
+++ b/indexer/src/test_utils.rs
@@ -271,6 +271,86 @@ pub mod rpc_mocks {
             .create()
     }
 
+    /// Escrow instance the `mock_get_block_with_deposit` fixture parses to.
+    ///
+    /// A Deposit reads its instance from account index 2, and the fixture passes
+    /// accounts `0..12` straight through, so the instance is whatever sits at
+    /// account key 2. Callers configure the indexer with this value; anything
+    /// else makes the processor drop the deposit as out of scope.
+    pub fn deposit_fixture_instance() -> solana_sdk::pubkey::Pubkey {
+        crate::test_utils::pubkey::test_pubkey(2)
+    }
+
+    /// Mock `getBlock(slot)` returning a block with one top-level escrow Deposit.
+    ///
+    /// The deposit's amount is carried by its DepositEvent self-CPI, which is the
+    /// value the parser records, so both halves are built from `amount`.
+    pub fn mock_get_block_with_deposit(
+        server: &mut Server,
+        slot: u64,
+        parent_slot: u64,
+        amount: u64,
+    ) -> Mock {
+        use crate::indexer::datasource::common::parser::escrow::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
+        use crate::test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes};
+
+        // Escrow program at key index 0; the rest pad the deposit's 12 accounts.
+        let mut account_keys: Vec<String> = (0u8..12)
+            .map(|i| crate::test_utils::pubkey::test_pubkey(i).to_string())
+            .collect();
+        account_keys[0] = PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string();
+
+        let deposit_data = bs58::encode(deposit_ix_bytes(amount, None)).into_string();
+        let event_data = bs58::encode(deposit_event_bytes(amount)).into_string();
+
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [slot]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": format!("TestBlockHash{slot}"),
+                        "parentSlot": parent_slot,
+                        "transactions": [{
+                            "transaction": {
+                                "signatures": [format!("sig_deposit_slot_{slot}")],
+                                "message": {
+                                    "accountKeys": account_keys,
+                                    "instructions": [{
+                                        "programIdIndex": 0,
+                                        "accounts": (0u8..12).collect::<Vec<u8>>(),
+                                        "data": deposit_data
+                                    }]
+                                }
+                            },
+                            "meta": {
+                                "err": null,
+                                "logMessages": null,
+                                "loadedAddresses": null,
+                                "innerInstructions": [{
+                                    "index": 0,
+                                    "instructions": [{
+                                        "programIdIndex": 0,
+                                        "accounts": [],
+                                        "data": event_data,
+                                        "stackHeight": 2
+                                    }]
+                                }]
+                            }
+                        }]
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .create()
+    }
+
     /// Mock `getBlock(slot)` answering a JSON-RPC error with the given code.
     pub fn mock_get_block_error(server: &mut Server, slot: u64, code: i32, message: &str) -> Mock {
         server

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -112,6 +112,11 @@ path = "tests/indexer/reconnect_gap_fill_fail_closed.rs"
 name = "startup_anchor"
 path = "tests/indexer/startup_anchor.rs"
 
+# One-shot backfill repair: records its range, verifies it, fails closed on write errors.
+[[test]]
+name = "backfill_only_e2e"
+path = "tests/indexer/backfill_only_e2e.rs"
+
 # Yellowstone inner_instructions + unknown-discriminator arms.
 [[test]]
 name = "yellowstone_inner_and_unknown"

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -45,6 +45,7 @@ integration-test:
 	@echo "=== prod-feature indexer group ==="
 	@cargo test --test reconciliation_integration -- --nocapture
 	@cargo test --test gap_detection_integration -- --nocapture
+	@cargo test --test backfill_only_e2e -- --nocapture
 	@cargo test --test truncate_integration -- --nocapture
 	@cargo test --test pausable_mint_integration -- --nocapture
 	@cargo test --test permanent_delegate_mint_integration -- --nocapture
@@ -237,6 +238,8 @@ integration-coverage-indexer:
 	@cargo llvm-cov test --no-report --workspace --test reconciliation_integration -- --nocapture
 	@echo "Running gap detection integration tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test gap_detection_integration -- --nocapture
+	@echo "Running backfill-only e2e tests with coverage instrumentation..."
+	@cargo llvm-cov test --no-report --workspace --test backfill_only_e2e -- --nocapture
 	@echo "Running truncate integration tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test truncate_integration -- --nocapture
 	@echo "Running pausable mint integration tests with coverage instrumentation..."

--- a/integration/tests/indexer/backfill_only_e2e.rs
+++ b/integration/tests/indexer/backfill_only_e2e.rs
@@ -25,7 +25,7 @@ mod setup;
 use helpers::{db, send_and_confirm_instructions};
 use private_channel_indexer::{
     config::{BackfillConfig, ReconciliationConfig},
-    error::IndexerError,
+    error::{CheckpointError, IndexerError},
     indexer::run,
     storage::{PostgresDb, Storage},
     DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig, ProgramType,
@@ -403,6 +403,80 @@ async fn backfill_only_exits_nonzero_when_slot_writes_fail(
         checkpoint.is_none_or(|slot| slot < deposit_slot),
         "checkpoint {checkpoint:?} must stay below the unwritten deposit slot \
          {deposit_slot} so a retry replays it"
+    );
+
+    Ok(())
+}
+
+/// A repair whose start slot sits above the durable checkpoint must refuse.
+///
+/// The fill would cover only the range above that slot while the gated writer, seeded at
+/// the same floor, walked its frontier to the target. The run would exit clean having
+/// committed a checkpoint over slots nothing ever fetched, and because the next run reads
+/// that higher checkpoint as its floor, the skipped band would never be offered again.
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_only_refuses_a_start_slot_above_the_checkpoint(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (validator, faucet) = start_test_validator_no_geyser().await;
+    let rpc_url = validator.rpc_url();
+    let client = Arc::new(RpcClient::new_with_commitment(
+        rpc_url.clone(),
+        CommitmentConfig::confirmed(),
+    ));
+    let (db_url, _storage, _pg) = start_postgres("backfill_only_start_slot_guard").await?;
+
+    let env = TestEnvironment::setup(&client, &faucet, 1, USER_BALANCE, None).await?;
+    let user = &env.users[0];
+
+    let (_sig, deposit_slot) =
+        execute_deposit(&client, user, &env.instance, &env.mint, DEPOSIT_AMOUNT_A).await?;
+    wait_for_finalized_slot(&rpc_url, deposit_slot + 3).await;
+    wait_for_block_available(&rpc_url, deposit_slot).await;
+
+    // Establish the checkpoint through the real repair path rather than seeding a row, so
+    // the guard is tested against a checkpoint this pipeline actually wrote.
+    let (common, indexer) =
+        backfill_only_config(rpc_url.clone(), db_url.clone(), env.instance, deposit_slot);
+    run_backfill_only_once(common, indexer)
+        .await
+        .expect("the first repair must succeed and leave a checkpoint");
+
+    let pool: PgPool = db::connect(&db_url).await?;
+    let committed = db::get_checkpoint_slot(&pool, "escrow")
+        .await?
+        .expect("the first run must leave a durable checkpoint");
+
+    // Well clear of the tip, so the skipped band is unambiguous.
+    let (common, indexer) = backfill_only_config(
+        rpc_url.clone(),
+        db_url.clone(),
+        env.instance,
+        committed + 10_000,
+    );
+    let err = run_backfill_only_once(common, indexer)
+        .await
+        .expect_err("a start slot above the checkpoint must refuse");
+
+    match err {
+        IndexerError::Checkpoint(CheckpointError::StartSlotAheadOfCheckpoint {
+            setting,
+            start_slot,
+            checkpoint,
+            ..
+        }) => {
+            assert_eq!(setting, "indexer.backfill.start_slot");
+            assert_eq!(start_slot, committed + 10_000);
+            assert_eq!(checkpoint, committed);
+        }
+        other => panic!("expected a start-slot refusal, got: {other:?}"),
+    }
+
+    // The refusal is only worth anything if it committed nothing on the way out.
+    let after = db::get_checkpoint_slot(&pool, "escrow").await?;
+    assert_eq!(
+        after,
+        Some(committed),
+        "a refused run must leave the checkpoint untouched, got {after:?}"
     );
 
     Ok(())

--- a/integration/tests/indexer/backfill_only_e2e.rs
+++ b/integration/tests/indexer/backfill_only_e2e.rs
@@ -1,0 +1,371 @@
+//! End-to-end coverage for backfill-only mode (`backfill.backfill_only = true`).
+//!
+//! This is the repair path an operator runs when finalized events are known to be
+//! missing from the database. It is a one-shot: `private_channel_indexer::run` fills the
+//! resolved slot range and exits, with no live datasource behind it.
+//!
+//! Two properties are pinned here, both of which need real Postgres:
+//!
+//! 1. A clean run records every deposit in the range and advances the durable
+//!    checkpoint to the range top, and re-running it changes nothing.
+//! 2. A run whose slot writes fail exits non-zero carrying the storage error, and
+//!    leaves the checkpoint parked below the slot it could not store, so the next
+//!    attempt replays from there.
+
+// Shared `#[path]` helper modules (helpers, setup) expose more than this binary
+// uses; match the sibling integration test crates and allow the unused items.
+#![allow(dead_code)]
+
+#[path = "helpers/mod.rs"]
+mod helpers;
+
+#[path = "setup.rs"]
+mod setup;
+
+use helpers::{db, send_and_confirm_instructions};
+use private_channel_indexer::{
+    config::{BackfillConfig, ReconciliationConfig},
+    error::IndexerError,
+    indexer::run,
+    storage::{PostgresDb, Storage},
+    DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig, ProgramType,
+    RpcPollingConfig, StorageType,
+};
+use setup::{find_allowed_mint_pda, find_event_authority_pda, TestEnvironment};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::{CommitmentConfig, CommitmentLevel},
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
+use solana_transaction_status::UiTransactionEncoding;
+use sqlx::PgPool;
+use std::{sync::Arc, time::Duration};
+use test_utils::validator_helper::start_test_validator_no_geyser;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+/// Upper bound for one backfill-only run (resolve, fill, drain, verify, close).
+const BACKFILL_TIMEOUT_SECS: u64 = 180;
+/// Per-user SPL balance minted at setup, large enough to fund the deposits below.
+const USER_BALANCE: u64 = 1_000_000;
+/// Deposit amounts, distinct so each row can be told apart in the assertions.
+const DEPOSIT_AMOUNT_A: u64 = 31_000;
+const DEPOSIT_AMOUNT_B: u64 = 42_000;
+
+// ── harness ─────────────────────────────────────────────────────────────────
+
+async fn start_postgres(
+    db_name: &str,
+) -> Result<
+    (
+        String,
+        Arc<Storage>,
+        testcontainers::ContainerAsync<Postgres>,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let container = Postgres::default()
+        .with_db_name(db_name)
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db_url = format!("postgres://postgres:password@{}:{}/{}", host, port, db_name);
+
+    let storage = Arc::new(Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url.clone(),
+            max_connections: 5,
+        })
+        .await?,
+    ));
+    storage.init_schema().await?;
+
+    Ok((db_url, storage, container))
+}
+
+/// Backfill-only config for the escrow indexer over `(start_slot - 1, tip]`.
+///
+/// `rpc_polling` is required even though no datasource is ever started: the backfill
+/// branch reads its encoding and commitment before deciding the mode.
+fn backfill_only_config(
+    rpc_url: String,
+    db_url: String,
+    instance: Pubkey,
+    start_slot: u64,
+) -> (PrivateChannelIndexerConfig, IndexerConfig) {
+    let common = PrivateChannelIndexerConfig {
+        program_type: ProgramType::Escrow,
+        storage_type: StorageType::Postgres,
+        rpc_url: rpc_url.clone(),
+        // Only read by startup reconciliation, which backfill-only mode skips.
+        source_rpc_url: Some(rpc_url.clone()),
+        fallback_rpc_url: None,
+        postgres: PostgresConfig {
+            database_url: db_url,
+            max_connections: 5,
+        },
+        escrow_instance_id: Some(instance),
+    };
+
+    let indexer = IndexerConfig {
+        datasource_type: DatasourceType::RpcPolling,
+        rpc_polling: Some(RpcPollingConfig {
+            poll_interval_ms: 200,
+            error_retry_interval_ms: 1000,
+            batch_size: 10,
+            from_slot: Some(start_slot),
+            encoding: UiTransactionEncoding::Json,
+            commitment: CommitmentLevel::Finalized,
+        }),
+        yellowstone: None,
+        backfill: BackfillConfig {
+            enabled: true,
+            exit_after_backfill: true,
+            rpc_url,
+            batch_size: 50,
+            // The range is bounded by the deposits below, not by a gap ceiling.
+            max_gap_slots: u64::MAX,
+            start_slot: Some(start_slot),
+        },
+        reconciliation: ReconciliationConfig::default(),
+    };
+
+    (common, indexer)
+}
+
+async fn run_backfill_only_once(
+    common: PrivateChannelIndexerConfig,
+    indexer: IndexerConfig,
+) -> Result<(), IndexerError> {
+    tokio::time::timeout(
+        Duration::from_secs(BACKFILL_TIMEOUT_SECS),
+        run(common, indexer, None),
+    )
+    .await
+    .expect("backfill-only run timed out")
+}
+
+/// Wait for the finalized tip to clear `target`, so every deposit block is inside the
+/// range and retrievable rather than raced at the bleeding edge.
+async fn wait_for_finalized_slot(rpc_url: &str, target: u64) {
+    let client = RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::finalized());
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if client
+            .get_slot()
+            .await
+            .map(|s| s >= target)
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for finalized slot to reach {target}"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+}
+
+/// Submit one escrow deposit and return its signature and confirmed slot.
+async fn execute_deposit(
+    client: &RpcClient,
+    user: &Keypair,
+    instance: &Pubkey,
+    mint: &Pubkey,
+    amount: u64,
+) -> Result<(String, u64), Box<dyn std::error::Error>> {
+    let (allowed_mint_pda, _) = find_allowed_mint_pda(instance, mint);
+    let (event_authority_pda, _) = find_event_authority_pda();
+
+    let user_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
+        &user.pubkey(),
+        mint,
+        &spl_token::ID,
+    );
+    let instance_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
+        instance,
+        mint,
+        &spl_token::ID,
+    );
+
+    let deposit_ix = private_channel_escrow_program_client::instructions::DepositBuilder::new()
+        .payer(user.pubkey())
+        .user(user.pubkey())
+        .instance(*instance)
+        .mint(*mint)
+        .allowed_mint(allowed_mint_pda)
+        .user_ata(user_ata)
+        .instance_ata(instance_ata)
+        .system_program(solana_system_interface::program::ID)
+        .token_program(spl_token::ID)
+        .associated_token_program(spl_associated_token_account::ID)
+        .event_authority(event_authority_pda)
+        .private_channel_escrow_program(
+            private_channel_escrow_program_client::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
+        )
+        .amount(amount)
+        .instruction();
+
+    let signature =
+        send_and_confirm_instructions(client, &[deposit_ix], user, &[user], "Deposit").await?;
+
+    let statuses = client.get_signature_statuses(&[signature]).await?;
+    let slot = statuses
+        .value
+        .first()
+        .and_then(|s| s.as_ref())
+        .map(|s| s.slot)
+        .ok_or("deposit signature has no confirmed slot")?;
+
+    Ok((signature.to_string(), slot))
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+/// A backfill-only repair must record the finalized deposits in its range and only
+/// report success once the checkpoint covers that range. Re-running it must be a no-op.
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_only_records_finalized_deposits_and_exits_clean(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (validator, faucet) = start_test_validator_no_geyser().await;
+    let rpc_url = validator.rpc_url();
+    let client = Arc::new(RpcClient::new_with_commitment(
+        rpc_url.clone(),
+        CommitmentConfig::confirmed(),
+    ));
+    let (db_url, _storage, _pg) = start_postgres("backfill_only_records").await?;
+
+    let env = TestEnvironment::setup(&client, &faucet, 1, USER_BALANCE, None).await?;
+    let user = &env.users[0];
+
+    // Everything before the first deposit is outside the repair range.
+    let start_slot = client.get_slot().await?;
+
+    let (sig_a, slot_a) =
+        execute_deposit(&client, user, &env.instance, &env.mint, DEPOSIT_AMOUNT_A).await?;
+    let (sig_b, slot_b) =
+        execute_deposit(&client, user, &env.instance, &env.mint, DEPOSIT_AMOUNT_B).await?;
+
+    // Headroom past the last deposit so its block is finalized and inside the range.
+    wait_for_finalized_slot(&rpc_url, slot_b + 3).await;
+
+    let (common, indexer) =
+        backfill_only_config(rpc_url.clone(), db_url.clone(), env.instance, start_slot);
+    run_backfill_only_once(common, indexer)
+        .await
+        .expect("a clean backfill-only run must succeed");
+
+    // The run closes the pool it was given, so assertions need their own.
+    let pool: PgPool = db::connect(&db_url).await?;
+
+    let row_a = db::get_transaction(&pool, &sig_a)
+        .await?
+        .expect("deposit A must be recorded by the repair");
+    let row_b = db::get_transaction(&pool, &sig_b)
+        .await?
+        .expect("deposit B must be recorded by the repair");
+    assert_eq!(row_a.amount.value(), DEPOSIT_AMOUNT_A);
+    assert_eq!(row_b.amount.value(), DEPOSIT_AMOUNT_B);
+    assert_eq!(row_a.slot as u64, slot_a);
+    assert_eq!(row_b.slot as u64, slot_b);
+    assert_eq!(
+        row_a.status, "pending",
+        "a backfilled deposit is queued for the operator, not already serviced"
+    );
+
+    let checkpoint = db::get_checkpoint_slot(&pool, "escrow")
+        .await?
+        .expect("a successful repair must leave a durable checkpoint");
+    assert!(
+        checkpoint >= slot_b,
+        "checkpoint {checkpoint} must cover the last recorded deposit at slot {slot_b}"
+    );
+
+    let count_after_first = db::count_transactions(&pool).await?;
+    assert_eq!(
+        count_after_first, 2,
+        "exactly the two deposits are recorded"
+    );
+
+    // Second run: the range now starts at the committed checkpoint, so the deposits
+    // are below it and are never re-emitted.
+    let (common, indexer) =
+        backfill_only_config(rpc_url.clone(), db_url.clone(), env.instance, start_slot);
+    run_backfill_only_once(common, indexer)
+        .await
+        .expect("re-running a completed repair must still succeed");
+
+    let pool: PgPool = db::connect(&db_url).await?;
+    assert_eq!(
+        db::count_transactions(&pool).await?,
+        count_after_first,
+        "a second repair must not duplicate rows"
+    );
+    let checkpoint_after = db::get_checkpoint_slot(&pool, "escrow").await?.unwrap();
+    assert!(
+        checkpoint_after >= checkpoint,
+        "the checkpoint must never regress across repairs"
+    );
+
+    Ok(())
+}
+
+/// When a slot's rows cannot be written the repair must fail loudly with the storage
+/// error, and must leave the checkpoint below that slot so the next run replays it.
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_only_exits_nonzero_when_slot_writes_fail(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (validator, faucet) = start_test_validator_no_geyser().await;
+    let rpc_url = validator.rpc_url();
+    let client = Arc::new(RpcClient::new_with_commitment(
+        rpc_url.clone(),
+        CommitmentConfig::confirmed(),
+    ));
+    let (db_url, _storage, _pg) = start_postgres("backfill_only_write_fail").await?;
+
+    let env = TestEnvironment::setup(&client, &faucet, 1, USER_BALANCE, None).await?;
+    let user = &env.users[0];
+
+    let start_slot = client.get_slot().await?;
+    let (_sig, deposit_slot) =
+        execute_deposit(&client, user, &env.instance, &env.mint, DEPOSIT_AMOUNT_A).await?;
+    wait_for_finalized_slot(&rpc_url, deposit_slot + 3).await;
+
+    // Reject every insert. NOT VALID skips the scan of existing rows, and the schema
+    // setup the run performs on boot leaves it in place because each statement is
+    // guarded and its one data statement touches no rows on an empty table.
+    let pool: PgPool = db::connect(&db_url).await?;
+    sqlx::query(
+        "ALTER TABLE transactions ADD CONSTRAINT reject_all_inserts CHECK (false) NOT VALID",
+    )
+    .execute(&pool)
+    .await?;
+    pool.close().await;
+
+    let (common, indexer) =
+        backfill_only_config(rpc_url.clone(), db_url.clone(), env.instance, start_slot);
+    let result = run_backfill_only_once(common, indexer).await;
+
+    match result {
+        Err(IndexerError::Storage(_)) => {}
+        other => panic!(
+            "a slot whose rows cannot be written must surface the storage error rather \
+             than a channel or completeness error, got: {other:?}"
+        ),
+    }
+
+    let pool: PgPool = db::connect(&db_url).await?;
+    let checkpoint = db::get_checkpoint_slot(&pool, "escrow").await?;
+    assert!(
+        checkpoint.is_none_or(|slot| slot < deposit_slot),
+        "checkpoint {checkpoint:?} must stay below the unwritten deposit slot \
+         {deposit_slot} so a retry replays it"
+    );
+
+    Ok(())
+}

--- a/integration/tests/indexer/backfill_only_e2e.rs
+++ b/integration/tests/indexer/backfill_only_e2e.rs
@@ -171,6 +171,33 @@ async fn wait_for_finalized_slot(rpc_url: &str, target: u64) {
     }
 }
 
+/// Block until `slot`'s block can actually be fetched.
+///
+/// Finalization alone is not enough: the validator will list a recent slot before its block
+/// is fully readable, and the fill refuses to checkpoint past a block it cannot read. Waiting
+/// on the fetch itself is what makes the range below deterministic.
+async fn wait_for_block_available(rpc_url: &str, slot: u64) {
+    let client = RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::finalized());
+    let config = solana_client::rpc_config::RpcBlockConfig {
+        encoding: Some(UiTransactionEncoding::Json),
+        transaction_details: Some(solana_transaction_status::TransactionDetails::Full),
+        rewards: Some(false),
+        commitment: Some(CommitmentConfig::finalized()),
+        max_supported_transaction_version: Some(0),
+    };
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if client.get_block_with_config(slot, config).await.is_ok() {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for slot {slot} to become fetchable"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+}
+
 /// Submit one escrow deposit and return its signature and confirmed slot.
 async fn execute_deposit(
     client: &RpcClient,
@@ -243,9 +270,6 @@ async fn backfill_only_records_finalized_deposits_and_exits_clean(
     let env = TestEnvironment::setup(&client, &faucet, 1, USER_BALANCE, None).await?;
     let user = &env.users[0];
 
-    // Everything before the first deposit is outside the repair range.
-    let start_slot = client.get_slot().await?;
-
     let (sig_a, slot_a) =
         execute_deposit(&client, user, &env.instance, &env.mint, DEPOSIT_AMOUNT_A).await?;
     let (sig_b, slot_b) =
@@ -253,6 +277,15 @@ async fn backfill_only_records_finalized_deposits_and_exits_clean(
 
     // Headroom past the last deposit so its block is finalized and inside the range.
     wait_for_finalized_slot(&rpc_url, slot_b + 3).await;
+    wait_for_block_available(&rpc_url, slot_a).await;
+    wait_for_block_available(&rpc_url, slot_b).await;
+
+    // Anchor the range at the first deposit rather than at whatever slot the validator
+    // happened to be on at startup. A freshly started validator lists its earliest slots
+    // without always serving their blocks, and the fill refuses to checkpoint past a block
+    // it cannot read, so a range reaching back that far fails on the ledger rather than on
+    // anything this test is about.
+    let start_slot = slot_a;
 
     let (common, indexer) =
         backfill_only_config(rpc_url.clone(), db_url.clone(), env.instance, start_slot);
@@ -331,10 +364,14 @@ async fn backfill_only_exits_nonzero_when_slot_writes_fail(
     let env = TestEnvironment::setup(&client, &faucet, 1, USER_BALANCE, None).await?;
     let user = &env.users[0];
 
-    let start_slot = client.get_slot().await?;
     let (_sig, deposit_slot) =
         execute_deposit(&client, user, &env.instance, &env.mint, DEPOSIT_AMOUNT_A).await?;
     wait_for_finalized_slot(&rpc_url, deposit_slot + 3).await;
+    wait_for_block_available(&rpc_url, deposit_slot).await;
+
+    // Anchored at the deposit for the same reason as the test above: a range reaching back
+    // to the validator's first slots fails on unreadable blocks before it reaches this one.
+    let start_slot = deposit_slot;
 
     // Reject every insert. NOT VALID skips the scan of existing rows, and the schema
     // setup the run performs on boot leaves it in place because each statement is

--- a/integration/tests/indexer/backfill_only_e2e.rs
+++ b/integration/tests/indexer/backfill_only_e2e.rs
@@ -7,7 +7,7 @@
 //! Two properties are pinned here, both of which need real Postgres:
 //!
 //! 1. A clean run records every deposit in the range and advances the durable
-//!    checkpoint to the range top, and re-running it changes nothing.
+//!    checkpoint past the last of them, and re-running it changes nothing.
 //! 2. A run whose slot writes fail exits non-zero carrying the storage error, and
 //!    leaves the checkpoint parked below the slot it could not store, so the next
 //!    attempt replays from there.
@@ -255,7 +255,8 @@ async fn execute_deposit(
 // ── tests ───────────────────────────────────────────────────────────────────
 
 /// A backfill-only repair must record the finalized deposits in its range and only
-/// report success once the checkpoint covers that range. Re-running it must be a no-op.
+/// report success once the checkpoint covers every one of them. Re-running it must be
+/// a no-op.
 #[tokio::test(flavor = "multi_thread")]
 async fn backfill_only_records_finalized_deposits_and_exits_clean(
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/integration/tests/indexer/bootstrap_validation.rs
+++ b/integration/tests/indexer/bootstrap_validation.rs
@@ -86,3 +86,87 @@ async fn run_rejects_escrow_without_instance_id() {
         ),
     }
 }
+
+/// The same guard has to hold in backfill-only mode, which skips startup reconciliation.
+///
+/// Without an instance id the processor drops every escrow instruction as out of scope,
+/// so a repair would store nothing yet still advance the checkpoint over the range it
+/// claimed to fix. Refusing to start is what keeps that range repairable.
+#[tokio::test(flavor = "multi_thread")]
+async fn run_rejects_escrow_without_instance_id_in_backfill_only() {
+    let pg_container = Postgres::default()
+        .with_db_name("bootstrap_validation_backfill_only")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("postgres container must start");
+    let pg_host = pg_container.get_host().await.unwrap();
+    let pg_port = pg_container.get_host_port_ipv4(5432).await.unwrap();
+    let db_url = format!(
+        "postgres://postgres:password@{}:{}/bootstrap_validation_backfill_only",
+        pg_host, pg_port
+    );
+
+    let common_config = PrivateChannelIndexerConfig {
+        program_type: ProgramType::Escrow,
+        storage_type: StorageType::Postgres,
+        rpc_url: "http://127.0.0.1:1".to_string(),
+        source_rpc_url: None,
+        fallback_rpc_url: None,
+        postgres: PostgresConfig {
+            database_url: db_url.clone(),
+            max_connections: 2,
+        },
+        // Deliberately missing: this is the invariant under test.
+        escrow_instance_id: None,
+    };
+
+    let indexer_config = IndexerConfig {
+        datasource_type: DatasourceType::RpcPolling,
+        rpc_polling: None,
+        yellowstone: None,
+        backfill: BackfillConfig {
+            enabled: true,
+            exit_after_backfill: true,
+            rpc_url: "http://127.0.0.1:1".to_string(),
+            batch_size: 100,
+            max_gap_slots: 1_000,
+            start_slot: None,
+        },
+        reconciliation: ReconciliationConfig::default(),
+    };
+
+    let result = run(common_config, indexer_config, None).await;
+
+    let err = result.expect_err(
+        "backfill-only mode must reject Escrow program_type with no escrow_instance_id",
+    );
+    match err {
+        IndexerError::Reconciliation(ReconciliationError::InvalidPubkey { pubkey, reason }) => {
+            assert_eq!(pubkey, "<missing>");
+            assert!(
+                reason.contains("escrow_instance_id"),
+                "reason must mention the missing config field, got: {reason}"
+            );
+        }
+        other => panic!(
+            "expected IndexerError::Reconciliation(InvalidPubkey{{..}}) in backfill-only mode, got: {other:?}"
+        ),
+    }
+
+    // The guard fires before the pipeline exists, so nothing can have been checkpointed.
+    let pool = sqlx::postgres::PgPool::connect(&db_url)
+        .await
+        .expect("assertion pool must connect");
+    let checkpoint: Option<(i64,)> =
+        sqlx::query_as("SELECT last_committed_slot FROM indexer_state WHERE program_type = $1")
+            .bind("escrow")
+            .fetch_optional(&pool)
+            .await
+            .expect("checkpoint lookup must succeed");
+    assert!(
+        checkpoint.is_none(),
+        "a refused start must leave no checkpoint row behind, got {checkpoint:?}"
+    );
+}

--- a/integration/tests/indexer/resync.rs
+++ b/integration/tests/indexer/resync.rs
@@ -124,6 +124,11 @@ async fn start_postgres_for_resync(
 }
 
 /// Source-RPC-only resync service (no channel reconciliation): legacy behavior.
+///
+/// An escrow rebuild is refused without an instance scope, since an unset scope
+/// filters out every escrow instruction and would rebuild an empty DB. These
+/// tests run against a bare validator with no escrow deposits, so the scope only
+/// has to be present; which key it names does not change the outcome.
 fn make_resync_service(rpc_url: String, storage: Arc<Storage>) -> ResyncService {
     let rpc_poller = Arc::new(RpcPoller::new(
         rpc_url.clone(),
@@ -143,7 +148,7 @@ fn make_resync_service(rpc_url: String, storage: Arc<Storage>) -> ResyncService 
         rpc_poller,
         ProgramType::Escrow,
         backfill_config,
-        None,
+        Some(Pubkey::new_unique()),
     )
 }
 

--- a/test_utils/src/validator_helper.rs
+++ b/test_utils/src/validator_helper.rs
@@ -208,6 +208,12 @@ pub async fn start_test_validator() -> (TestValidator, Keypair, u16) {
         full_api: true,
         disable_health_check: true,
         enable_rpc_transaction_history: true,
+        // Inner instructions and logs are only persisted with this on, and the escrow
+        // programs report every deposit and withdrawal through a self-CPI event that the
+        // indexer reads out of the inner instruction list. Without it a block comes back
+        // with the top-level instruction and no event, so anything reading chain history
+        // over RPC decodes each deposit to nothing.
+        enable_extended_tx_metadata_storage: true,
         ..Default::default()
     };
 
@@ -287,6 +293,12 @@ pub async fn start_test_validator_no_geyser() -> (TestValidator, Keypair) {
         full_api: true,
         disable_health_check: true,
         enable_rpc_transaction_history: true,
+        // Inner instructions and logs are only persisted with this on, and the escrow
+        // programs report every deposit and withdrawal through a self-CPI event that the
+        // indexer reads out of the inner instruction list. Without it a block comes back
+        // with the top-level instruction and no event, so anything reading chain history
+        // over RPC decodes each deposit to nothing.
+        enable_extended_tx_metadata_storage: true,
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary

Closes issue 266. Backfill-only mode is used to repair missing finalized deposits or withdrawals, but it previously started the checkpoint writer and backfill producer without starting the transaction processor, which is the component that writes rows and advances the checkpoint. As a result, small repairs could finish successfully while dropping all parsed events, while larger repairs could block on the full instruction channel. A missed deposit could leave funds in escrow without a mint, while a missed withdrawal could leave burned receipt tokens without a release row.

Backfill-only mode now starts and manages the full pipeline: resolve the range, start the writer, spawn the processor, run the backfill, close the sender, join the processor, drain pending events, and verify the final checkpoint before closing the database pool. The processor now receives the escrow instance ID; without it, all escrow instructions are filtered out. The configuration guard is therefore enforced consistently for both backfill and resync. The backfill error is also retained until cleanup so a partial repair preserves the completed prefix, while the final verification fails with `BackfillIncomplete` if the checkpoint did not reach the target.

The same instance-scope validation is now applied to resync before it can drop existing data, and `backfill_only` without `backfill.enabled` is now rejected instead of silently starting live indexing. The live indexing path is unchanged. Tests cover the pipeline, checkpoint verification, configuration guards, idempotent reruns, and write failures that leave the checkpoint safely behind.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 17,749 | 19,421 | 91.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33519179920) |
| Indexer | 37,730 | 41,399 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33519179920) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33519179920) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33519179920) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 15,216 | 19,594 | 77.7% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33519179920) |
| **Total** | **73,641** | **83,812** | **87.9%** | |

> Last updated: 2026-09-01 15:24:18 UTC by E2E Integration