### PR TITLE
fix(indexer): backfill and commit before startup reconciliation instead of after (issue-261)

### DIFF
--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -56,6 +56,12 @@ pub enum ReconciliationError {
     #[error("{count} mint(s) have channel supply above escrow custody by more than {threshold} raw units; see logs for per-mint details")]
     SupplyExceedsCustody { count: usize, threshold: u64 },
 
+    /// Channel supply could not be read at all, so the invariant never ran. Startup stops
+    /// rather than proceed unchecked: an unreadable gateway hides an existing breach just
+    /// as well as a healthy channel does, and the two are indistinguishable from here.
+    #[error("channel supply for {count} mint(s) was unreadable across every attempt; the supply invariant did not run, so custody cannot be vouched for")]
+    SupplyInvariantUnverified { count: usize },
+
     /// The custody reading came from a slot the ledger has already passed, so the two
     /// cannot be compared at a common point and any verdict would be guesswork. Usually a
     /// lagging RPC node, which is why a re-read is worth trying before giving up.

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -144,4 +144,17 @@ pub enum CheckpointError {
 
     #[error("Invalid checkpoint: slot {slot} is before last checkpoint {last}")]
     InvalidCheckpoint { slot: u64, last: u64 },
+
+    /// `last` stays an Option so "stalled at slot N" and "no row was ever written" read
+    /// differently in the log: the first points at an unprocessed slot in the range, the
+    /// second at a checkpoint writer that never flushed. They need different responses.
+    #[error(
+        "Checkpoint for {program_type} reached {last:?}, never {target}, after {waited_secs}s"
+    )]
+    CommitTimeout {
+        program_type: String,
+        last: Option<u64>,
+        target: u64,
+        waited_secs: u64,
+    },
 }

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -62,6 +62,13 @@ pub enum ReconciliationError {
     #[error("channel supply for {count} mint(s) was unreadable across every attempt; the supply invariant did not run, so custody cannot be vouched for")]
     SupplyInvariantUnverified { count: usize },
 
+    /// The two token-program sweeps never answered at the same slot, so the custody
+    /// numbers describe no single point and cannot be compared against a ledger bounded at
+    /// one. Usually a load-balanced endpoint answering from nodes at different heights,
+    /// which is why another sweep is worth trying before giving up.
+    #[error("custody sweeps never settled on one slot after {attempts} attempts (last spread {low}..{high}); custody cannot be pinned to a single point")]
+    CustodySlotUnsettled { attempts: u32, low: u64, high: u64 },
+
     /// The custody reading came from a slot the ledger has already passed, so the two
     /// cannot be compared at a common point and any verdict would be guesswork. Usually a
     /// lagging RPC node, which is why a re-read is worth trying before giving up.

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -56,6 +56,12 @@ pub enum ReconciliationError {
     #[error("{count} mint(s) have channel supply above escrow custody by more than {threshold} raw units; see logs for per-mint details")]
     SupplyExceedsCustody { count: usize, threshold: u64 },
 
+    /// The custody reading came from a slot the ledger has already passed, so the two
+    /// cannot be compared at a common point and any verdict would be guesswork. Usually a
+    /// lagging RPC node, which is why a re-read is worth trying before giving up.
+    #[error("custody was read at slot {snapshot_slot}, behind the committed checkpoint {committed}; the node is answering from behind the ledger")]
+    CustodyBehindLedger { snapshot_slot: u64, committed: u64 },
+
     #[error("Invalid pubkey '{pubkey}': {reason}")]
     InvalidPubkey { pubkey: String, reason: String },
 

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -50,6 +50,12 @@ pub enum ReconciliationError {
     #[error("{count} mint(s) exceed mismatch threshold of {threshold} raw units; see logs for per-mint details")]
     MismatchExceedsThreshold { count: usize, threshold: u64 },
 
+    /// Minted channel supply is above the custody backing it. Kept separate from a
+    /// custody-versus-ledger mismatch because no amount of indexing changes either side
+    /// of this comparison: it reads the chain twice and never touches the database.
+    #[error("{count} mint(s) have channel supply above escrow custody by more than {threshold} raw units; see logs for per-mint details")]
+    SupplyExceedsCustody { count: usize, threshold: u64 },
+
     #[error("Invalid pubkey '{pubkey}': {reason}")]
     InvalidPubkey { pubkey: String, reason: String },
 

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::interval;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 /// Gated ticks with no frontier advance before a stall warning fires (~15s at 5s/tick).
 const STALL_WARN_TICKS: u32 = 3;
@@ -348,6 +348,87 @@ pub async fn get_last_checkpoint(
 
     info!("Last checkpoint for {:?}: {:?}", program_type, checkpoint);
     Ok(checkpoint)
+}
+
+/// Longest startup will wait for a filled range to become durable before giving up.
+///
+/// Sized as a fail-closed backstop rather than a tuning knob. By the time the wait starts
+/// every message has already been sent, and the instruction channel holds at most a
+/// thousand of them, so what remains is the processor draining that buffer plus one flush
+/// interval. Two minutes is far above that, and exceeding it means a slot is genuinely
+/// stuck rather than slow.
+pub const CHECKPOINT_COMMIT_TIMEOUT_SECS: u64 = 120;
+
+/// How often the wait re-reads the durable checkpoint.
+const CHECKPOINT_COMMIT_POLL_MS: u64 = 200;
+
+/// Wait until the durable checkpoint for `program_type` covers `target`.
+///
+/// This is the witness that a backfilled range is both processed and persisted. It is
+/// exact rather than approximate because the writer's gate seeds its frontier at the
+/// range floor and then advances only across contiguous slots, so the checkpoint cannot
+/// reach the target until every slot in between has been fully written.
+///
+/// A read failure is a database blip and is retried; an absent row means the writer has
+/// not flushed for the first time yet, which is normal on a fresh store, so it is also
+/// retried. Only the deadline ends this unsuccessfully, and it does so by failing the
+/// boot: continuing would compare on-chain custody against a ledger still missing a slot.
+pub async fn wait_for_checkpoint_commit(
+    storage: &Arc<Storage>,
+    program_type: ProgramType,
+    target: u64,
+    timeout: Duration,
+) -> Result<(), CheckpointError> {
+    let started = tokio::time::Instant::now();
+    let key = program_key(program_type);
+    let mut last: Option<u64> = None;
+    // Only a successful read tells us anything about the frontier. Without this, a store
+    // whose reads all fail would time out reporting "no row was ever written", sending an
+    // operator after a stalled writer when the real fault is an unreachable database.
+    let mut read_ok = false;
+
+    loop {
+        // Read the row directly rather than through get_last_checkpoint, whose per-call
+        // info log would emit hundreds of lines across a long wait.
+        match storage.get_committed_checkpoint(&key).await {
+            Ok(committed) => {
+                last = committed;
+                read_ok = true;
+                if committed.is_some_and(|slot| slot >= target) {
+                    info!(
+                        "Checkpoint for {:?} committed at {:?}, covering backfill target {}",
+                        program_type, committed, target
+                    );
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Checkpoint read failed while waiting for {:?} to reach {}, retrying: {}",
+                    program_type, target, e
+                );
+            }
+        }
+
+        let waited_secs = started.elapsed().as_secs();
+        if started.elapsed() >= timeout {
+            if !read_ok {
+                error!(
+                    "Checkpoint for {:?} was never readable while waiting for {}; the store \
+                     is unreachable rather than the frontier being stalled",
+                    program_type, target
+                );
+            }
+            return Err(CheckpointError::CommitTimeout {
+                program_type: key,
+                last,
+                target,
+                waited_secs,
+            });
+        }
+
+        tokio::time::sleep(Duration::from_millis(CHECKPOINT_COMMIT_POLL_MS)).await;
+    }
 }
 
 #[cfg(test)]
@@ -743,6 +824,113 @@ mod tests {
 
         assert_eq!(escrow_checkpoint, Some(100));
         assert_eq!(withdraw_checkpoint, Some(200));
+    }
+
+    // ============================================================================
+    // wait_for_checkpoint_commit Tests
+    // ============================================================================
+
+    /// Target the wait tests aim at, and a timeout long enough that only a real
+    /// stall reaches it.
+    const WAIT_TARGET: u64 = 500;
+    const GENEROUS: Duration = Duration::from_secs(5);
+    const IMPATIENT: Duration = Duration::from_millis(400);
+
+    /// Set the escrow checkpoint after a short delay, standing in for the writer's flush.
+    fn commit_after(mock: MockStorage, slot: u64, delay: Duration) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            mock.set_checkpoint("escrow", slot);
+        })
+    }
+
+    /// Both end states belong in one test: a batch flush can land the frontier above the
+    /// target, so an equality check would wait forever on a checkpoint that already
+    /// covers everything the fill produced.
+    #[tokio::test]
+    async fn wait_for_checkpoint_commit_returns_once_target_committed() {
+        for committed in [WAIT_TARGET, WAIT_TARGET + 5] {
+            let mock = MockStorage::new();
+            let storage: Arc<Storage> = Arc::new(Storage::Mock(mock.clone()));
+            let writer = commit_after(mock, committed, Duration::from_millis(150));
+
+            let result =
+                wait_for_checkpoint_commit(&storage, ProgramType::Escrow, WAIT_TARGET, GENEROUS)
+                    .await;
+
+            assert!(
+                result.is_ok(),
+                "a committed checkpoint of {committed} must satisfy target {WAIT_TARGET}"
+            );
+            writer.await.unwrap();
+        }
+    }
+
+    /// A frontier one slot short means a slot in the range was never processed. Failing
+    /// the boot is the point: continuing would compare on-chain custody against a ledger
+    /// that is still missing a slot, which is the bug this wait exists to prevent.
+    #[tokio::test]
+    async fn wait_for_checkpoint_commit_times_out_below_target() {
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", WAIT_TARGET - 1);
+        let storage: Arc<Storage> = Arc::new(Storage::Mock(mock));
+
+        let err = wait_for_checkpoint_commit(&storage, ProgramType::Escrow, WAIT_TARGET, IMPATIENT)
+            .await
+            .expect_err("a frontier below the target must not be accepted");
+
+        match err {
+            CheckpointError::CommitTimeout { last, target, .. } => {
+                assert_eq!(last, Some(WAIT_TARGET - 1));
+                assert_eq!(target, WAIT_TARGET);
+            }
+            other => panic!("expected CommitTimeout, got {other:?}"),
+        }
+    }
+
+    /// A database blip during the wait must not abort a boot that is one flush away from
+    /// succeeding.
+    #[tokio::test]
+    async fn wait_for_checkpoint_commit_rides_out_transient_read_failures() {
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", WAIT_TARGET);
+        mock.set_fail_times("get_committed_checkpoint", 2);
+        let storage: Arc<Storage> = Arc::new(Storage::Mock(mock));
+
+        let result =
+            wait_for_checkpoint_commit(&storage, ProgramType::Escrow, WAIT_TARGET, GENEROUS).await;
+
+        assert!(
+            result.is_ok(),
+            "two failed reads must be retried, not treated as a stall: {result:?}"
+        );
+    }
+
+    /// A store with no row yet is normal for the first moments of a fresh boot, so the
+    /// wait polls on. It still has to end: absence forever is a stall like any other, and
+    /// reporting it as `None` rather than 0 tells an operator the writer never flushed.
+    #[tokio::test]
+    async fn wait_for_checkpoint_commit_treats_absent_row_as_not_yet() {
+        let absent: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+        let err = wait_for_checkpoint_commit(&absent, ProgramType::Escrow, WAIT_TARGET, IMPATIENT)
+            .await
+            .expect_err("an absent row must not be read as a satisfied target");
+
+        match err {
+            CheckpointError::CommitTimeout { last, .. } => assert_eq!(last, None),
+            other => panic!("expected CommitTimeout, got {other:?}"),
+        }
+
+        let mock = MockStorage::new();
+        let storage: Arc<Storage> = Arc::new(Storage::Mock(mock.clone()));
+        let writer = commit_after(mock, WAIT_TARGET, Duration::from_millis(150));
+        assert!(
+            wait_for_checkpoint_commit(&storage, ProgramType::Escrow, WAIT_TARGET, GENEROUS)
+                .await
+                .is_ok(),
+            "a row written mid-wait must satisfy the target"
+        );
+        writer.await.unwrap();
     }
 
     // ============================================================================

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -53,6 +53,8 @@ pub struct YellowstoneSource {
     batch_size: usize,
     #[cfg(feature = "datasource-rpc")]
     storage: Option<Arc<Storage>>,
+    #[cfg(feature = "datasource-rpc")]
+    arm_first_connection: bool,
     health: Option<Arc<private_channel_metrics::HealthState>>,
     /// Silent-stream watchdog window. Defaults to STREAM_STALL_TIMEOUT; overridable
     /// (mainly so tests can drive the reconnect path without a 120s wait).
@@ -81,6 +83,8 @@ impl YellowstoneSource {
             batch_size: 0,
             #[cfg(feature = "datasource-rpc")]
             storage: None,
+            #[cfg(feature = "datasource-rpc")]
+            arm_first_connection: false,
             health: None,
             stall_timeout: STREAM_STALL_TIMEOUT,
         }
@@ -115,6 +119,20 @@ impl YellowstoneSource {
     #[cfg(feature = "datasource-rpc")]
     pub fn with_storage(mut self, storage: Arc<Storage>) -> Self {
         self.storage = Some(storage);
+        self
+    }
+
+    /// Repair the window below the first streamed slot as well as later reconnects.
+    ///
+    /// The first connection normally skips this, on the grounds that startup catch-up
+    /// covers everything below it. That only holds while the catch-up runs alongside the
+    /// stream. When it runs to completion first, the slots produced between its target
+    /// and the first streamed slot belong to neither, and the first streamed slot would
+    /// carry the checkpoint straight over them. Callers that complete their catch-up
+    /// before starting the stream must set this so that window is replayed instead.
+    #[cfg(feature = "datasource-rpc")]
+    pub fn with_first_connection_arming(mut self) -> Self {
+        self.arm_first_connection = true;
         self
     }
 }
@@ -450,6 +468,8 @@ impl DataSource for YellowstoneSource {
         let batch_size = self.batch_size;
         #[cfg(feature = "datasource-rpc")]
         let storage = self.storage.clone();
+        #[cfg(feature = "datasource-rpc")]
+        let arm_first_connection = self.arm_first_connection;
 
         let handle = tokio::spawn(async move {
             // Reconnect gate context, built once; None disables reconnect gating.
@@ -468,11 +488,13 @@ impl DataSource for YellowstoneSource {
             // One in-flight reconnect backfill, owned here and superseded on each reconnect.
             #[cfg(feature = "datasource-rpc")]
             let mut backfill_handle: Option<tokio::task::JoinHandle<()>> = None;
-            // True once some connection has subscribed. Only later connections arm the
-            // reconnect gate; the first stream is a cold start that startup backfill
-            // already covers. A connect that fails before subscribing does not count.
+            // True once some connection has subscribed, which is what makes a connection
+            // arm the reconnect gate. A connect that fails before subscribing does not
+            // count. Seeded true when the caller finished its catch-up before starting
+            // the stream, because then the first connection also has a window below it to
+            // repair rather than a cold start someone else already covered.
             #[cfg(feature = "datasource-rpc")]
-            let mut ever_streamed = false;
+            let mut ever_streamed = arm_first_connection;
 
             loop {
                 if cancellation_token.is_cancelled() {

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -77,6 +77,20 @@ const RECONCILE_RETRY_DELAY_MS: u64 = 2_000;
 #[cfg(all(feature = "datasource-rpc", test))]
 const RECONCILE_RETRY_DELAY_MS: u64 = 10;
 
+/// Whether another fill could plausibly clear this failure.
+///
+/// Only a balance mismatch can be, and only because the chain kept moving while startup
+/// was catching up, so the next fill may pull in the rows that explain it. Storage, RPC,
+/// configuration and corruption faults produce the same answer however many times they
+/// are retried, so they stop the boot on the spot instead of paying for two more fills.
+#[cfg(feature = "datasource-rpc")]
+fn reconcile_error_may_clear(error: &IndexerError) -> bool {
+    matches!(
+        error,
+        IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold { .. })
+    )
+}
+
 /// Compare on-chain escrow custody against the indexed ledger.
 ///
 /// A non-escrow program has no custody to check and returns immediately. The instance id
@@ -364,7 +378,7 @@ pub async fn run(
                     .await
                 {
                     Ok(()) => break,
-                    Err(e) if attempt < RECONCILE_MAX_ATTEMPTS => {
+                    Err(e) if attempt < RECONCILE_MAX_ATTEMPTS && reconcile_error_may_clear(&e) => {
                         warn!(
                             "Startup reconciliation attempt {}/{} did not balance, retrying \
                              after letting the chain move on: {}",
@@ -584,6 +598,54 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Only a balance mismatch earns another fill. Retrying the rest would repeat the
+    /// whole range resolution and fill twice over before failing with the same error,
+    /// and would log an infrastructure fault as if the books were out by a deposit.
+    #[cfg(feature = "datasource-rpc")]
+    #[test]
+    fn only_a_balance_mismatch_is_worth_another_fill() {
+        let cases = [
+            (
+                ReconciliationError::MismatchExceedsThreshold {
+                    count: 1,
+                    threshold: 0,
+                },
+                true,
+            ),
+            (
+                ReconciliationError::Rpc {
+                    mint: "mint".to_string(),
+                    reason: "unreachable".to_string(),
+                },
+                false,
+            ),
+            (ReconciliationError::MissingChannelRpc, false),
+            (
+                ReconciliationError::InvalidPubkey {
+                    pubkey: "bad".to_string(),
+                    reason: "malformed".to_string(),
+                },
+                false,
+            ),
+            (
+                ReconciliationError::DbBalanceOverflow {
+                    mint: "mint".to_string(),
+                    net: "1".to_string(),
+                },
+                false,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let rendered = error.to_string();
+            assert_eq!(
+                reconcile_error_may_clear(&IndexerError::Reconciliation(error)),
+                expected,
+                "wrong retry decision for: {rendered}"
+            );
+        }
+    }
 
     /// A ready shutdown future must not steal the race from an already-finished
     /// processor: the biased select reports the processor's fatal error so run()

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -79,10 +79,10 @@ const RECONCILE_RETRY_DELAY_MS: u64 = 10;
 
 /// Whether another fill could plausibly clear this failure.
 ///
-/// Only a balance mismatch can be, and only because the chain kept moving while startup
-/// was catching up, so the next fill may pull in the rows that explain it. Storage, RPC,
-/// configuration and corruption faults produce the same answer however many times they
-/// are retried, so they stop the boot on the spot instead of paying for two more fills.
+/// Only a custody-versus-ledger mismatch can be, and only because the chain kept moving
+/// while startup was catching up, so the next fill may pull in the rows that explain it.
+/// Everything else, a supply breach included, compares the same two numbers however many
+/// times it runs, so it stops the boot on the spot instead of paying for two more fills.
 #[cfg(feature = "datasource-rpc")]
 fn reconcile_error_may_clear(error: &IndexerError) -> bool {
     matches!(
@@ -617,6 +617,13 @@ mod tests {
                 ReconciliationError::Rpc {
                     mint: "mint".to_string(),
                     reason: "unreachable".to_string(),
+                },
+                false,
+            ),
+            (
+                ReconciliationError::SupplyExceedsCustody {
+                    count: 1,
+                    threshold: 0,
                 },
                 false,
             ),

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -20,7 +20,9 @@ use crate::{
     error::BackfillError,
     indexer::{
         backfill::{BackfillService, StartupRange},
-        checkpoint::{wait_for_checkpoint_commit, CHECKPOINT_COMMIT_TIMEOUT_SECS},
+        checkpoint::{
+            get_last_checkpoint, wait_for_checkpoint_commit, CHECKPOINT_COMMIT_TIMEOUT_SECS,
+        },
     },
     operator::escrow_sweep::CustodySnapshot,
 };
@@ -80,17 +82,20 @@ const RECONCILE_RETRY_DELAY_MS: u64 = 2_000;
 #[cfg(all(feature = "datasource-rpc", test))]
 const RECONCILE_RETRY_DELAY_MS: u64 = 10;
 
-/// Whether another fill could plausibly clear this failure.
+/// Whether another attempt could plausibly clear this failure.
 ///
-/// Only a custody-versus-ledger mismatch can be, and only because the chain kept moving
-/// while startup was catching up, so the next fill may pull in the rows that explain it.
-/// Everything else, a supply breach included, compares the same two numbers however many
-/// times it runs, so it stops the boot on the spot instead of paying for two more fills.
+/// Two can. A custody-versus-ledger mismatch may be explained by rows the next fill pulls
+/// in. A custody reading from behind our own ledger is a node that has not caught up, and
+/// a fresh read usually lands ahead of it. Everything else, a supply breach included,
+/// compares the same numbers however many times it runs, so it stops the boot on the spot.
 #[cfg(feature = "datasource-rpc")]
 fn reconcile_error_may_clear(error: &IndexerError) -> bool {
     matches!(
         error,
-        IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold { .. })
+        IndexerError::Reconciliation(
+            ReconciliationError::MismatchExceedsThreshold { .. }
+                | ReconciliationError::CustodyBehindLedger { .. }
+        )
     )
 }
 
@@ -136,6 +141,7 @@ async fn reconcile_escrow_against(
         config,
         common_config.program_type,
         storage,
+        &common_config.rpc_url,
         common_config.source_rpc_url.as_deref(),
         &instance_id,
         snapshot,
@@ -416,39 +422,73 @@ pub async fn run(
                         let snapshot =
                             capture_custody_snapshot(&common_config.rpc_url, &instance_id).await?;
 
+                        // The ledger must not already sit above the reading it is about to
+                        // be judged by. If it does, the node is answering from behind us
+                        // and there is no slot at which the two can be compared, so refuse
+                        // rather than reach a verdict from an incomplete custody view.
+                        let committed = get_last_checkpoint(&storage, common_config.program_type)
+                            .await?
+                            .unwrap_or(0);
+                        if snapshot.slot < committed {
+                            let behind = IndexerError::Reconciliation(
+                                ReconciliationError::CustodyBehindLedger {
+                                    snapshot_slot: snapshot.slot,
+                                    committed,
+                                },
+                            );
+                            if attempt < RECONCILE_MAX_ATTEMPTS {
+                                warn!(
+                                    "Startup reconciliation attempt {}/{}: {}, re-reading",
+                                    attempt, RECONCILE_MAX_ATTEMPTS, behind
+                                );
+                                tokio::time::sleep(Duration::from_millis(RECONCILE_RETRY_DELAY_MS))
+                                    .await;
+                                continue;
+                            }
+                            return Err(behind);
+                        }
+
                         let range = resolve_startup_range(&backfill_service).await?;
 
-                        // Pin the live source to backfill's boundary so it resumes with no
-                        // hole and no overlap. Taken from the last attempt, which resolved
-                        // highest.
-                        rpc_live_start_slot = Some(range.live_start_slot);
                         // The floor, never the target: the range above it is not filled yet.
                         #[cfg(feature = "datasource-yellowstone")]
                         {
                             startup_anchor_hint = Some(range.anchor);
                         }
 
-                        if let Some((from_slot, target)) = range.gap {
+                        // Fill up to the snapshot's slot rather than the chain tip. Stopping
+                        // exactly where custody was measured is what makes the comparison
+                        // total: the ledger ends at that slot, custody describes that slot,
+                        // and there is no band of rows above it that the comparison would
+                        // have to leave unexamined.
+                        let ledger_end = if snapshot.slot > range.anchor {
                             arm_and_fill(
                                 &backfill_service,
                                 &instruction_tx,
                                 common_config.program_type,
-                                from_slot,
-                                target,
+                                range.anchor,
+                                snapshot.slot,
                             )
                             .await?;
 
                             wait_for_checkpoint_commit(
                                 &storage,
                                 common_config.program_type,
-                                target,
+                                snapshot.slot,
                                 Duration::from_secs(CHECKPOINT_COMMIT_TIMEOUT_SECS),
                             )
                             .await?;
                             info!("Backfill completed successfully");
+                            snapshot.slot
                         } else {
                             info!("No backfill gap; checkpoint writer left ungated");
-                        }
+                            range.anchor
+                        };
+
+                        // One past whatever the ledger now covers. The fill stopped short of
+                        // the tip, so the resolved live start would leave everything between
+                        // the two unread by either producer.
+                        rpc_live_start_slot = Some(ledger_end + 1);
 
                         match reconcile_escrow_against(
                             &indexer_config.reconciliation,
@@ -749,6 +789,14 @@ mod tests {
                     threshold: 0,
                 },
                 false,
+            ),
+            // A lagging node usually catches up, so this one is worth re-reading.
+            (
+                ReconciliationError::CustodyBehindLedger {
+                    snapshot_slot: 90,
+                    committed: 100,
+                },
+                true,
             ),
             (ReconciliationError::MissingChannelRpc, false),
             (

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -1,9 +1,11 @@
-use crate::config::ProgramType;
+use crate::config::{ProgramType, ReconciliationConfig};
 use crate::error::{DataSourceError, IndexerError, ReconciliationError};
 use crate::{
     indexer::{
-        checkpoint::CheckpointWriter, datasource::common::datasource::DataSource,
-        reconciliation::run_startup_reconciliation, transaction_processor::TransactionProcessor,
+        checkpoint::{CheckpointMsg, CheckpointWriter},
+        datasource::common::{datasource::DataSource, types::ProcessorMessage},
+        reconciliation::run_startup_reconciliation,
+        transaction_processor::TransactionProcessor,
     },
     shutdown_utils::{cleanup_after_backfill, shutdown_indexer},
     storage::{PostgresDb, Storage},
@@ -11,7 +13,16 @@ use crate::{
 };
 
 #[cfg(feature = "datasource-rpc")]
-use crate::indexer::backfill::BackfillService;
+use crate::{
+    channel_utils::send_guaranteed,
+    error::BackfillError,
+    indexer::{
+        backfill::BackfillService,
+        checkpoint::{wait_for_checkpoint_commit, CHECKPOINT_COMMIT_TIMEOUT_SECS},
+    },
+};
+#[cfg(feature = "datasource-rpc")]
+use std::time::Duration;
 
 #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
 use crate::indexer::backfill::ensure_startup_anchor;
@@ -22,10 +33,13 @@ use crate::indexer::datasource::rpc_polling::{rpc::RpcPoller, RpcPollingSource};
 #[cfg(feature = "datasource-yellowstone")]
 use crate::indexer::datasource::yellowstone::YellowstoneSource;
 use private_channel_metrics::HealthState;
+use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
 use tokio::signal;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+#[cfg(feature = "datasource-rpc")]
+use tracing::warn;
 use tracing::{error, info};
 
 /// Which side of the processor-vs-shutdown race fired.
@@ -52,6 +66,94 @@ async fn supervise(
     }
 }
 
+/// Reconcile attempts before a mismatch is treated as real rather than as a deposit that
+/// landed while startup was still catching up.
+#[cfg(feature = "datasource-rpc")]
+const RECONCILE_MAX_ATTEMPTS: u32 = 3;
+
+/// Pause between reconcile attempts, so the next one has new slots to pull in.
+#[cfg(all(feature = "datasource-rpc", not(test)))]
+const RECONCILE_RETRY_DELAY_MS: u64 = 2_000;
+#[cfg(all(feature = "datasource-rpc", test))]
+const RECONCILE_RETRY_DELAY_MS: u64 = 10;
+
+/// Compare on-chain escrow custody against the indexed ledger.
+///
+/// A non-escrow program has no custody to check and returns immediately. The instance id
+/// is validated once at startup, so its absence here can only mean a non-escrow program.
+async fn reconcile_escrow(
+    config: &ReconciliationConfig,
+    common_config: &PrivateChannelIndexerConfig,
+    storage: &Arc<Storage>,
+) -> Result<(), IndexerError> {
+    let Some(instance_id) = common_config.escrow_instance_id else {
+        return Ok(());
+    };
+
+    run_startup_reconciliation(
+        config,
+        common_config.program_type,
+        storage,
+        &common_config.rpc_url,
+        // For the escrow indexer, source_rpc_url is the channel (gateway) handle used
+        // only for the supply invariant; None skips it.
+        common_config.source_rpc_url.as_deref(),
+        &instance_id,
+    )
+    .await
+}
+
+/// Build the service that resolves and fills the startup range.
+#[cfg(feature = "datasource-rpc")]
+fn build_backfill_service(
+    storage: Arc<Storage>,
+    common_config: &PrivateChannelIndexerConfig,
+    indexer_config: &IndexerConfig,
+) -> Result<BackfillService, IndexerError> {
+    let rpc_polling_config =
+        indexer_config
+            .rpc_polling
+            .as_ref()
+            .ok_or_else(|| DataSourceError::InvalidConfig {
+                reason: "RPC polling config required for backfill".to_string(),
+            })?;
+
+    let rpc_poller = Arc::new(RpcPoller::new(
+        indexer_config.backfill.rpc_url.clone(),
+        rpc_polling_config.encoding,
+        rpc_polling_config.commitment,
+    ));
+
+    Ok(BackfillService::new(
+        storage,
+        rpc_poller,
+        common_config.program_type,
+        indexer_config.backfill.clone(),
+        common_config.escrow_instance_id,
+    ))
+}
+
+/// Spawn the processor that turns decoded instructions into rows and checkpoint updates.
+fn spawn_transaction_processor(
+    storage: Arc<Storage>,
+    checkpoint_tx: mpsc::Sender<CheckpointMsg>,
+    instruction_rx: mpsc::Receiver<ProcessorMessage>,
+    escrow_instance_id: Option<Pubkey>,
+    health: Option<Arc<HealthState>>,
+) -> tokio::task::JoinHandle<Result<(), IndexerError>> {
+    let mut transaction_processor = TransactionProcessor::new(storage, checkpoint_tx);
+    // Wire the escrow instance scope. Config validation guarantees Some for the
+    // Escrow program; None here means the Withdraw program, where no instance
+    // scoping applies.
+    if let Some(instance_id) = escrow_instance_id {
+        transaction_processor = transaction_processor.with_escrow_instance_id(instance_id);
+    }
+    if let Some(h) = health {
+        transaction_processor = transaction_processor.with_health(h);
+    }
+    tokio::spawn(transaction_processor.start(instruction_rx))
+}
+
 pub async fn run(
     common_config: PrivateChannelIndexerConfig,
     indexer_config: IndexerConfig,
@@ -75,61 +177,102 @@ pub async fn run(
     storage.init_schema().await?;
     info!("Storage initialized");
 
-    // 2. Startup reconciliation (escrow only, before any data processing).
+    // 2. Validate the escrow reconciliation wiring before doing any work.
     //
-    // Skip when running in backfill-only mode (backfill.enabled &&
-    // backfill.exit_after_backfill). In that mode the DB is intentionally
-    // incomplete — reconciling it against the current on-chain state would
-    // produce false positives and block the very operation that repairs the
-    // discrepancy. Concurrent backfill (exit_after_backfill = false) still
-    // runs reconciliation because the live datasource is about to start.
+    // Only the config check runs here. The reconciliation itself compares on-chain
+    // custody against the database, so it has to wait until backfill has finished
+    // importing whatever the database is missing; running it first compares live
+    // custody against a ledger that is knowingly stale. This check has no such
+    // dependency, so keeping it here makes a misconfiguration fail in milliseconds
+    // instead of after a full backfill.
     let backfill_only =
         indexer_config.backfill.enabled && indexer_config.backfill.exit_after_backfill;
-    if !backfill_only {
-        match (common_config.program_type, common_config.escrow_instance_id) {
-            (ProgramType::Escrow, Some(seed)) => {
-                run_startup_reconciliation(
-                    &indexer_config.reconciliation,
-                    common_config.program_type,
-                    &storage,
-                    &common_config.rpc_url,
-                    // For the escrow indexer, source_rpc_url is the channel (gateway)
-                    // handle used only for the supply invariant; None skips it.
-                    common_config.source_rpc_url.as_deref(),
-                    &seed,
-                )
-                .await?;
-            }
-            (ProgramType::Escrow, None) => {
-                return Err(IndexerError::Reconciliation(
-                    ReconciliationError::InvalidPubkey {
-                        pubkey: "<missing>".to_string(),
-                        reason: "escrow_instance_id is required for escrow reconciliation"
-                            .to_string(),
-                    },
-                ));
-            }
-            _ => {
-                info!("Startup reconciliation skipped (non-escrow program)");
-            }
+    match (common_config.program_type, common_config.escrow_instance_id) {
+        (ProgramType::Escrow, None) => {
+            return Err(IndexerError::Reconciliation(
+                ReconciliationError::InvalidPubkey {
+                    pubkey: "<missing>".to_string(),
+                    reason: "escrow_instance_id is required for escrow reconciliation".to_string(),
+                },
+            ));
         }
-    } else {
+        (ProgramType::Escrow, Some(_)) => {}
+        _ => {
+            info!("Startup reconciliation skipped (non-escrow program)");
+        }
+    }
+
+    if backfill_only {
         info!("Startup reconciliation skipped (backfill-only mode)");
+    } else if !indexer_config.backfill.enabled {
+        // No import is configured, so the ledger will not get any more complete than it
+        // is right now and the comparison is as meaningful here as anywhere.
+        reconcile_escrow(&indexer_config.reconciliation, &common_config, &storage).await?;
     }
 
     // 3. Create channels
     let (instruction_tx, instruction_rx) = mpsc::channel(1000);
     let (checkpoint_tx, checkpoint_rx) = mpsc::channel(1000);
 
-    // 4. Resolve the backfill range, gate the checkpoint writer to it, then start
-    //    the writer. Checkpoint updates only begin once the processor starts further
-    //    below (step 8), so the gate is always in place before the first update —
-    //    no live-tip slot can slip past it and push the checkpoint over the gap.
-    let mut checkpoint_writer = CheckpointWriter::new(storage.clone());
+    // 4a. Backfill-only mode is self-contained: it gates the writer to the fill range,
+    //     runs the fill and exits. Nothing below this point applies to it.
+    if backfill_only {
+        #[cfg(not(feature = "datasource-rpc"))]
+        return Err(DataSourceError::InvalidConfig {
+            reason: "Datasource rpc needs to be enabled for backfilling".to_string(),
+        }
+        .into());
+
+        #[cfg(feature = "datasource-rpc")]
+        {
+            let backfill_service =
+                build_backfill_service(storage.clone(), &common_config, &indexer_config)?;
+
+            // Gate the writer to the fill range so a withheld (failed-write) slot stalls
+            // the checkpoint instead of being leapfrogged by a later one. No live stream,
+            // so a resolve failure fails closed rather than falling back to ungated.
+            let mut checkpoint_writer = CheckpointWriter::new(storage.clone());
+            let range = backfill_service.resolve_range().await?;
+            if let Some((from_slot, target)) = range.gap {
+                checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
+            }
+            let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
+            info!("CheckpointWriter service started");
+            if let Some((from_slot, target)) = range.gap {
+                backfill_service
+                    .run_range(from_slot, target, instruction_tx.clone())
+                    .await?;
+            }
+            info!("Backfill completed, performing graceful cleanup...");
+            if let Err(e) = cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage).await
+            {
+                error!("Cleanup after backfill failed: {}", e);
+                return Err(IndexerError::ShutdownChannelSend);
+            }
+            return Ok(());
+        }
+    }
+
+    // 4b. Start the checkpoint writer ungated. When a fill runs below it arms the gate
+    //     in-band with a Regate that rides ahead of the slots it protects, which also
+    //     lets a second attempt re-arm over a range the first one did not cover.
+    let checkpoint_handle = CheckpointWriter::new(storage.clone()).start(checkpoint_rx);
+    info!("CheckpointWriter service started");
+
+    // 4c. Start the processor before any fill, because the fill blocks on a full
+    //     instruction channel and nothing else drains it. Until the datasource starts
+    //     the processor simply parks waiting for messages.
+    let mut processor_handle = spawn_transaction_processor(
+        storage.clone(),
+        checkpoint_tx.clone(),
+        instruction_rx,
+        common_config.escrow_instance_id,
+        health.clone(),
+    );
 
     // First slot the live RPC source must request, captured from the backfill range so
     // both producers share one boundary. None when backfill is disabled or resolves no
-    // range, in which case step 6 falls back to the configured from_slot.
+    // range, in which case the datasource falls back to the configured from_slot.
     #[cfg(feature = "datasource-rpc")]
     let mut rpc_live_start_slot: Option<u64> = None;
 
@@ -137,89 +280,38 @@ pub async fn run(
     #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
     let mut startup_anchor_hint: Option<u64> = None;
 
+    // Whether a startup fill ran ahead of the live stream, which is what opens the window
+    // the Yellowstone source has to repair on its very first connection.
+    #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
+    let mut backfill_preceded_stream = false;
+
+    // 4d. Fill the missing range, wait for it to become durable, then reconcile.
+    //
+    // Reconciliation compares current on-chain custody against the indexed ledger, so it
+    // can only be trusted once the ledger has caught up. Waiting for the checkpoint, not
+    // merely for the fill to return, is what makes "caught up" verifiable: the gate only
+    // lets the checkpoint reach the target after every slot below it has been written.
+    //
+    // The loop exists because the chain keeps moving. A deposit landing between the range
+    // being resolved and custody being read is on-chain but not yet indexed, and at the
+    // default zero tolerance that is fatal. Each retry re-fills only the slots the
+    // previous attempt took to run, so the window shrinks quickly. A mismatch that
+    // backfilling cannot explain still fails the boot on the final attempt.
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
             reason: "Datasource rpc needs to be enabled for backfilling".to_string(),
-        });
+        }
+        .into());
 
         #[cfg(feature = "datasource-rpc")]
         {
-            use crate::error::DataSourceError;
+            let backfill_service =
+                build_backfill_service(storage.clone(), &common_config, &indexer_config)?;
 
-            let rpc_polling_config = indexer_config.rpc_polling.as_ref().ok_or_else(|| {
-                DataSourceError::InvalidConfig {
-                    reason: "RPC polling config required for backfill".to_string(),
-                }
-            })?;
-            let rpc_poller = Arc::new(RpcPoller::new(
-                indexer_config.backfill.rpc_url.clone(),
-                rpc_polling_config.encoding,
-                rpc_polling_config.commitment,
-            ));
-
-            let backfill_service = BackfillService::new(
-                storage.clone(),
-                rpc_poller,
-                common_config.program_type,
-                indexer_config.backfill.clone(),
-                common_config.escrow_instance_id,
-            );
-
-            if indexer_config.backfill.exit_after_backfill {
-                // Backfill-only: gate the writer to the fill range so a withheld
-                // (failed-write) slot stalls the checkpoint instead of being
-                // leapfrogged by a later one. No live stream, so a resolve failure
-                // fails closed rather than falling back to ungated.
-                let range = backfill_service.resolve_range().await?;
-                if let Some((from_slot, target)) = range.gap {
-                    checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
-                }
-                let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
-                info!("CheckpointWriter service started");
-                if let Some((from_slot, target)) = range.gap {
-                    backfill_service
-                        .run_range(from_slot, target, instruction_tx.clone())
-                        .await?;
-                }
-                info!("Backfill completed, performing graceful cleanup...");
-                if let Err(e) =
-                    cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage).await
-                {
-                    error!("Cleanup after backfill failed: {}", e);
-                    return Err(IndexerError::ShutdownChannelSend);
-                }
-                return Ok(());
-            } else {
-                // Gate the writer to the range backfill will fill. resolve_range retries
-                // transient RPC failures; a persistent failure fails closed (see below).
-                match backfill_service.resolve_range().await {
-                    Ok(range) => {
-                        // Pin the live source to backfill's boundary so it resumes with
-                        // no hole and no overlap, whether or not there is a gap to fill.
-                        rpc_live_start_slot = Some(range.live_start_slot);
-                        // The floor, never the target: the range above it is not filled yet.
-                        #[cfg(feature = "datasource-yellowstone")]
-                        {
-                            startup_anchor_hint = Some(range.anchor);
-                        }
-                        if let Some((from_slot, target)) = range.gap {
-                            checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
-                            let instruction_tx_clone = instruction_tx.clone();
-                            tokio::spawn(async move {
-                                if let Err(e) = backfill_service
-                                    .run_range(from_slot, target, instruction_tx_clone)
-                                    .await
-                                {
-                                    error!("Backfill failed: {}", e);
-                                } else {
-                                    info!("Backfill completed successfully");
-                                }
-                            });
-                        } else {
-                            info!("No backfill gap; checkpoint writer left ungated");
-                        }
-                    }
+            for attempt in 1..=RECONCILE_MAX_ATTEMPTS {
+                let range = match backfill_service.resolve_range().await {
+                    Ok(range) => range,
                     Err(e) => {
                         error!(
                             "Backfill range resolution failed after retries; refusing to start \
@@ -228,13 +320,71 @@ pub async fn run(
                         );
                         return Err(e);
                     }
+                };
+
+                // Pin the live source to backfill's boundary so it resumes with no hole
+                // and no overlap. Taken from the last attempt, which resolved highest.
+                rpc_live_start_slot = Some(range.live_start_slot);
+                // The floor, never the target: the range above it is not filled yet.
+                #[cfg(feature = "datasource-yellowstone")]
+                {
+                    startup_anchor_hint = Some(range.anchor);
                 }
+
+                if let Some((from_slot, target)) = range.gap {
+                    send_guaranteed(
+                        &instruction_tx,
+                        ProcessorMessage::Regate {
+                            program_type: common_config.program_type,
+                            from: from_slot,
+                            target,
+                        },
+                        "Regate (startup backfill)",
+                    )
+                    .await
+                    .map_err(|e| IndexerError::Backfill(BackfillError::ChannelSend(e)))?;
+
+                    backfill_service
+                        .run_range(from_slot, target, instruction_tx.clone())
+                        .await?;
+
+                    wait_for_checkpoint_commit(
+                        &storage,
+                        common_config.program_type,
+                        target,
+                        Duration::from_secs(CHECKPOINT_COMMIT_TIMEOUT_SECS),
+                    )
+                    .await?;
+                    info!("Backfill completed successfully");
+                } else {
+                    info!("No backfill gap; checkpoint writer left ungated");
+                }
+
+                match reconcile_escrow(&indexer_config.reconciliation, &common_config, &storage)
+                    .await
+                {
+                    Ok(()) => break,
+                    Err(e) if attempt < RECONCILE_MAX_ATTEMPTS => {
+                        warn!(
+                            "Startup reconciliation attempt {}/{} did not balance, retrying \
+                             after letting the chain move on: {}",
+                            attempt, RECONCILE_MAX_ATTEMPTS, e
+                        );
+                        // A retry is only worth anything once there are new slots to pull
+                        // in. Reconciling again against a range that has not moved would
+                        // compare the same two numbers and burn the attempt for nothing.
+                        tokio::time::sleep(Duration::from_millis(RECONCILE_RETRY_DELAY_MS)).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+
+            #[cfg(feature = "datasource-yellowstone")]
+            {
+                backfill_preceded_stream = true;
             }
         }
     }
-
-    let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
-    info!("CheckpointWriter service started");
 
     // 6. Start datasource
     let mut datasource: Box<dyn DataSource> = match indexer_config.datasource_type {
@@ -326,13 +476,24 @@ pub async fn run(
                 )
                 .await?;
 
-                source
+                let source = source
                     .with_gap_detection(
                         gap_rpc_poller,
                         indexer_config.backfill.max_gap_slots,
                         indexer_config.backfill.batch_size,
                     )
-                    .with_storage(storage.clone())
+                    .with_storage(storage.clone());
+
+                // A fill that ran to completion above leaves the slots produced since its
+                // target covered by neither it nor the stream, and the first streamed slot
+                // would carry the checkpoint straight over them. Arming the first
+                // connection replays that window instead. The anchor it needs was just
+                // guaranteed above.
+                if backfill_preceded_stream {
+                    source.with_first_connection_arming()
+                } else {
+                    source
+                }
             };
 
             let source = if let Some(h) = health.clone() {
@@ -364,20 +525,6 @@ pub async fn run(
     let datasource_handle = datasource
         .start(instruction_tx.clone(), cancellation_token.clone())
         .await?;
-
-    // 8. Start transaction processor
-    let mut transaction_processor =
-        TransactionProcessor::new(storage.clone(), checkpoint_tx.clone());
-    // Wire the escrow instance scope. Config validation guarantees Some for the
-    // Escrow program; None here means the Withdraw program, where no instance
-    // scoping applies.
-    if let Some(instance_id) = common_config.escrow_instance_id {
-        transaction_processor = transaction_processor.with_escrow_instance_id(instance_id);
-    }
-    if let Some(h) = health.clone() {
-        transaction_processor = transaction_processor.with_health(h);
-    }
-    let mut processor_handle = tokio::spawn(transaction_processor.start(instruction_rx));
 
     info!("Indexer started, waiting for shutdown signal...");
 

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -4,7 +4,9 @@ use crate::{
     indexer::{
         checkpoint::{CheckpointMsg, CheckpointWriter},
         datasource::common::{datasource::DataSource, types::ProcessorMessage},
-        reconciliation::run_startup_reconciliation,
+        reconciliation::{
+            capture_custody_snapshot, reconcile_against_snapshot, run_startup_reconciliation,
+        },
         transaction_processor::TransactionProcessor,
     },
     shutdown_utils::{cleanup_after_backfill, shutdown_indexer},
@@ -17,9 +19,10 @@ use crate::{
     channel_utils::send_guaranteed,
     error::BackfillError,
     indexer::{
-        backfill::BackfillService,
+        backfill::{BackfillService, StartupRange},
         checkpoint::{wait_for_checkpoint_commit, CHECKPOINT_COMMIT_TIMEOUT_SECS},
     },
+    operator::escrow_sweep::CustodySnapshot,
 };
 #[cfg(feature = "datasource-rpc")]
 use std::time::Duration;
@@ -115,6 +118,82 @@ async fn reconcile_escrow(
         &instance_id,
     )
     .await
+}
+
+/// Compare custody captured before the fill against the ledger it has since caught up to.
+#[cfg(feature = "datasource-rpc")]
+async fn reconcile_escrow_against(
+    config: &ReconciliationConfig,
+    common_config: &PrivateChannelIndexerConfig,
+    storage: &Arc<Storage>,
+    snapshot: &CustodySnapshot,
+) -> Result<(), IndexerError> {
+    let Some(instance_id) = common_config.escrow_instance_id else {
+        return Ok(());
+    };
+
+    reconcile_against_snapshot(
+        config,
+        common_config.program_type,
+        storage,
+        common_config.source_rpc_url.as_deref(),
+        &instance_id,
+        snapshot,
+    )
+    .await
+}
+
+/// Work out the startup range, refusing to start rather than running past an unfilled gap.
+#[cfg(feature = "datasource-rpc")]
+async fn resolve_startup_range(
+    backfill_service: &BackfillService,
+) -> Result<StartupRange, IndexerError> {
+    backfill_service.resolve_range().await.inspect_err(|e| {
+        error!(
+            "Backfill range resolution failed after retries; refusing to start rather than \
+             running ungated past the unfilled gap: {}",
+            e
+        );
+    })
+}
+
+/// Arm the checkpoint gate to the range about to be filled.
+///
+/// Sent in band on the instruction channel, so the gate is always applied before any slot
+/// the fill emits and can never be leapfrogged by one that arrives first.
+#[cfg(feature = "datasource-rpc")]
+async fn arm_backfill_gate(
+    instruction_tx: &mpsc::Sender<ProcessorMessage>,
+    program_type: ProgramType,
+    from_slot: u64,
+    target: u64,
+) -> Result<(), IndexerError> {
+    send_guaranteed(
+        instruction_tx,
+        ProcessorMessage::Regate {
+            program_type,
+            from: from_slot,
+            target,
+        },
+        "Regate (startup backfill)",
+    )
+    .await
+    .map_err(|e| IndexerError::Backfill(BackfillError::ChannelSend(e)))
+}
+
+/// Arm the gate and fill the range, returning once every slot has been sent.
+#[cfg(feature = "datasource-rpc")]
+async fn arm_and_fill(
+    backfill_service: &BackfillService,
+    instruction_tx: &mpsc::Sender<ProcessorMessage>,
+    program_type: ProgramType,
+    from_slot: u64,
+    target: u64,
+) -> Result<(), IndexerError> {
+    arm_backfill_gate(instruction_tx, program_type, from_slot, target).await?;
+    backfill_service
+        .run_range(from_slot, target, instruction_tx.clone())
+        .await
 }
 
 /// Build the service that resolves and fills the startup range.
@@ -299,18 +378,24 @@ pub async fn run(
     #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
     let mut backfill_preceded_stream = false;
 
-    // 4d. Fill the missing range, wait for it to become durable, then reconcile.
+    // 4d. Fill the missing range. An escrow indexer waits for that fill to become durable
+    // and reconciles before the stream starts; every other program type keeps the fill
+    // alongside the stream, as it was before, since it has no custody to compare against
+    // and nothing to gain from booting later.
     //
-    // Reconciliation compares current on-chain custody against the indexed ledger, so it
-    // can only be trusted once the ledger has caught up. Waiting for the checkpoint, not
-    // merely for the fill to return, is what makes "caught up" verifiable: the gate only
-    // lets the checkpoint reach the target after every slot below it has been written.
+    // On the escrow path custody is captured BEFORE the fill and the ledger is compared
+    // against it bounded to the slot it was read at. Reading custody afterwards would
+    // judge a ledger frozen at the fill target against a chain that had moved on, and any
+    // deposit finalizing in between would fail the boot at the default zero tolerance.
     //
-    // The loop exists because the chain keeps moving. A deposit landing between the range
-    // being resolved and custody being read is on-chain but not yet indexed, and at the
-    // default zero tolerance that is fatal. Each retry re-fills only the slots the
-    // previous attempt took to run, so the window shrinks quickly. A mismatch that
-    // backfilling cannot explain still fails the boot on the final attempt.
+    // Waiting for the checkpoint, not merely for the fill to return, is what makes
+    // "caught up" verifiable: the gate only lets the checkpoint reach the target once
+    // every slot below it has been written.
+    //
+    // The loop is the safety net for the two things a single snapshot cannot pin down:
+    // the sweep's two per-program calls can land on different slots, and a node can answer
+    // from behind our own checkpoint. Both clear on a re-read. A mismatch that backfilling
+    // cannot explain still fails the boot on the final attempt.
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -323,79 +408,117 @@ pub async fn run(
             let backfill_service =
                 build_backfill_service(storage.clone(), &common_config, &indexer_config)?;
 
-            for attempt in 1..=RECONCILE_MAX_ATTEMPTS {
-                let range = match backfill_service.resolve_range().await {
-                    Ok(range) => range,
-                    Err(e) => {
-                        error!(
-                            "Backfill range resolution failed after retries; refusing to start \
-                             rather than running ungated past the unfilled gap: {}",
-                            e
-                        );
-                        return Err(e);
+            // Only an escrow indexer has custody to compare against, so only it has a
+            // reason to hold the stream back until the fill is durable.
+            match common_config.escrow_instance_id {
+                Some(instance_id) => {
+                    for attempt in 1..=RECONCILE_MAX_ATTEMPTS {
+                        let snapshot =
+                            capture_custody_snapshot(&common_config.rpc_url, &instance_id).await?;
+
+                        let range = resolve_startup_range(&backfill_service).await?;
+
+                        // Pin the live source to backfill's boundary so it resumes with no
+                        // hole and no overlap. Taken from the last attempt, which resolved
+                        // highest.
+                        rpc_live_start_slot = Some(range.live_start_slot);
+                        // The floor, never the target: the range above it is not filled yet.
+                        #[cfg(feature = "datasource-yellowstone")]
+                        {
+                            startup_anchor_hint = Some(range.anchor);
+                        }
+
+                        if let Some((from_slot, target)) = range.gap {
+                            arm_and_fill(
+                                &backfill_service,
+                                &instruction_tx,
+                                common_config.program_type,
+                                from_slot,
+                                target,
+                            )
+                            .await?;
+
+                            wait_for_checkpoint_commit(
+                                &storage,
+                                common_config.program_type,
+                                target,
+                                Duration::from_secs(CHECKPOINT_COMMIT_TIMEOUT_SECS),
+                            )
+                            .await?;
+                            info!("Backfill completed successfully");
+                        } else {
+                            info!("No backfill gap; checkpoint writer left ungated");
+                        }
+
+                        match reconcile_escrow_against(
+                            &indexer_config.reconciliation,
+                            &common_config,
+                            &storage,
+                            &snapshot,
+                        )
+                        .await
+                        {
+                            Ok(()) => break,
+                            Err(e)
+                                if attempt < RECONCILE_MAX_ATTEMPTS
+                                    && reconcile_error_may_clear(&e) =>
+                            {
+                                warn!(
+                                    "Startup reconciliation attempt {}/{} did not balance, \
+                                     retrying with a freshly read custody snapshot: {}",
+                                    attempt, RECONCILE_MAX_ATTEMPTS, e
+                                );
+                                // Worth repeating only once the node has had a moment to
+                                // settle; an immediate re-read would compare the same two
+                                // numbers and burn the attempt for nothing.
+                                tokio::time::sleep(Duration::from_millis(RECONCILE_RETRY_DELAY_MS))
+                                    .await;
+                            }
+                            Err(e) => return Err(e),
+                        }
                     }
-                };
 
-                // Pin the live source to backfill's boundary so it resumes with no hole
-                // and no overlap. Taken from the last attempt, which resolved highest.
-                rpc_live_start_slot = Some(range.live_start_slot);
-                // The floor, never the target: the range above it is not filled yet.
-                #[cfg(feature = "datasource-yellowstone")]
-                {
-                    startup_anchor_hint = Some(range.anchor);
+                    // Only this path leaves a window between the fill and the first
+                    // streamed slot; a concurrent fill still covers the cold start itself.
+                    #[cfg(feature = "datasource-yellowstone")]
+                    {
+                        backfill_preceded_stream = true;
+                    }
                 }
+                None => {
+                    let range = resolve_startup_range(&backfill_service).await?;
+                    rpc_live_start_slot = Some(range.live_start_slot);
+                    #[cfg(feature = "datasource-yellowstone")]
+                    {
+                        startup_anchor_hint = Some(range.anchor);
+                    }
 
-                if let Some((from_slot, target)) = range.gap {
-                    send_guaranteed(
-                        &instruction_tx,
-                        ProcessorMessage::Regate {
-                            program_type: common_config.program_type,
-                            from: from_slot,
+                    if let Some((from_slot, target)) = range.gap {
+                        // Armed out here rather than inside the task so the gate is in
+                        // place before the datasource below can emit its first slot.
+                        arm_backfill_gate(
+                            &instruction_tx,
+                            common_config.program_type,
+                            from_slot,
                             target,
-                        },
-                        "Regate (startup backfill)",
-                    )
-                    .await
-                    .map_err(|e| IndexerError::Backfill(BackfillError::ChannelSend(e)))?;
-
-                    backfill_service
-                        .run_range(from_slot, target, instruction_tx.clone())
+                        )
                         .await?;
 
-                    wait_for_checkpoint_commit(
-                        &storage,
-                        common_config.program_type,
-                        target,
-                        Duration::from_secs(CHECKPOINT_COMMIT_TIMEOUT_SECS),
-                    )
-                    .await?;
-                    info!("Backfill completed successfully");
-                } else {
-                    info!("No backfill gap; checkpoint writer left ungated");
-                }
-
-                match reconcile_escrow(&indexer_config.reconciliation, &common_config, &storage)
-                    .await
-                {
-                    Ok(()) => break,
-                    Err(e) if attempt < RECONCILE_MAX_ATTEMPTS && reconcile_error_may_clear(&e) => {
-                        warn!(
-                            "Startup reconciliation attempt {}/{} did not balance, retrying \
-                             after letting the chain move on: {}",
-                            attempt, RECONCILE_MAX_ATTEMPTS, e
-                        );
-                        // A retry is only worth anything once there are new slots to pull
-                        // in. Reconciling again against a range that has not moved would
-                        // compare the same two numbers and burn the attempt for nothing.
-                        tokio::time::sleep(Duration::from_millis(RECONCILE_RETRY_DELAY_MS)).await;
+                        let instruction_tx_clone = instruction_tx.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = backfill_service
+                                .run_range(from_slot, target, instruction_tx_clone)
+                                .await
+                            {
+                                error!("Backfill failed: {}", e);
+                            } else {
+                                info!("Backfill completed successfully");
+                            }
+                        });
+                    } else {
+                        info!("No backfill gap; checkpoint writer left ungated");
                     }
-                    Err(e) => return Err(e),
                 }
-            }
-
-            #[cfg(feature = "datasource-yellowstone")]
-            {
-                backfill_preceded_stream = true;
             }
         }
     }

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -95,6 +95,7 @@ fn reconcile_error_may_clear(error: &IndexerError) -> bool {
         IndexerError::Reconciliation(
             ReconciliationError::MismatchExceedsThreshold { .. }
                 | ReconciliationError::CustodyBehindLedger { .. }
+                | ReconciliationError::CustodySlotUnsettled { .. }
         )
     )
 }
@@ -419,8 +420,31 @@ pub async fn run(
             match common_config.escrow_instance_id {
                 Some(instance_id) => {
                     for attempt in 1..=RECONCILE_MAX_ATTEMPTS {
+                        // A sweep that never settled on one slot gets the same second
+                        // chance a mismatch does: the node was moving under it, and the
+                        // next sweep may catch it still. Anything else is fatal here.
                         let snapshot =
-                            capture_custody_snapshot(&common_config.rpc_url, &instance_id).await?;
+                            match capture_custody_snapshot(&common_config.rpc_url, &instance_id)
+                                .await
+                            {
+                                Ok(snapshot) => snapshot,
+                                Err(e)
+                                    if attempt < RECONCILE_MAX_ATTEMPTS
+                                        && reconcile_error_may_clear(&e) =>
+                                {
+                                    warn!(
+                                        "Startup reconciliation attempt {}/{} could not take a \
+                                     custody snapshot, re-reading: {}",
+                                        attempt, RECONCILE_MAX_ATTEMPTS, e
+                                    );
+                                    tokio::time::sleep(Duration::from_millis(
+                                        RECONCILE_RETRY_DELAY_MS,
+                                    ))
+                                    .await;
+                                    continue;
+                                }
+                                Err(e) => return Err(e),
+                            };
 
                         // The ledger must not already sit above the reading it is about to
                         // be judged by. If it does, the node is answering from behind us

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -205,6 +205,11 @@ pub async fn reconcile_against_snapshot(
 /// Readings a supply breach must appear in, consecutively, before it is believed.
 const SUPPLY_BREACH_CONFIRMATIONS: u32 = 3;
 
+/// Ceiling on reading rounds. A round whose supply read fails proves nothing either way,
+/// so it buys a replacement round instead of counting: a flaky RPC must not shorten the
+/// rule to fewer than SUPPLY_BREACH_CONFIRMATIONS real comparisons.
+const SUPPLY_BREACH_MAX_ROUNDS: u32 = SUPPLY_BREACH_CONFIRMATIONS * 2;
+
 /// Pause between those readings, so each one sees a genuinely later state of both chains.
 #[cfg(not(test))]
 const SUPPLY_BREACH_RECHECK_DELAY_MS: u64 = 500;
@@ -221,6 +226,14 @@ struct SupplyBreach {
     gap: u64,
 }
 
+/// What a single reading round learned: the mints it found breaching, and the mints it
+/// could not read at all. The two are kept apart because a read that failed is not
+/// evidence that a mint recovered, and only evidence of recovery may clear a breach.
+struct SupplyReading {
+    breaches: Vec<SupplyBreach>,
+    unread: HashSet<Pubkey>,
+}
+
 /// Take one reading of every mint's channel supply and compare it against escrow custody.
 ///
 /// Supplies are read first and custody after, so the custody reading cannot be missing a
@@ -235,10 +248,11 @@ async fn measure_supply_breaches(
     config: &ReconciliationConfig,
     results: &[MintReconciliation],
     only: Option<&HashSet<Pubkey>>,
-) -> Result<Vec<SupplyBreach>, IndexerError> {
+) -> Result<SupplyReading, IndexerError> {
     // Same mint universe as the ledger comparison, so a mint is never dropped from the
     // invariant just because it holds nothing on chain.
     let mut supplies: Vec<(&MintReconciliation, Pubkey, u64)> = Vec::new();
+    let mut unread: HashSet<Pubkey> = HashSet::new();
     for r in results {
         let mint = r
             .mint
@@ -253,17 +267,21 @@ async fn measure_supply_breaches(
         match fetch_channel_supply(channel_rpc, &mint).await {
             Ok(supply) => supplies.push((r, mint, supply)),
             Err(e) => {
+                unread.insert(mint);
                 warn!(
                     mint = %r.mint,
                     reason = %e.reason,
-                    "Startup supply invariant: channel supply read failed, skipping this mint"
+                    "Startup supply invariant: channel supply read failed"
                 );
             }
         }
     }
 
     if supplies.is_empty() {
-        return Ok(Vec::new());
+        return Ok(SupplyReading {
+            breaches: Vec::new(),
+            unread,
+        });
     }
 
     let custody = capture_custody_snapshot(escrow_rpc_url, instance_pda).await?;
@@ -288,7 +306,7 @@ async fn measure_supply_breaches(
             });
         }
     }
-    Ok(breaches)
+    Ok(SupplyReading { breaches, unread })
 }
 
 /// Fail startup if any mint's channel supply exceeds the custody backing it.
@@ -300,9 +318,11 @@ async fn measure_supply_breaches(
 /// same persistence rule the runtime invariant uses. A real insolvency does not heal
 /// between reads, so this costs nothing on a healthy boot and nothing in detection.
 ///
-/// A per-mint supply read that errors is skipped with a warn rather than aborting the boot:
-/// the channel RPC (gateway) may not be ready yet, the runtime loop is the primary control,
-/// and a transient read must not crash-loop the indexer.
+/// A supply read that errors is skipped with a warn rather than aborting the boot: the
+/// channel RPC (gateway) may not be ready yet, the runtime loop is the primary control, and
+/// a transient read must not crash-loop the indexer. Once a mint has breached, though, the
+/// same silence means the opposite. Nothing has retracted the breach, so it keeps its
+/// suspect status and the boot fails if no later round ever reads it clean.
 async fn check_channel_supply_invariant(
     channel_rpc_url: &str,
     escrow_rpc_url: &str,
@@ -319,10 +339,13 @@ async fn check_channel_supply_invariant(
     // Each round re-reads only what the previous one suspected, so a mint has to breach in
     // every reading to survive to the end.
     let mut suspects: Option<HashSet<Pubkey>> = None;
-    let mut confirmed: Vec<SupplyBreach> = Vec::new();
+    // Per mint: its latest breach numbers, and how many readings have shown that breach.
+    // Counted per mint because the rule is about one mint's own history; a shared counter
+    // would let a mint seen breaching once ride out on rounds other mints supplied.
+    let mut standing: BTreeMap<Pubkey, (SupplyBreach, u32)> = BTreeMap::new();
 
-    for attempt in 1..=SUPPLY_BREACH_CONFIRMATIONS {
-        let breaches = measure_supply_breaches(
+    for round in 1..=SUPPLY_BREACH_MAX_ROUNDS {
+        let reading = measure_supply_breaches(
             &channel_rpc,
             escrow_rpc_url,
             instance_pda,
@@ -332,18 +355,52 @@ async fn check_channel_supply_invariant(
         )
         .await?;
 
-        if breaches.is_empty() {
+        // A suspect the node would not answer for is not evidence that it recovered, so it
+        // stays a suspect. A mint with no breach behind it is still skipped on a failed
+        // read: the channel RPC may simply not be up yet this early in the boot.
+        let unresolved: HashSet<Pubkey> = match suspects.as_ref() {
+            Some(prior) => reading.unread.intersection(prior).copied().collect(),
+            None => HashSet::new(),
+        };
+
+        if reading.breaches.is_empty() && unresolved.is_empty() {
             return Ok(());
         }
 
-        suspects = Some(breaches.iter().map(|b| b.key).collect());
-        confirmed = breaches;
+        // Carry forward only what this round still holds against: a mint read cleanly here
+        // is out, whatever an earlier round said about it.
+        let mut still: HashSet<Pubkey> = reading.breaches.iter().map(|b| b.key).collect();
+        still.extend(unresolved.iter().copied());
+        standing.retain(|mint, _| still.contains(mint));
 
-        if attempt < SUPPLY_BREACH_CONFIRMATIONS {
+        // A breach reading advances that mint's count; a round that could not read it
+        // neither advances nor resets it, having shown nothing either way.
+        for b in reading.breaches {
+            match standing.get_mut(&b.key) {
+                Some((detail, readings)) => {
+                    *detail = b;
+                    *readings += 1;
+                }
+                None => {
+                    standing.insert(b.key, (b, 1));
+                }
+            }
+        }
+        suspects = Some(still);
+
+        if standing
+            .values()
+            .any(|(_, readings)| *readings >= SUPPLY_BREACH_CONFIRMATIONS)
+        {
+            break;
+        }
+
+        if round < SUPPLY_BREACH_MAX_ROUNDS {
             warn!(
-                mint_count = confirmed.len(),
-                attempt,
-                confirmations = SUPPLY_BREACH_CONFIRMATIONS,
+                mint_count = standing.len(),
+                round,
+                required = SUPPLY_BREACH_CONFIRMATIONS,
+                unresolved = unresolved.len(),
                 "Startup supply invariant: possible breach, re-reading before acting on it"
             );
             tokio::time::sleep(std::time::Duration::from_millis(
@@ -353,7 +410,9 @@ async fn check_channel_supply_invariant(
         }
     }
 
-    for b in &confirmed {
+    // `readings` is per mint, so a mint that ran out of rounds while unreadable is visibly
+    // weaker evidence than one that breached in every reading, though both stop the boot.
+    for (b, readings) in standing.values() {
         error!(
             reconciliation_alert = true,
             mint = %b.mint,
@@ -362,14 +421,15 @@ async fn check_channel_supply_invariant(
             custody_slot = b.custody_slot,
             gap = b.gap,
             threshold = config.mismatch_threshold_raw,
-            confirmations = SUPPLY_BREACH_CONFIRMATIONS,
+            readings,
+            required = SUPPLY_BREACH_CONFIRMATIONS,
             "RECONCILIATION ALERT: channel token supply exceeds escrow custody"
         );
     }
 
     Err(IndexerError::Reconciliation(
         ReconciliationError::SupplyExceedsCustody {
-            count: confirmed.len(),
+            count: standing.len(),
             threshold: config.mismatch_threshold_raw,
         },
     ))
@@ -1208,6 +1268,20 @@ mod tests {
         };
     }
 
+    /// A channel-supply read the node refuses outright. Uses -32601 so the retry wrapper
+    /// treats it as permanent and answers immediately instead of backing off five times.
+    async fn mock_channel_supply_failure(server: &mut mockito::Server) {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex("getAccountInfo".to_string()))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}"#,
+            )
+            .create_async()
+            .await;
+    }
+
     /// Supply and custody sit on different chains, so one reading can catch a mint mid
     /// flight: minted here, not yet released there. Startup must re-read before acting,
     /// or an operator working alongside it turns an ordinary boot into a fatal alert.
@@ -1242,6 +1316,171 @@ mod tests {
         assert!(
             result.is_ok(),
             "a breach that does not survive a re-read must not abort startup: {:?}",
+            result
+        );
+    }
+
+    /// A channel-supply read scoped to one mint, so a test can script the two mints of a
+    /// round independently. `times` caps how many reads this answer is served for.
+    async fn mock_supply_for_mint(
+        server: &mut mockito::Server,
+        mint: &Pubkey,
+        supply: u64,
+        times: Option<usize>,
+    ) -> mockito::Mock {
+        use base64::Engine as _;
+        use spl_token::solana_program::program_option::COption;
+        use spl_token::solana_program::program_pack::Pack;
+        use spl_token::state::Mint;
+
+        let mint_state = Mint {
+            mint_authority: COption::Some(Pubkey::new_unique()),
+            supply,
+            decimals: 6,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        };
+        let mut buf = vec![0u8; Mint::LEN];
+        mint_state.pack_into_slice(&mut buf);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
+        let mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex("getAccountInfo".to_string()),
+                mockito::Matcher::Regex(mint.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","id":1,"result":{{"context":{{"slot":100}},"value":{{"owner":"{prog}","lamports":1000000,"data":["{b64}","base64"],"executable":false,"rentEpoch":0}}}}}}"#,
+                prog = spl_token::id(),
+            ));
+        match times {
+            Some(n) => mock.expect(n).create_async().await,
+            None => mock.create_async().await,
+        }
+    }
+
+    /// Same scoping for a read the node refuses outright.
+    async fn mock_supply_failure_for_mint(
+        server: &mut mockito::Server,
+        mint: &Pubkey,
+        times: Option<usize>,
+    ) -> mockito::Mock {
+        let mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex("getAccountInfo".to_string()),
+                mockito::Matcher::Regex(mint.to_string()),
+            ]))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}"#,
+            );
+        match times {
+            Some(n) => mock.expect(n).create_async().await,
+            None => mock.create_async().await,
+        }
+    }
+
+    /// A confirmation round that cannot read the mint has learned nothing. Reading that
+    /// silence as "the breach cleared" would let an insolvent channel boot whenever the
+    /// channel RPC failed right after the first reading caught it.
+    #[tokio::test]
+    async fn supply_breach_is_not_cleared_by_a_failed_re_read() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        // First reading catches supply above custody; every re-read then fails outright.
+        mock_channel_supply_times(&mut server, 1_200, Some(1)).await;
+        mock_channel_supply_failure(&mut server).await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1_000, 0)]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+        let url = server.url();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &seed,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(IndexerError::Reconciliation(
+                    ReconciliationError::SupplyExceedsCustody { .. }
+                ))
+            ),
+            "an unreadable suspect must not clear the breach: {:?}",
+            result
+        );
+    }
+
+    /// The rule is about one mint's own history. With a counter shared across mints, two
+    /// suspects taking turns to breach reach three rounds between them, and a mint seen
+    /// breaching once gets closed out as confirmed on readings that were never about it.
+    #[tokio::test]
+    async fn one_mint_cannot_confirm_a_breach_on_another_mints_readings() {
+        let mut server = mockito::Server::new_async().await;
+        let alpha = Pubkey::new_unique();
+        let beta = Pubkey::new_unique();
+        mock_escrow_sweep(
+            &mut server,
+            &[(alpha.to_string(), 1_000), (beta.to_string(), 1_000)],
+        )
+        .await;
+
+        // Both breach on round 1, so both stay suspects. From there they take turns, and
+        // three rounds pass with a breach in each while neither mint has three of its own.
+        mock_supply_for_mint(&mut server, &alpha, 1_200, Some(2)).await;
+        mock_supply_failure_for_mint(&mut server, &alpha, None).await;
+
+        mock_supply_for_mint(&mut server, &beta, 1_200, Some(1)).await;
+        mock_supply_failure_for_mint(&mut server, &beta, Some(1)).await;
+        mock_supply_for_mint(&mut server, &beta, 1_200, Some(1)).await;
+        // Only reached if the loop kept going past the third round.
+        let beyond_round_three = mock_supply_for_mint(&mut server, &beta, 1_200, None).await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![
+            make_mint_balance(&alpha.to_string(), 1_000, 0),
+            make_mint_balance(&beta.to_string(), 1_000, 0),
+        ]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+        let url = server.url();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &seed,
+        )
+        .await;
+
+        beyond_round_three.assert_async().await;
+        assert!(
+            matches!(
+                result,
+                Err(IndexerError::Reconciliation(
+                    ReconciliationError::SupplyExceedsCustody { .. }
+                ))
+            ),
+            "a suspect that is never read clean still stops the boot: {:?}",
             result
         );
     }

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -95,6 +95,7 @@ pub async fn run_startup_reconciliation(
         config,
         program_type,
         storage,
+        rpc_url,
         channel_rpc_url,
         instance_pda,
         &snapshot,
@@ -138,6 +139,7 @@ pub async fn reconcile_against_snapshot(
     config: &ReconciliationConfig,
     program_type: ProgramType,
     storage: &Storage,
+    rpc_url: &str,
     channel_rpc_url: Option<&str>,
     instance_pda: &Pubkey,
     snapshot: &CustodySnapshot,
@@ -192,7 +194,8 @@ pub async fn reconcile_against_snapshot(
     // means the same thing however far behind the ledger is. Reporting the ledger
     // mismatch ahead of it would hide the graver finding whenever both are true, and
     // would send startup back for another catch-up that cannot change this answer.
-    check_channel_supply_invariant(channel_rpc_url, config, &results).await?;
+    check_channel_supply_invariant(channel_rpc_url, rpc_url, instance_pda, config, &results)
+        .await?;
 
     classify_and_report(config, &results)?;
 
@@ -207,8 +210,18 @@ pub async fn reconcile_against_snapshot(
 /// the boot: the channel RPC (gateway) may not be ready yet, the runtime loop is
 /// the primary control, and a transient read must not crash-loop the indexer.
 /// Only a proven supply-over-custody breach is fatal.
+///
+/// This deliberately does NOT reuse the frozen snapshot the ledger is judged against.
+/// That snapshot is deliberately old: it is taken before the catch-up so the ledger can be
+/// brought level with it. Supply, by contrast, is read now, and an operator running
+/// alongside startup can mint a deposit that landed after the snapshot. Judged against the
+/// snapshot that mint looks like supply with no backing, and startup would abort over a
+/// deposit that is sitting in custody on chain. A reading taken after the supply reads
+/// cannot be missing anything they saw.
 async fn check_channel_supply_invariant(
     channel_rpc_url: &str,
+    escrow_rpc_url: &str,
+    instance_pda: &Pubkey,
     config: &ReconciliationConfig,
     results: &[MintReconciliation],
 ) -> Result<(), IndexerError> {
@@ -218,7 +231,9 @@ async fn check_channel_supply_invariant(
         CommitmentConfig::finalized(),
     );
 
-    let mut breaches = 0usize;
+    // Same mint universe as the ledger comparison, so a mint is never dropped from the
+    // invariant just because it holds nothing on chain.
+    let mut supplies: Vec<(&MintReconciliation, Pubkey, u64)> = Vec::new();
     for r in results {
         let mint = r
             .mint
@@ -227,25 +242,46 @@ async fn check_channel_supply_invariant(
                 pubkey: r.mint.clone(),
                 reason: e.to_string(),
             })?;
-        let supply = match fetch_channel_supply(&channel_rpc, &mint).await {
-            Ok(s) => s,
+        match fetch_channel_supply(&channel_rpc, &mint).await {
+            Ok(supply) => supplies.push((r, mint, supply)),
             Err(e) => {
                 warn!(
                     mint = %r.mint,
                     reason = %e.reason,
                     "Startup supply invariant: channel supply read failed, skipping this mint"
                 );
-                continue;
             }
-        };
+        }
+    }
 
-        let gap = supply.saturating_sub(r.on_chain_actual);
+    if supplies.is_empty() {
+        return Ok(());
+    }
+
+    // Taken after every supply read, so it cannot be missing a deposit that backs one of
+    // them. A mint absent from it holds nothing, which is what a single sweep reported.
+    let custody = capture_custody_snapshot(escrow_rpc_url, instance_pda).await?;
+
+    let mut breaches = 0usize;
+    for (r, mint, supply) in supplies {
+        // Custody moves in both directions while these reads happen: a deposit raises it
+        // after the snapshot, and a release lowers it before the fresh sweep. Judging
+        // against the higher of the two means neither ordering can invent a breach, and a
+        // mint still fails when no reading of custody can account for its supply.
+        let on_chain_custody = custody
+            .balances
+            .get(&mint)
+            .copied()
+            .unwrap_or(0)
+            .max(r.on_chain_actual);
+        let gap = supply.saturating_sub(on_chain_custody);
         if gap > config.mismatch_threshold_raw {
             error!(
                 reconciliation_alert = true,
                 mint = %r.mint,
                 supply,
-                on_chain_custody = r.on_chain_actual,
+                on_chain_custody,
+                custody_slot = custody.slot,
                 gap,
                 threshold = config.mismatch_threshold_raw,
                 "RECONCILIATION ALERT: channel token supply exceeds escrow custody"
@@ -969,6 +1005,90 @@ mod tests {
         assert!(
             result.is_ok(),
             "net (deposits - withdrawals) must match on-chain: {:?}",
+            result
+        );
+    }
+
+    /// A deposit that lands after the snapshot can be minted before the supply is read, so
+    /// judging supply against the frozen snapshot would call a fully backed mint a breach
+    /// and abort the boot. The snapshot is deliberately old; the supply check must read
+    /// custody for itself.
+    #[tokio::test]
+    async fn supply_invariant_is_not_fooled_by_custody_that_arrived_after_the_snapshot() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // Custody now holds the deposit backing the mint, and the channel has minted it.
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        mock_channel_supply(&mut server, 1_000).await;
+
+        // The snapshot predates the deposit: at that slot the escrow held nothing.
+        let snapshot = CustodySnapshot {
+            balances: HashMap::from([(mint, 0)]),
+            slot: 50,
+        };
+
+        let storage = Storage::Mock(MockStorage::new());
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let url = server.url();
+        let result = reconcile_against_snapshot(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &Pubkey::new_unique(),
+            &snapshot,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "a mint backed by custody that arrived after the snapshot must not be a breach: {:?}",
+            result
+        );
+    }
+
+    /// The mirror case. A release lowers custody between the supply reads and the fresh
+    /// sweep, so the later reading is the one missing the backing. Judging against the
+    /// higher of the two readings is what keeps a routine withdrawal from aborting a boot.
+    #[tokio::test]
+    async fn supply_invariant_is_not_fooled_by_custody_released_after_the_snapshot() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // The fresh sweep sees the escrow already emptied by a release.
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 0)]).await;
+        mock_channel_supply(&mut server, 1_000).await;
+
+        // The snapshot predates the release: at that slot custody still backed the supply.
+        let snapshot = CustodySnapshot {
+            balances: HashMap::from([(mint, 1_000)]),
+            slot: 50,
+        };
+
+        // The ledger matches the snapshot, so only the supply logic is under test here.
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1_000, 0)]);
+        let storage = Storage::Mock(mock_storage);
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let url = server.url();
+        let result = reconcile_against_snapshot(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &Pubkey::new_unique(),
+            &snapshot,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "custody released after the snapshot must not read as a supply breach: {:?}",
             result
         );
     }

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -30,7 +30,9 @@ use crate::{
     config::{ProgramType, ReconciliationConfig},
     error::{IndexerError, ReconciliationError},
     operator::{
-        escrow_sweep::{fetch_channel_supply, fetch_escrow_balances_by_mint, CustodySnapshot},
+        escrow_sweep::{
+            fetch_channel_supply, fetch_escrow_balances_by_mint, CustodySnapshot, SweepFailure,
+        },
         rpc_util::RpcClientWithRetry,
         RetryConfig,
     },
@@ -121,9 +123,22 @@ pub async fn capture_custody_snapshot(
 
     let snapshot = fetch_escrow_balances_by_mint(&rpc_client, *instance_pda)
         .await
-        .map_err(|e| ReconciliationError::Rpc {
-            mint: instance_pda.to_string(),
-            reason: e.reason,
+        .map_err(|e| match e {
+            // Kept distinct so the caller's retry can take another sweep: this one says the
+            // node never held still, not that custody could not be read.
+            SweepFailure::SlotUnsettled {
+                attempts,
+                low,
+                high,
+            } => ReconciliationError::CustodySlotUnsettled {
+                attempts,
+                low,
+                high,
+            },
+            SweepFailure::Read(e) => ReconciliationError::Rpc {
+                mint: instance_pda.to_string(),
+                reason: e.reason,
+            },
         })?;
 
     info!(

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -202,7 +202,7 @@ async fn check_channel_supply_invariant(
 
     if breaches > 0 {
         return Err(IndexerError::Reconciliation(
-            ReconciliationError::MismatchExceedsThreshold {
+            ReconciliationError::SupplyExceedsCustody {
                 count: breaches,
                 threshold: config.mismatch_threshold_raw,
             },
@@ -976,7 +976,7 @@ mod tests {
         )
         .await;
         match result {
-            Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+            Err(IndexerError::Reconciliation(ReconciliationError::SupplyExceedsCustody {
                 count,
                 ..
             })) => assert_eq!(count, 1),

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -38,7 +38,7 @@ use crate::{
     storage::Storage,
 };
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use tracing::{error, info, warn};
 
 /// Per-mint result produced during reconciliation.
@@ -202,22 +202,107 @@ pub async fn reconcile_against_snapshot(
     Ok(())
 }
 
-/// Read channel-token supply per mint and fail startup if any mint's supply
-/// exceeds its on-chain custody beyond the threshold. Startup is quiescent, so a
-/// plain `mismatch_threshold_raw` compare suffices with no envelope/persistence.
+/// Readings a supply breach must appear in, consecutively, before it is believed.
+const SUPPLY_BREACH_CONFIRMATIONS: u32 = 3;
+
+/// Pause between those readings, so each one sees a genuinely later state of both chains.
+#[cfg(not(test))]
+const SUPPLY_BREACH_RECHECK_DELAY_MS: u64 = 500;
+#[cfg(test)]
+const SUPPLY_BREACH_RECHECK_DELAY_MS: u64 = 10;
+
+/// One mint whose channel supply was not covered by custody in a single reading.
+struct SupplyBreach {
+    mint: String,
+    key: Pubkey,
+    supply: u64,
+    custody: u64,
+    custody_slot: u64,
+    gap: u64,
+}
+
+/// Take one reading of every mint's channel supply and compare it against escrow custody.
 ///
-/// A per-mint supply read that errors is skipped with a warn rather than aborting
-/// the boot: the channel RPC (gateway) may not be ready yet, the runtime loop is
-/// the primary control, and a transient read must not crash-loop the indexer.
-/// Only a proven supply-over-custody breach is fatal.
+/// Supplies are read first and custody after, so the custody reading cannot be missing a
+/// deposit any supply read already saw. The frozen snapshot is folded in as a floor
+/// because custody also falls: a release between the two lowers the fresh reading, and
+/// judging against the higher of the two stops an ordinary withdrawal from looking like a
+/// breach. `only` restricts the reading to mints an earlier round already suspected.
+async fn measure_supply_breaches(
+    channel_rpc: &RpcClientWithRetry,
+    escrow_rpc_url: &str,
+    instance_pda: &Pubkey,
+    config: &ReconciliationConfig,
+    results: &[MintReconciliation],
+    only: Option<&HashSet<Pubkey>>,
+) -> Result<Vec<SupplyBreach>, IndexerError> {
+    // Same mint universe as the ledger comparison, so a mint is never dropped from the
+    // invariant just because it holds nothing on chain.
+    let mut supplies: Vec<(&MintReconciliation, Pubkey, u64)> = Vec::new();
+    for r in results {
+        let mint = r
+            .mint
+            .parse::<Pubkey>()
+            .map_err(|e| ReconciliationError::InvalidPubkey {
+                pubkey: r.mint.clone(),
+                reason: e.to_string(),
+            })?;
+        if only.is_some_and(|s| !s.contains(&mint)) {
+            continue;
+        }
+        match fetch_channel_supply(channel_rpc, &mint).await {
+            Ok(supply) => supplies.push((r, mint, supply)),
+            Err(e) => {
+                warn!(
+                    mint = %r.mint,
+                    reason = %e.reason,
+                    "Startup supply invariant: channel supply read failed, skipping this mint"
+                );
+            }
+        }
+    }
+
+    if supplies.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let custody = capture_custody_snapshot(escrow_rpc_url, instance_pda).await?;
+
+    let mut breaches = Vec::new();
+    for (r, mint, supply) in supplies {
+        let on_chain_custody = custody
+            .balances
+            .get(&mint)
+            .copied()
+            .unwrap_or(0)
+            .max(r.on_chain_actual);
+        let gap = supply.saturating_sub(on_chain_custody);
+        if gap > config.mismatch_threshold_raw {
+            breaches.push(SupplyBreach {
+                mint: r.mint.clone(),
+                key: mint,
+                supply,
+                custody: on_chain_custody,
+                custody_slot: custody.slot,
+                gap,
+            });
+        }
+    }
+    Ok(breaches)
+}
+
+/// Fail startup if any mint's channel supply exceeds the custody backing it.
 ///
-/// This deliberately does NOT reuse the frozen snapshot the ledger is judged against.
-/// That snapshot is deliberately old: it is taken before the catch-up so the ledger can be
-/// brought level with it. Supply, by contrast, is read now, and an operator running
-/// alongside startup can mint a deposit that landed after the snapshot. Judged against the
-/// snapshot that mint looks like supply with no backing, and startup would abort over a
-/// deposit that is sitting in custody on chain. A reading taken after the supply reads
-/// cannot be missing anything they saw.
+/// Supply and custody live on different chains and both keep moving, so no single pass can
+/// read them at one instant: a deposit minted between the readings, or a burn whose release
+/// has not landed yet, each make a healthy mint look short-changed for a moment. A breach
+/// is therefore believed only if it survives several consecutive readings, which is the
+/// same persistence rule the runtime invariant uses. A real insolvency does not heal
+/// between reads, so this costs nothing on a healthy boot and nothing in detection.
+///
+/// A per-mint supply read that errors is skipped with a warn rather than aborting the boot:
+/// the channel RPC (gateway) may not be ready yet, the runtime loop is the primary control,
+/// and a transient read must not crash-loop the indexer.
 async fn check_channel_supply_invariant(
     channel_rpc_url: &str,
     escrow_rpc_url: &str,
@@ -231,74 +316,63 @@ async fn check_channel_supply_invariant(
         CommitmentConfig::finalized(),
     );
 
-    // Same mint universe as the ledger comparison, so a mint is never dropped from the
-    // invariant just because it holds nothing on chain.
-    let mut supplies: Vec<(&MintReconciliation, Pubkey, u64)> = Vec::new();
-    for r in results {
-        let mint = r
-            .mint
-            .parse::<Pubkey>()
-            .map_err(|e| ReconciliationError::InvalidPubkey {
-                pubkey: r.mint.clone(),
-                reason: e.to_string(),
-            })?;
-        match fetch_channel_supply(&channel_rpc, &mint).await {
-            Ok(supply) => supplies.push((r, mint, supply)),
-            Err(e) => {
-                warn!(
-                    mint = %r.mint,
-                    reason = %e.reason,
-                    "Startup supply invariant: channel supply read failed, skipping this mint"
-                );
-            }
+    // Each round re-reads only what the previous one suspected, so a mint has to breach in
+    // every reading to survive to the end.
+    let mut suspects: Option<HashSet<Pubkey>> = None;
+    let mut confirmed: Vec<SupplyBreach> = Vec::new();
+
+    for attempt in 1..=SUPPLY_BREACH_CONFIRMATIONS {
+        let breaches = measure_supply_breaches(
+            &channel_rpc,
+            escrow_rpc_url,
+            instance_pda,
+            config,
+            results,
+            suspects.as_ref(),
+        )
+        .await?;
+
+        if breaches.is_empty() {
+            return Ok(());
         }
-    }
 
-    if supplies.is_empty() {
-        return Ok(());
-    }
+        suspects = Some(breaches.iter().map(|b| b.key).collect());
+        confirmed = breaches;
 
-    // Taken after every supply read, so it cannot be missing a deposit that backs one of
-    // them. A mint absent from it holds nothing, which is what a single sweep reported.
-    let custody = capture_custody_snapshot(escrow_rpc_url, instance_pda).await?;
-
-    let mut breaches = 0usize;
-    for (r, mint, supply) in supplies {
-        // Custody moves in both directions while these reads happen: a deposit raises it
-        // after the snapshot, and a release lowers it before the fresh sweep. Judging
-        // against the higher of the two means neither ordering can invent a breach, and a
-        // mint still fails when no reading of custody can account for its supply.
-        let on_chain_custody = custody
-            .balances
-            .get(&mint)
-            .copied()
-            .unwrap_or(0)
-            .max(r.on_chain_actual);
-        let gap = supply.saturating_sub(on_chain_custody);
-        if gap > config.mismatch_threshold_raw {
-            error!(
-                reconciliation_alert = true,
-                mint = %r.mint,
-                supply,
-                on_chain_custody,
-                custody_slot = custody.slot,
-                gap,
-                threshold = config.mismatch_threshold_raw,
-                "RECONCILIATION ALERT: channel token supply exceeds escrow custody"
+        if attempt < SUPPLY_BREACH_CONFIRMATIONS {
+            warn!(
+                mint_count = confirmed.len(),
+                attempt,
+                confirmations = SUPPLY_BREACH_CONFIRMATIONS,
+                "Startup supply invariant: possible breach, re-reading before acting on it"
             );
-            breaches += 1;
+            tokio::time::sleep(std::time::Duration::from_millis(
+                SUPPLY_BREACH_RECHECK_DELAY_MS,
+            ))
+            .await;
         }
     }
 
-    if breaches > 0 {
-        return Err(IndexerError::Reconciliation(
-            ReconciliationError::SupplyExceedsCustody {
-                count: breaches,
-                threshold: config.mismatch_threshold_raw,
-            },
-        ));
+    for b in &confirmed {
+        error!(
+            reconciliation_alert = true,
+            mint = %b.mint,
+            supply = b.supply,
+            on_chain_custody = b.custody,
+            custody_slot = b.custody_slot,
+            gap = b.gap,
+            threshold = config.mismatch_threshold_raw,
+            confirmations = SUPPLY_BREACH_CONFIRMATIONS,
+            "RECONCILIATION ALERT: channel token supply exceeds escrow custody"
+        );
     }
-    Ok(())
+
+    Err(IndexerError::Reconciliation(
+        ReconciliationError::SupplyExceedsCustody {
+            count: confirmed.len(),
+            threshold: config.mismatch_threshold_raw,
+        },
+    ))
 }
 
 /// Build the per-mint reconciliation set from the union of (DB mints) and
@@ -1095,6 +1169,16 @@ mod tests {
 
     /// getAccountInfo mock returning an SPL Mint blob with `supply`.
     async fn mock_channel_supply(server: &mut mockito::Server, supply: u64) {
+        mock_channel_supply_times(server, supply, None).await;
+    }
+
+    /// `times` caps how many reads this supply is served for, so a test can script one
+    /// reading followed by a different one.
+    async fn mock_channel_supply_times(
+        server: &mut mockito::Server,
+        supply: u64,
+        times: Option<usize>,
+    ) {
         use base64::Engine as _;
         use spl_token::solana_program::program_option::COption;
         use spl_token::solana_program::program_pack::Pack;
@@ -1110,16 +1194,56 @@ mod tests {
         let mut buf = vec![0u8; Mint::LEN];
         mint_state.pack_into_slice(&mut buf);
         let b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
-        server
+        let mock = server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex("getAccountInfo".to_string()))
             .with_status(200)
             .with_body(format!(
                 r#"{{"jsonrpc":"2.0","id":1,"result":{{"context":{{"slot":100}},"value":{{"owner":"{prog}","lamports":1000000,"data":["{b64}","base64"],"executable":false,"rentEpoch":0}}}}}}"#,
                 prog = spl_token::id(),
-            ))
-            .create_async()
-            .await;
+            ));
+        match times {
+            Some(n) => mock.expect(n).create_async().await,
+            None => mock.create_async().await,
+        };
+    }
+
+    /// Supply and custody sit on different chains, so one reading can catch a mint mid
+    /// flight: minted here, not yet released there. Startup must re-read before acting,
+    /// or an operator working alongside it turns an ordinary boot into a fatal alert.
+    #[tokio::test]
+    async fn supply_breach_that_clears_on_a_re_read_is_not_fatal() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        // First reading catches supply above custody; the next one no longer does.
+        mock_channel_supply_times(&mut server, 1_200, Some(1)).await;
+        mock_channel_supply(&mut server, 1_000).await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1_000, 0)]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+        let url = server.url();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &seed,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "a breach that does not survive a re-read must not abort startup: {:?}",
+            result
+        );
     }
 
     #[tokio::test]

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -12,8 +12,10 @@
 //! Only completed withdrawals (`release_funds`) reduce the ATA balance.
 //!
 //! Flow:
-//! 1. Sweep the escrow instance's on-chain token accounts, summed per mint.
-//! 2. Query the DB for per-mint aggregate balances (all deposits − completed withdrawals).
+//! 1. Sweep the escrow instance's on-chain token accounts, summed per mint, noting the
+//!    slot the reading is valid as of.
+//! 2. Query the DB for per-mint aggregate balances (all deposits − completed
+//!    withdrawals), bounded by that slot so both sides describe the same instant.
 //! 3. Compare the union of both mint sets; a mint on only one side compares against 0.
 //! 4. If any mint's channel supply exceeds its custody by more than the threshold, log
 //!    error, emit alert, abort startup. Checked first: it reads the chain on both sides,
@@ -27,7 +29,7 @@ use crate::{
     config::{ProgramType, ReconciliationConfig},
     error::{IndexerError, ReconciliationError},
     operator::{
-        escrow_sweep::{fetch_channel_supply, fetch_escrow_balances_by_mint},
+        escrow_sweep::{fetch_channel_supply, fetch_escrow_balances_by_mint, CustodySnapshot},
         rpc_util::RpcClientWithRetry,
         RetryConfig,
     },
@@ -88,6 +90,63 @@ pub async fn run_startup_reconciliation(
         return Ok(());
     }
 
+    let snapshot = capture_custody_snapshot(rpc_url, instance_pda).await?;
+    reconcile_against_snapshot(
+        config,
+        program_type,
+        storage,
+        channel_rpc_url,
+        instance_pda,
+        &snapshot,
+    )
+    .await
+}
+
+/// Read the escrow's on-chain custody, along with the slot the reading is valid as of.
+///
+/// Callers that can catch their ledger up take this first and compare against it after,
+/// so the two sides of the comparison describe the same slot. Reading custody afterwards
+/// instead would measure a chain that has moved on from the ledger it is judged against.
+pub async fn capture_custody_snapshot(
+    rpc_url: &str,
+    instance_pda: &Pubkey,
+) -> Result<CustodySnapshot, IndexerError> {
+    let rpc_client = RpcClientWithRetry::with_retry_config(
+        rpc_url.to_string(),
+        RetryConfig::default(),
+        CommitmentConfig::finalized(),
+    );
+
+    let snapshot = fetch_escrow_balances_by_mint(&rpc_client, *instance_pda)
+        .await
+        .map_err(|e| ReconciliationError::Rpc {
+            mint: instance_pda.to_string(),
+            reason: e.reason,
+        })?;
+
+    info!(
+        instance_pda = %instance_pda,
+        snapshot_slot = snapshot.slot,
+        mint_count = snapshot.balances.len(),
+        "Captured on-chain escrow custody"
+    );
+    Ok(snapshot)
+}
+
+/// Compare a captured custody snapshot against the ledger as of the snapshot's slot.
+pub async fn reconcile_against_snapshot(
+    config: &ReconciliationConfig,
+    program_type: ProgramType,
+    storage: &Storage,
+    channel_rpc_url: Option<&str>,
+    instance_pda: &Pubkey,
+    snapshot: &CustodySnapshot,
+) -> Result<(), IndexerError> {
+    if program_type != ProgramType::Escrow {
+        info!("Startup reconciliation skipped (program_type is not Escrow)");
+        return Ok(());
+    }
+
     // The supply invariant must always run for an escrow indexer, so the channel
     // RPC is a hard config gate: a missing or blank one fails the boot even in empty state.
     let channel_rpc_url = channel_rpc_url
@@ -97,9 +156,9 @@ pub async fn run_startup_reconciliation(
             ReconciliationError::MissingChannelRpc,
         ))?;
 
-    let instance_pda = *instance_pda;
     info!(
         instance_pda = %instance_pda,
+        snapshot_slot = snapshot.slot,
         "Running startup reconciliation"
     );
 
@@ -108,26 +167,15 @@ pub async fn run_startup_reconciliation(
     // dedup hides anything they haven't already seen.
     log_orphan_deposit_rows_at_startup(storage).await;
 
-    let rpc_client = RpcClientWithRetry::with_retry_config(
-        rpc_url.to_string(),
-        RetryConfig::default(),
-        CommitmentConfig::finalized(),
-    );
-
-    // The on-chain sweep is the authoritative custody view.
-    let on_chain_balances = fetch_escrow_balances_by_mint(&rpc_client, instance_pda)
-        .await
-        .map_err(|e| ReconciliationError::Rpc {
-            mint: instance_pda.to_string(),
-            reason: e.reason,
-        })?;
-
+    // Bounded by the snapshot's slot so the ledger side answers for the same instant the
+    // custody side does. Without it, rows indexed after the reading would be counted
+    // against custody that never reflected them.
     let mint_balances = storage
-        .get_mint_balances_for_reconciliation()
+        .get_mint_balances_for_reconciliation(snapshot.slot)
         .await
         .map_err(ReconciliationError::Storage)?;
 
-    let results = build_reconciliation_set(&mint_balances, &on_chain_balances)?;
+    let results = build_reconciliation_set(&mint_balances, &snapshot.balances)?;
 
     if results.is_empty() {
         // Reached only when both the escrow sweep and the DB are genuinely empty, i.e. a truly-first deploy.

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -15,9 +15,13 @@
 //! 1. Sweep the escrow instance's on-chain token accounts, summed per mint.
 //! 2. Query the DB for per-mint aggregate balances (all deposits − completed withdrawals).
 //! 3. Compare the union of both mint sets; a mint on only one side compares against 0.
-//! 4. If any |on_chain - db_expected| > threshold → log error, emit alert, abort startup.
-//! 5. If any mismatch ≤ threshold (but > 0) → log warning, continue.
-//! 6. If all balanced (or both sides empty) → log info, continue.
+//! 4. If any mint's channel supply exceeds its custody by more than the threshold, log
+//!    error, emit alert, abort startup. Checked first: it reads the chain on both sides,
+//!    so it is unaffected by how far behind the DB is and can never be repaired by
+//!    indexing more slots.
+//! 5. If any |on_chain - db_expected| > threshold → log error, emit alert, abort startup.
+//! 6. If any mismatch ≤ threshold (but > 0) → log warning, continue.
+//! 7. If all balanced (or both sides empty) → log info, continue.
 
 use crate::{
     config::{ProgramType, ReconciliationConfig},
@@ -136,11 +140,13 @@ pub async fn run_startup_reconciliation(
         "Comparing DB totals against on-chain escrow balances"
     );
 
-    classify_and_report(config, &results)?;
-
-    // Independent supply invariant: the minted channel-token supply must not
-    // exceed on-chain custody.
+    // The supply invariant runs first because it reads the chain on both sides and so
+    // means the same thing however far behind the ledger is. Reporting the ledger
+    // mismatch ahead of it would hide the graver finding whenever both are true, and
+    // would send startup back for another catch-up that cannot change this answer.
     check_channel_supply_invariant(channel_rpc_url, config, &results).await?;
+
+    classify_and_report(config, &results)?;
 
     Ok(())
 }
@@ -981,6 +987,49 @@ mod tests {
                 ..
             })) => assert_eq!(count, 1),
             other => panic!("supply over custody must block startup, got: {:?}", other),
+        }
+    }
+
+    /// A stale ledger must not hide a supply breach. The breach is the graver finding and
+    /// the only one of the two that no amount of further indexing can clear, so startup
+    /// has to report it rather than the mismatch that happens to sit alongside it.
+    #[tokio::test]
+    async fn startup_reconciliation_reports_the_supply_breach_over_a_stale_ledger() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // Custody 1000 against a ledger at 900 is a mismatch of 100, and minted supply
+        // 1200 is 200 above custody. Both exceed the threshold on the same mint.
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        mock_channel_supply(&mut server, 1_200).await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 900, 0)]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 10,
+        };
+        let seed = Pubkey::new_unique();
+        let url = server.url();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &seed,
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::Reconciliation(ReconciliationError::SupplyExceedsCustody {
+                count,
+                ..
+            })) => assert_eq!(count, 1),
+            other => panic!(
+                "the supply breach must surface ahead of the ledger mismatch, got: {:?}",
+                other
+            ),
         }
     }
 

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -20,7 +20,8 @@
 //! 4. If any mint's channel supply exceeds its custody by more than the threshold, log
 //!    error, emit alert, abort startup. Checked first: it reads the chain on both sides,
 //!    so it is unaffected by how far behind the DB is and can never be repaired by
-//!    indexing more slots.
+//!    indexing more slots. A supply that cannot be read at all aborts too, since an
+//!    unreadable channel and a solvent one look the same from here.
 //! 5. If any |on_chain - db_expected| > threshold → log error, emit alert, abort startup.
 //! 6. If any mismatch ≤ threshold (but > 0) → log warning, continue.
 //! 7. If all balanced (or both sides empty) → log info, continue.
@@ -318,11 +319,10 @@ async fn measure_supply_breaches(
 /// same persistence rule the runtime invariant uses. A real insolvency does not heal
 /// between reads, so this costs nothing on a healthy boot and nothing in detection.
 ///
-/// A supply read that errors is skipped with a warn rather than aborting the boot: the
-/// channel RPC (gateway) may not be ready yet, the runtime loop is the primary control, and
-/// a transient read must not crash-loop the indexer. Once a mint has breached, though, the
-/// same silence means the opposite. Nothing has retracted the breach, so it keeps its
-/// suspect status and the boot fails if no later round ever reads it clean.
+/// A supply read that errors buys another round rather than being written off. The rounds
+/// give a gateway that is still coming up time to answer, but a mint that stays unreadable
+/// to the end stops the boot: an unreadable channel hides an existing breach exactly as
+/// well as a healthy one does, and nothing here can tell the two apart.
 async fn check_channel_supply_invariant(
     channel_rpc_url: &str,
     escrow_rpc_url: &str,
@@ -355,13 +355,10 @@ async fn check_channel_supply_invariant(
         )
         .await?;
 
-        // A suspect the node would not answer for is not evidence that it recovered, so it
-        // stays a suspect. A mint with no breach behind it is still skipped on a failed
-        // read: the channel RPC may simply not be up yet this early in the boot.
-        let unresolved: HashSet<Pubkey> = match suspects.as_ref() {
-            Some(prior) => reading.unread.intersection(prior).copied().collect(),
-            None => HashSet::new(),
-        };
+        // A mint the node would not answer for proves nothing either way, so it stays a
+        // suspect and buys another round. Later rounds only ask about suspects, so whatever
+        // came back unread is already the set still owed an answer.
+        let unresolved = &reading.unread;
 
         if reading.breaches.is_empty() && unresolved.is_empty() {
             return Ok(());
@@ -371,6 +368,7 @@ async fn check_channel_supply_invariant(
         // is out, whatever an earlier round said about it.
         let mut still: HashSet<Pubkey> = reading.breaches.iter().map(|b| b.key).collect();
         still.extend(unresolved.iter().copied());
+        let unresolved_count = unresolved.len();
         standing.retain(|mint, _| still.contains(mint));
 
         // A breach reading advances that mint's count; a round that could not read it
@@ -400,7 +398,7 @@ async fn check_channel_supply_invariant(
                 mint_count = standing.len(),
                 round,
                 required = SUPPLY_BREACH_CONFIRMATIONS,
-                unresolved = unresolved.len(),
+                unresolved = unresolved_count,
                 "Startup supply invariant: possible breach, re-reading before acting on it"
             );
             tokio::time::sleep(std::time::Duration::from_millis(
@@ -427,11 +425,27 @@ async fn check_channel_supply_invariant(
         );
     }
 
+    if !standing.is_empty() {
+        return Err(IndexerError::Reconciliation(
+            ReconciliationError::SupplyExceedsCustody {
+                count: standing.len(),
+                threshold: config.mismatch_threshold_raw,
+            },
+        ));
+    }
+
+    // Left over: mints that never breached but were never readable either. The invariant
+    // did not run for them, and an unreadable gateway looks exactly like a healthy one from
+    // here, so the boot stops instead of vouching for custody it never measured.
+    let unverified = suspects.map(|s| s.len()).unwrap_or(0);
+    error!(
+        reconciliation_alert = true,
+        mint_count = unverified,
+        rounds = SUPPLY_BREACH_MAX_ROUNDS,
+        "RECONCILIATION ALERT: channel supply unreadable, the supply invariant did not run"
+    );
     Err(IndexerError::Reconciliation(
-        ReconciliationError::SupplyExceedsCustody {
-            count: standing.len(),
-            threshold: config.mismatch_threshold_raw,
-        },
+        ReconciliationError::SupplyInvariantUnverified { count: unverified },
     ))
 }
 
@@ -991,6 +1005,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let mint = Pubkey::new_unique();
         mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        // Healthy supply, so the ledger comparison stays the thing under test.
+        mock_channel_supply(&mut server, 0).await;
 
         let storage = Storage::Mock(MockStorage::new());
         let config = ReconciliationConfig {
@@ -1024,6 +1040,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let mint = Pubkey::new_unique();
         mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        // Healthy supply, so the ledger comparison stays the thing under test.
+        mock_channel_supply(&mut server, 1_000).await;
 
         let mock_storage = MockStorage::new();
         mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1000, 0)]);
@@ -1051,6 +1069,8 @@ mod tests {
         let mint = Pubkey::new_unique();
         // DB expects 1000, on-chain has 1005 => mismatch 5 <= threshold 10 => ok
         mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_005)]).await;
+        // Healthy supply, so the ledger comparison stays the thing under test.
+        mock_channel_supply(&mut server, 1_000).await;
 
         let mock_storage = MockStorage::new();
         mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1000, 0)]);
@@ -1082,6 +1102,8 @@ mod tests {
         let mint = Pubkey::new_unique();
         // DB expects 1000, on-chain has 1020 => mismatch 20 > threshold 10 => err
         mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_020)]).await;
+        // Healthy supply, so the ledger comparison stays the thing under test.
+        mock_channel_supply(&mut server, 1_000).await;
 
         let mock_storage = MockStorage::new();
         mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1000, 0)]);
@@ -1118,6 +1140,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let mint = Pubkey::new_unique();
         mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        // Healthy supply, so the ledger comparison stays the thing under test.
+        mock_channel_supply(&mut server, 1_000).await;
 
         let mock_storage = MockStorage::new();
         mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1500, 500)]);
@@ -1421,6 +1445,48 @@ mod tests {
                 ))
             ),
             "an unreadable suspect must not clear the breach: {:?}",
+            result
+        );
+    }
+
+    /// A gateway that answers nothing leaves the invariant unrun, and an unreadable channel
+    /// looks exactly like a solvent one from here. Startup must stop rather than vouch for
+    /// custody it never measured.
+    #[tokio::test]
+    async fn supply_that_is_never_readable_stops_startup() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // Custody and ledger agree, so only the unreadable supply can decide this.
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+        mock_channel_supply_failure(&mut server).await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1_000, 0)]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+        let url = server.url();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &seed,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(IndexerError::Reconciliation(
+                    ReconciliationError::SupplyInvariantUnverified { count: 1 }
+                ))
+            ),
+            "an unreadable supply must stop the boot, not pass it: {:?}",
             result
         );
     }

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -227,8 +227,10 @@ const SUPPLY_BREACH_CONFIRMATIONS: u32 = 3;
 const SUPPLY_BREACH_MAX_ROUNDS: u32 = SUPPLY_BREACH_CONFIRMATIONS * 2;
 
 /// Pause between those readings, so each one sees a genuinely later state of both chains.
+/// Sized for a withdrawal in flight: the burn and the release finalize on separate chains
+/// moments apart, and the readings have to span that gap or all of them land inside it.
 #[cfg(not(test))]
-const SUPPLY_BREACH_RECHECK_DELAY_MS: u64 = 500;
+const SUPPLY_BREACH_RECHECK_DELAY_MS: u64 = 2_000;
 #[cfg(test)]
 const SUPPLY_BREACH_RECHECK_DELAY_MS: u64 = 10;
 
@@ -253,10 +255,12 @@ struct SupplyReading {
 /// Take one reading of every mint's channel supply and compare it against escrow custody.
 ///
 /// Supplies are read first and custody after, so the custody reading cannot be missing a
-/// deposit any supply read already saw. The frozen snapshot is folded in as a floor
-/// because custody also falls: a release between the two lowers the fresh reading, and
-/// judging against the higher of the two stops an ordinary withdrawal from looking like a
-/// breach. `only` restricts the reading to mints an earlier round already suspected.
+/// deposit any supply read already saw. Custody is judged on this round's reading alone.
+/// The frozen snapshot is never mixed in: it only ages, so using it as a floor would let a
+/// mint that lost its backing after the snapshot keep answering with custody it no longer
+/// holds. A release landing between the two reads can still make one round look short, and
+/// the repeated readings above are what settle that. `only` restricts the reading to mints
+/// an earlier round already suspected.
 async fn measure_supply_breaches(
     channel_rpc: &RpcClientWithRetry,
     escrow_rpc_url: &str,
@@ -304,12 +308,7 @@ async fn measure_supply_breaches(
 
     let mut breaches = Vec::new();
     for (r, mint, supply) in supplies {
-        let on_chain_custody = custody
-            .balances
-            .get(&mint)
-            .copied()
-            .unwrap_or(0)
-            .max(r.on_chain_actual);
+        let on_chain_custody = custody.balances.get(&mint).copied().unwrap_or(0);
         let gap = supply.saturating_sub(on_chain_custody);
         if gap > config.mismatch_threshold_raw {
             breaches.push(SupplyBreach {
@@ -1223,16 +1222,18 @@ mod tests {
         );
     }
 
-    /// The mirror case. A release lowers custody between the supply reads and the fresh
-    /// sweep, so the later reading is the one missing the backing. Judging against the
-    /// higher of the two readings is what keeps a routine withdrawal from aborting a boot.
+    /// The mirror case. A withdrawal burns on the channel and releases on Solana, and for
+    /// a moment a reading can catch the release without the burn. Custody is short in that
+    /// one reading only, so the re-read is what has to clear it.
     #[tokio::test]
-    async fn supply_invariant_is_not_fooled_by_custody_released_after_the_snapshot() {
+    async fn custody_released_before_its_burn_is_visible_clears_on_a_re_read() {
         let mut server = mockito::Server::new_async().await;
         let mint = Pubkey::new_unique();
-        // The fresh sweep sees the escrow already emptied by a release.
+        // The fresh sweep sees the escrow already emptied by the release.
         mock_escrow_sweep(&mut server, &[(mint.to_string(), 0)]).await;
-        mock_channel_supply(&mut server, 1_000).await;
+        // First reading still predates the burn; the next one sees the supply gone too.
+        mock_channel_supply_times(&mut server, 1_000, Some(1)).await;
+        mock_channel_supply(&mut server, 0).await;
 
         // The snapshot predates the release: at that slot custody still backed the supply.
         let snapshot = CustodySnapshot {
@@ -1261,7 +1262,55 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "custody released after the snapshot must not read as a supply breach: {:?}",
+            "a release read ahead of its burn must not abort the boot: {:?}",
+            result
+        );
+    }
+
+    /// Custody that is gone and stays gone is the insolvency this gate exists to catch,
+    /// and a snapshot taken while the backing was still there must not answer for it. The
+    /// snapshot only ages, so letting it stand in for custody would excuse the breach on
+    /// every reading and pass the boot for good.
+    #[tokio::test]
+    async fn a_healthy_snapshot_cannot_excuse_custody_that_is_gone() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // Escrow is empty on every reading, and the supply was never burned against it.
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 0)]).await;
+        mock_channel_supply(&mut server, 1_000).await;
+
+        // Taken while custody still backed the supply, so the ledger comparison passes.
+        let snapshot = CustodySnapshot {
+            balances: HashMap::from([(mint, 1_000)]),
+            slot: 50,
+        };
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1_000, 0)]);
+        let storage = Storage::Mock(mock_storage);
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let url = server.url();
+        let result = reconcile_against_snapshot(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &url,
+            Some(&url),
+            &Pubkey::new_unique(),
+            &snapshot,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(IndexerError::Reconciliation(
+                    ReconciliationError::SupplyExceedsCustody { .. }
+                ))
+            ),
+            "supply standing over an empty escrow must stop the boot: {:?}",
             result
         );
     }

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -7,7 +7,9 @@ pub mod operator;
 pub mod shutdown_utils;
 pub mod storage;
 
-#[cfg(test)]
+// Also built for `test-mock-storage` so integration tests can construct the same
+// instruction and event bytes the parser reads, instead of re-encoding the layout.
+#[cfg(any(test, feature = "test-mock-storage"))]
 pub mod test_utils;
 
 pub use config::{

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -48,19 +48,54 @@ pub struct CustodySnapshot {
     pub slot: u64,
 }
 
+/// Attempts allowed to get both token-program sweeps to answer at the same slot.
+const SWEEP_SLOT_AGREEMENT_ATTEMPTS: u32 = 3;
+
 /// Sum every token account owned by the escrow instance, grouped by mint, across
 /// the SPL Token and Token-2022 programs.
+///
+/// The two programs need one call each, so their readings can land on different slots and
+/// the merged balances would then hold activity the lower slot never saw. No single slot
+/// describes such a snapshot honestly, and labelling it with the lower one understates the
+/// custody it carries, so the sweep is simply taken again until both calls answer at the
+/// same slot. Back-to-back finalized reads normally agree on the first try.
 pub async fn fetch_escrow_balances_by_mint(
     rpc_client: &RpcClientWithRetry,
     escrow_instance_id: Pubkey,
 ) -> Result<CustodySnapshot, EscrowSweepError> {
+    let mut attempt = 1;
+    loop {
+        let (balances, low, high) = sweep_once(rpc_client, escrow_instance_id).await?;
+        if low != high && attempt < SWEEP_SLOT_AGREEMENT_ATTEMPTS {
+            attempt += 1;
+            continue;
+        }
+        if low != high {
+            // Out of attempts. The lower slot is the only one both readings are known to
+            // cover, so it stays the label; the caller's own retry gets the next chance.
+            warn!(
+                low_slot = low,
+                high_slot = high,
+                "Escrow sweep: token programs kept answering at different slots"
+            );
+        }
+        return Ok(CustodySnapshot {
+            balances,
+            slot: low,
+        });
+    }
+}
+
+/// One pass over both token programs. Returns the merged balances plus the lowest and
+/// highest slot the two responses reported, which agree when the pass saw one instant.
+async fn sweep_once(
+    rpc_client: &RpcClientWithRetry,
+    escrow_instance_id: Pubkey,
+) -> Result<(HashMap<Pubkey, u64>, u64, u64), EscrowSweepError> {
     let mut balances = HashMap::new();
     let token_programs = [spl_token::id(), spl_token_2022::id()];
-    // One call per token program, so the two readings can land on different slots.
-    // The lower one is the only slot both are known to cover: a balance from the
-    // higher reading may include a transfer the lower one had not yet seen, so
-    // claiming the higher slot would assert custody the snapshot cannot vouch for.
-    let mut snapshot_slot = u64::MAX;
+    let mut lowest_slot = u64::MAX;
+    let mut highest_slot = 0u64;
 
     for token_program_id in token_programs {
         let response = rpc_client
@@ -85,7 +120,8 @@ pub async fn fetch_escrow_balances_by_mint(
                 ),
             })?;
 
-        snapshot_slot = snapshot_slot.min(response.context.slot);
+        lowest_slot = lowest_slot.min(response.context.slot);
+        highest_slot = highest_slot.max(response.context.slot);
         let accounts = response.value;
 
         // The RPC may return accounts in binary (base64) or JSON-parsed form
@@ -138,10 +174,7 @@ pub async fn fetch_escrow_balances_by_mint(
         }
     }
 
-    Ok(CustodySnapshot {
-        balances,
-        slot: snapshot_slot,
-    })
+    Ok((balances, lowest_slot, highest_slot))
 }
 
 /// Read the channel-token supply for `mint` on the PrivateChannel chain. An
@@ -271,20 +304,38 @@ mod tests {
         spl_slot: u64,
         token_2022_slot: u64,
     ) {
-        server
+        mock_sweep_at_slots_times(server, spl_accounts, spl_slot, token_2022_slot, None).await;
+    }
+
+    /// `times` caps how many sweeps this pair is served for, so a test can script one pass
+    /// followed by a different one.
+    async fn mock_sweep_at_slots_times(
+        server: &mut mockito::Server,
+        spl_accounts: &[String],
+        spl_slot: u64,
+        token_2022_slot: u64,
+        times: Option<usize>,
+    ) {
+        let spl = server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(spl_token::id().to_string()))
             .with_status(200)
-            .with_body(result_body(spl_accounts, spl_slot))
-            .create_async()
-            .await;
-        server
+            .with_body(result_body(spl_accounts, spl_slot));
+        let token_2022 = server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(spl_token_2022::id().to_string()))
             .with_status(200)
-            .with_body(empty_body(token_2022_slot))
-            .create_async()
-            .await;
+            .with_body(empty_body(token_2022_slot));
+        match times {
+            Some(n) => {
+                spl.expect(n).create_async().await;
+                token_2022.expect(n).create_async().await;
+            }
+            None => {
+                spl.create_async().await;
+                token_2022.create_async().await;
+            }
+        };
     }
 
     #[tokio::test]
@@ -351,9 +402,9 @@ mod tests {
         assert_eq!(balances[&mint], 50);
     }
 
-    /// The two per-program calls can land on different slots, and only the lower one is
-    /// covered by both. Claiming the higher would vouch for custody the earlier reading
-    /// never saw, which is exactly the drift the snapshot slot exists to prevent.
+    /// When the two calls will not settle on one slot, the lower one is all the snapshot
+    /// can claim: the higher reading may hold custody the earlier call never saw, and
+    /// claiming its slot would vouch for exactly the drift the slot exists to prevent.
     #[tokio::test]
     async fn snapshot_slot_is_the_lower_of_the_two_sweeps() {
         let mut server = mockito::Server::new_async().await;
@@ -367,6 +418,36 @@ mod tests {
         assert_eq!(
             snapshot.slot, 880,
             "the snapshot can only claim the lower slot"
+        );
+        assert_eq!(snapshot.balances[&mint], 42);
+    }
+
+    /// A deposit finalizing between the two calls leaves the merged balances holding
+    /// activity the lower slot never saw, so labelling them with it understates custody
+    /// and reconciliation reads the difference as a mismatch. Taking the sweep again is
+    /// enough, because the skew lasts only as long as the gap between the two calls.
+    #[tokio::test]
+    async fn sweep_is_retaken_until_both_token_programs_answer_at_one_slot() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // First pass straddles a slot boundary; the next one lands inside a single slot.
+        mock_sweep_at_slots_times(
+            &mut server,
+            &[json_parsed_account(mint, 42)],
+            900,
+            880,
+            Some(1),
+        )
+        .await;
+        mock_sweep_at_slots(&mut server, &[json_parsed_account(mint, 42)], 905, 905).await;
+
+        let snapshot = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            snapshot.slot, 905,
+            "a re-read that agrees must replace the straddled pass"
         );
         assert_eq!(snapshot.balances[&mint], 42);
     }

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -48,8 +48,10 @@ pub struct CustodySnapshot {
     pub slot: u64,
 }
 
-/// Attempts allowed to get both token-program sweeps to answer at the same slot.
-const SWEEP_SLOT_AGREEMENT_ATTEMPTS: u32 = 3;
+/// Attempts allowed to get both token-program sweeps to answer at the same slot. Set
+/// generously because running out is fatal, not a fallback: back-to-back finalized reads
+/// agree almost every time, so needing five means something is genuinely wrong.
+const SWEEP_SLOT_AGREEMENT_ATTEMPTS: u32 = 5;
 
 /// Sum every token account owned by the escrow instance, grouped by mint, across
 /// the SPL Token and Token-2022 programs.
@@ -57,8 +59,13 @@ const SWEEP_SLOT_AGREEMENT_ATTEMPTS: u32 = 3;
 /// The two programs need one call each, so their readings can land on different slots and
 /// the merged balances would then hold activity the lower slot never saw. No single slot
 /// describes such a snapshot honestly, and labelling it with the lower one understates the
-/// custody it carries, so the sweep is simply taken again until both calls answer at the
-/// same slot. Back-to-back finalized reads normally agree on the first try.
+/// custody it carries, so the sweep is taken again until both calls answer at the same
+/// slot. Back-to-back finalized reads normally agree on the first try.
+///
+/// If they never agree, the sweep fails rather than hand back a slot the balances do not
+/// match: a caller that bounds its ledger read by that slot would compare two different
+/// moments and call an ordinary channel broken. A caller that ignores the slot sees only a
+/// skipped round, which its own retry covers.
 pub async fn fetch_escrow_balances_by_mint(
     rpc_client: &RpcClientWithRetry,
     escrow_instance_id: Pubkey,
@@ -71,13 +78,17 @@ pub async fn fetch_escrow_balances_by_mint(
             continue;
         }
         if low != high {
-            // Out of attempts. The lower slot is the only one both readings are known to
-            // cover, so it stays the label; the caller's own retry gets the next chance.
             warn!(
                 low_slot = low,
                 high_slot = high,
+                attempts = SWEEP_SLOT_AGREEMENT_ATTEMPTS,
                 "Escrow sweep: token programs kept answering at different slots"
             );
+            return Err(EscrowSweepError {
+                reason: format!(
+                    "token program sweeps never settled on one slot after                      {SWEEP_SLOT_AGREEMENT_ATTEMPTS} attempts (last spread {low}..{high});                      custody cannot be pinned to a single point"
+                ),
+            });
         }
         return Ok(CustodySnapshot {
             balances,
@@ -402,24 +413,24 @@ mod tests {
         assert_eq!(balances[&mint], 50);
     }
 
-    /// When the two calls will not settle on one slot, the lower one is all the snapshot
-    /// can claim: the higher reading may hold custody the earlier call never saw, and
-    /// claiming its slot would vouch for exactly the drift the slot exists to prevent.
+    /// When the two calls never settle on one slot, no slot describes the merged balances.
+    /// Handing back the lower one would let a caller bound its ledger at a point the
+    /// balances overshoot, so the sweep fails instead of guessing.
     #[tokio::test]
-    async fn snapshot_slot_is_the_lower_of_the_two_sweeps() {
+    async fn sweep_fails_when_the_two_programs_never_agree_on_a_slot() {
         let mut server = mockito::Server::new_async().await;
         let mint = Pubkey::new_unique();
         mock_sweep_at_slots(&mut server, &[json_parsed_account(mint, 42)], 900, 880).await;
 
-        let snapshot = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
-            .await
-            .unwrap();
+        let result =
+            fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique()).await;
 
-        assert_eq!(
-            snapshot.slot, 880,
-            "the snapshot can only claim the lower slot"
+        let err = result.expect_err("a snapshot with no coherent slot must not be returned");
+        assert!(
+            err.reason.contains("never settled on one slot"),
+            "unexpected reason: {}",
+            err.reason
         );
-        assert_eq!(snapshot.balances[&mint], 42);
     }
 
     /// A deposit finalizing between the two calls leaves the merged balances holding

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -36,18 +36,34 @@ impl std::fmt::Display for EscrowSweepError {
 
 impl std::error::Error for EscrowSweepError {}
 
+/// On-chain custody together with the slot the reading reflects.
+///
+/// The slot is what lets a caller compare this against a ledger bounded at the same
+/// point instead of against one that has drifted, so the two sides describe one instant.
+#[derive(Debug, Clone)]
+pub struct CustodySnapshot {
+    /// Per-mint custody; a mint absent from the map holds zero on-chain.
+    pub balances: HashMap<Pubkey, u64>,
+    /// Slot the whole snapshot is valid as of.
+    pub slot: u64,
+}
+
 /// Sum every token account owned by the escrow instance, grouped by mint, across
-/// the SPL Token and Token-2022 programs. The returned map is the on-chain
-/// custody snapshot; a mint absent from the map holds zero on-chain.
+/// the SPL Token and Token-2022 programs.
 pub async fn fetch_escrow_balances_by_mint(
     rpc_client: &RpcClientWithRetry,
     escrow_instance_id: Pubkey,
-) -> Result<HashMap<Pubkey, u64>, EscrowSweepError> {
+) -> Result<CustodySnapshot, EscrowSweepError> {
     let mut balances = HashMap::new();
     let token_programs = [spl_token::id(), spl_token_2022::id()];
+    // One call per token program, so the two readings can land on different slots.
+    // The lower one is the only slot both are known to cover: a balance from the
+    // higher reading may include a transfer the lower one had not yet seen, so
+    // claiming the higher slot would assert custody the snapshot cannot vouch for.
+    let mut snapshot_slot = u64::MAX;
 
     for token_program_id in token_programs {
-        let accounts = rpc_client
+        let response = rpc_client
             .with_retry(
                 "get_token_accounts_by_owner",
                 RetryPolicy::Idempotent,
@@ -60,7 +76,6 @@ pub async fn fetch_escrow_balances_by_mint(
                             CommitmentConfig::finalized(),
                         )
                         .await
-                        .map(|response| response.value)
                 },
             )
             .await
@@ -69,6 +84,9 @@ pub async fn fetch_escrow_balances_by_mint(
                     "Failed to fetch token accounts for program {token_program_id}: {e}"
                 ),
             })?;
+
+        snapshot_slot = snapshot_slot.min(response.context.slot);
+        let accounts = response.value;
 
         // The RPC may return accounts in binary (base64) or JSON-parsed form
         // depending on the requested encoding; handle both.
@@ -120,7 +138,10 @@ pub async fn fetch_escrow_balances_by_mint(
         }
     }
 
-    Ok(balances)
+    Ok(CustodySnapshot {
+        balances,
+        slot: snapshot_slot,
+    })
 }
 
 /// Read the channel-token supply for `mint` on the PrivateChannel chain. An
@@ -225,32 +246,43 @@ mod tests {
         )
     }
 
-    fn result_body(values: &[String]) -> String {
+    fn result_body(values: &[String], slot: u64) -> String {
         format!(
-            r#"{{"jsonrpc":"2.0","result":{{"context":{{"slot":1}},"value":[{}]}},"id":1}}"#,
+            r#"{{"jsonrpc":"2.0","result":{{"context":{{"slot":{slot}}},"value":[{}]}},"id":1}}"#,
             values.join(",")
         )
     }
 
-    const EMPTY_BODY: &str =
-        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":[]},"id":1}"#;
+    fn empty_body(slot: u64) -> String {
+        result_body(&[], slot)
+    }
 
     /// The sweep calls `get_token_accounts_by_owner` once per token program. Route the
     /// SPL Token call (matched by its program id in the request body) to `spl_accounts`
     /// and the Token-2022 call to an empty list so the two are not double-counted.
     async fn mock_sweep(server: &mut mockito::Server, spl_accounts: &[String]) {
+        mock_sweep_at_slots(server, spl_accounts, 1, 1).await;
+    }
+
+    /// Same routing, with the context slot of each call pinned separately.
+    async fn mock_sweep_at_slots(
+        server: &mut mockito::Server,
+        spl_accounts: &[String],
+        spl_slot: u64,
+        token_2022_slot: u64,
+    ) {
         server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(spl_token::id().to_string()))
             .with_status(200)
-            .with_body(result_body(spl_accounts))
+            .with_body(result_body(spl_accounts, spl_slot))
             .create_async()
             .await;
         server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(spl_token_2022::id().to_string()))
             .with_status(200)
-            .with_body(EMPTY_BODY)
+            .with_body(empty_body(token_2022_slot))
             .create_async()
             .await;
     }
@@ -273,7 +305,8 @@ mod tests {
 
         let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
             .await
-            .unwrap();
+            .unwrap()
+            .balances;
 
         assert_eq!(balances.len(), 2);
         assert_eq!(balances[&mint1], 300, "same mint across accounts must sum");
@@ -288,7 +321,8 @@ mod tests {
 
         let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
             .await
-            .unwrap();
+            .unwrap()
+            .balances;
 
         assert_eq!(balances[&mint], 1_234, "base64 layout must unpack and sum");
     }
@@ -310,10 +344,31 @@ mod tests {
 
         let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
             .await
-            .unwrap();
+            .unwrap()
+            .balances;
 
         assert_eq!(balances.len(), 1);
         assert_eq!(balances[&mint], 50);
+    }
+
+    /// The two per-program calls can land on different slots, and only the lower one is
+    /// covered by both. Claiming the higher would vouch for custody the earlier reading
+    /// never saw, which is exactly the drift the snapshot slot exists to prevent.
+    #[tokio::test]
+    async fn snapshot_slot_is_the_lower_of_the_two_sweeps() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        mock_sweep_at_slots(&mut server, &[json_parsed_account(mint, 42)], 900, 880).await;
+
+        let snapshot = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            snapshot.slot, 880,
+            "the snapshot can only claim the lower slot"
+        );
+        assert_eq!(snapshot.balances[&mint], 42);
     }
 
     #[tokio::test]
@@ -323,7 +378,8 @@ mod tests {
 
         let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
             .await
-            .unwrap();
+            .unwrap()
+            .balances;
 
         assert!(balances.is_empty());
     }

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -36,6 +36,36 @@ impl std::fmt::Display for EscrowSweepError {
 
 impl std::error::Error for EscrowSweepError {}
 
+/// Why a custody sweep could not produce a snapshot.
+///
+/// Kept apart from a plain read failure because the two deserve different answers: a slot
+/// the calls never settled on is a property of that attempt, not of the chain, so sweeping
+/// again can fix it, while a failing read usually cannot.
+#[derive(Debug, Clone)]
+pub enum SweepFailure {
+    /// An RPC call or an account decode failed.
+    Read(EscrowSweepError),
+    /// The two token-program calls never answered at the same slot, so no single slot
+    /// describes the merged balances.
+    SlotUnsettled { attempts: u32, low: u64, high: u64 },
+}
+
+impl std::fmt::Display for SweepFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SweepFailure::Read(e) => write!(f, "{e}"),
+            SweepFailure::SlotUnsettled {
+                attempts,
+                low,
+                high,
+            } => write!(
+                f,
+                "token program sweeps never settled on one slot after {attempts} attempts (last spread {low}..{high})"
+            ),
+        }
+    }
+}
+
 /// On-chain custody together with the slot the reading reflects.
 ///
 /// The slot is what lets a caller compare this against a ledger bounded at the same
@@ -64,15 +94,17 @@ const SWEEP_SLOT_AGREEMENT_ATTEMPTS: u32 = 5;
 ///
 /// If they never agree, the sweep fails rather than hand back a slot the balances do not
 /// match: a caller that bounds its ledger read by that slot would compare two different
-/// moments and call an ordinary channel broken. A caller that ignores the slot sees only a
-/// skipped round, which its own retry covers.
+/// moments and call an ordinary channel broken. The failure is reported as its own kind so
+/// a caller can sweep again, since the skew belongs to the attempt rather than the chain.
 pub async fn fetch_escrow_balances_by_mint(
     rpc_client: &RpcClientWithRetry,
     escrow_instance_id: Pubkey,
-) -> Result<CustodySnapshot, EscrowSweepError> {
+) -> Result<CustodySnapshot, SweepFailure> {
     let mut attempt = 1;
     loop {
-        let (balances, low, high) = sweep_once(rpc_client, escrow_instance_id).await?;
+        let (balances, low, high) = sweep_once(rpc_client, escrow_instance_id)
+            .await
+            .map_err(SweepFailure::Read)?;
         if low != high && attempt < SWEEP_SLOT_AGREEMENT_ATTEMPTS {
             attempt += 1;
             continue;
@@ -84,10 +116,10 @@ pub async fn fetch_escrow_balances_by_mint(
                 attempts = SWEEP_SLOT_AGREEMENT_ATTEMPTS,
                 "Escrow sweep: token programs kept answering at different slots"
             );
-            return Err(EscrowSweepError {
-                reason: format!(
-                    "token program sweeps never settled on one slot after                      {SWEEP_SLOT_AGREEMENT_ATTEMPTS} attempts (last spread {low}..{high});                      custody cannot be pinned to a single point"
-                ),
+            return Err(SweepFailure::SlotUnsettled {
+                attempts: SWEEP_SLOT_AGREEMENT_ATTEMPTS,
+                low,
+                high,
             });
         }
         return Ok(CustodySnapshot {
@@ -427,10 +459,34 @@ mod tests {
 
         let err = result.expect_err("a snapshot with no coherent slot must not be returned");
         assert!(
-            err.reason.contains("never settled on one slot"),
-            "unexpected reason: {}",
-            err.reason
+            matches!(err, SweepFailure::SlotUnsettled { .. }),
+            "the caller has to be able to tell this apart from a read failure: {err:?}"
         );
+    }
+
+    /// The failure has to be its own kind, not a generic read error: startup retries a
+    /// sweep that would not settle, because the node was moving under it, and gives up on
+    /// one that could not be read at all.
+    #[tokio::test]
+    async fn a_slot_that_never_settles_is_reported_apart_from_a_read_failure() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        mock_sweep_at_slots(&mut server, &[json_parsed_account(mint, 42)], 900, 880).await;
+
+        let err = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .expect_err("a snapshot with no coherent slot must not be returned");
+
+        match err {
+            SweepFailure::SlotUnsettled { low, high, .. } => {
+                assert_eq!(
+                    (low, high),
+                    (880, 900),
+                    "the spread is reported as measured"
+                );
+            }
+            other => panic!("a slot disagreement must not look like a read failure: {other:?}"),
+        }
     }
 
     /// A deposit finalizing between the two calls leaves the merged balances holding
@@ -569,7 +625,14 @@ mod tests {
         let result =
             fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique()).await;
 
-        let err = result.expect_err("malformed account must error").reason;
-        assert!(err.contains("tokenAmount"), "unexpected error: {err}");
+        let err = result.expect_err("malformed account must error");
+        let SweepFailure::Read(read) = &err else {
+            panic!("a decode failure is a read failure, not a slot disagreement: {err:?}");
+        };
+        assert!(
+            read.reason.contains("tokenAmount"),
+            "unexpected error: {}",
+            read.reason
+        );
     }
 }

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -564,8 +564,11 @@ async fn fetch_on_chain_balances(
     rpc_client: &Arc<RpcClientWithRetry>,
     escrow_instance_id: Pubkey,
 ) -> Result<HashMap<Pubkey, u64>, OperatorError> {
+    // Runtime reconciliation compares against live DB totals, so it wants the balances
+    // only; the snapshot slot matters to startup, which bounds its ledger read by it.
     fetch_escrow_balances_by_mint(rpc_client, escrow_instance_id)
         .await
+        .map(|snapshot| snapshot.balances)
         .map_err(|e| OperatorError::RpcError(e.reason))
 }
 

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -569,7 +569,7 @@ async fn fetch_on_chain_balances(
     fetch_escrow_balances_by_mint(rpc_client, escrow_instance_id)
         .await
         .map(|snapshot| snapshot.balances)
-        .map_err(|e| OperatorError::RpcError(e.reason))
+        .map_err(|e| OperatorError::RpcError(e.to_string()))
 }
 
 /// Sends webhook alerts for balance mismatches with retry logic

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -254,11 +254,14 @@ impl Storage {
         .await
     }
 
-    /// Return per-mint aggregate balances (completed deposits minus withdrawals) for startup reconciliation.
+    /// Return per-mint aggregate balances (completed deposits minus withdrawals) for
+    /// startup reconciliation, counting only what was indexed at or below `as_of_slot`.
     pub async fn get_mint_balances_for_reconciliation(
         &self,
+        as_of_slot: u64,
     ) -> Result<Vec<MintDbBalance>, StorageError> {
-        get_mint_balances_for_reconciliation::get_mint_balances_for_reconciliation(self).await
+        get_mint_balances_for_reconciliation::get_mint_balances_for_reconciliation(self, as_of_slot)
+            .await
     }
 
     /// Query escrow balances by mint for continuous reconciliation checks.
@@ -1194,9 +1197,14 @@ mod tests {
         }
 
         let balances = storage
-            .get_mint_balances_for_reconciliation()
+            .get_mint_balances_for_reconciliation(900)
             .await
             .unwrap();
+        assert_eq!(
+            mock.last_reconciliation_slot(),
+            Some(900),
+            "the slot bound must reach storage, not be dropped on the way"
+        );
         assert_eq!(balances.len(), 2);
         assert!(balances.iter().any(|b| b.mint_address == "usdc"
             && b.total_deposits == BigDecimal::from(10000u64)

--- a/indexer/src/storage/common/storage/get_mint_balances_for_reconciliation.rs
+++ b/indexer/src/storage/common/storage/get_mint_balances_for_reconciliation.rs
@@ -3,12 +3,21 @@ use crate::{
     storage::common::{models::MintDbBalance, storage::Storage},
 };
 
+/// Slots are far below `i64::MAX`, so the clamp is unreachable in practice and only
+/// keeps an absurd value from wrapping into a negative bound that matches nothing.
+fn slot_bound(as_of_slot: u64) -> i64 {
+    i64::try_from(as_of_slot).unwrap_or(i64::MAX)
+}
+
 pub async fn get_mint_balances_for_reconciliation(
     storage: &Storage,
+    as_of_slot: u64,
 ) -> Result<Vec<MintDbBalance>, StorageError> {
     match storage {
-        Storage::Postgres(db) => Ok(db.get_mint_balances_for_reconciliation_internal().await?),
+        Storage::Postgres(db) => Ok(db
+            .get_mint_balances_for_reconciliation_internal(slot_bound(as_of_slot))
+            .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
-        Storage::Mock(mock) => mock.get_mint_balances_for_reconciliation().await,
+        Storage::Mock(mock) => mock.get_mint_balances_for_reconciliation(as_of_slot).await,
     }
 }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -28,6 +28,10 @@ pub struct MockStorage {
     pub call_counts: std::sync::Arc<Mutex<HashMap<String, usize>>>,
     pub mints: std::sync::Arc<Mutex<HashMap<String, DbMint>>>,
     pub mint_balances: std::sync::Arc<Mutex<Vec<MintDbBalance>>>,
+    /// Slot the last reconciliation balance read was bounded by, so a test can prove the
+    /// bound reached storage. The stored balances are pre-aggregated with no slot of
+    /// their own, so the mock records the bound rather than applying it.
+    pub last_reconciliation_slot: std::sync::Arc<Mutex<Option<u64>>>,
     pub pending_transactions: std::sync::Arc<Mutex<Vec<DbTransaction>>>,
     pub inserted_transactions: std::sync::Arc<Mutex<Vec<Vec<DbTransaction>>>>,
     pub inserted_single_transactions: std::sync::Arc<Mutex<Vec<DbTransaction>>>,
@@ -567,8 +571,15 @@ impl MockStorage {
 
     pub async fn get_mint_balances_for_reconciliation(
         &self,
+        as_of_slot: u64,
     ) -> Result<Vec<MintDbBalance>, StorageError> {
+        *self.last_reconciliation_slot.lock().unwrap() = Some(as_of_slot);
         Ok(self.mint_balances.lock().unwrap().clone())
+    }
+
+    /// Slot the last reconciliation balance read was bounded by.
+    pub fn last_reconciliation_slot(&self) -> Option<u64> {
+        *self.last_reconciliation_slot.lock().unwrap()
     }
 
     pub async fn get_escrow_balances_by_mint(&self) -> Result<Vec<MintDbBalance>, StorageError> {

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -2492,8 +2492,15 @@ impl PostgresDb {
     ///   `release_funds` call actually moves tokens out of the ATA.
     ///
     /// Mints with no transactions still appear (with totals = 0) because of the LEFT JOIN.
+    ///
+    /// `as_of_slot` bounds the totals to what was indexed at or below that slot, so the
+    /// answer describes the ledger at one point rather than at whatever moment the query
+    /// happened to run. The bound sits in the JOIN, not a WHERE clause, because moving it
+    /// to WHERE would discard the NULL rows the LEFT JOIN produces for a mint with no
+    /// qualifying transactions and silently drop that mint from the comparison.
     pub async fn get_mint_balances_for_reconciliation_internal(
         &self,
+        as_of_slot: i64,
     ) -> Result<Vec<MintDbBalance>, sqlx::Error> {
         sqlx::query_as::<_, MintDbBalance>(
             r#"
@@ -2509,10 +2516,11 @@ impl PostgresDb {
                     0
                 )::NUMERIC AS total_withdrawals
             FROM mints m
-            LEFT JOIN transactions t ON t.mint = m.mint_address
+            LEFT JOIN transactions t ON t.mint = m.mint_address AND t.slot <= $1
             GROUP BY m.mint_address, m.token_program
             "#,
         )
+        .bind(as_of_slot)
         .fetch_all(&self.pool)
         .await
     }

--- a/indexer/src/test_utils.rs
+++ b/indexer/src/test_utils.rs
@@ -139,7 +139,7 @@ pub mod rpc_blocks {
 /// self-CPI. Centralised here so the escrow parser tests and the decoder tests
 /// build the exact same bytes against one source of truth (the `pub(crate)`
 /// escrow constants), rather than each re-encoding the layout.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-mock-storage"))]
 pub mod escrow_fixtures {
     use crate::indexer::datasource::common::parser::escrow::{
         DEPOSIT, DEPOSIT_EVENT_DISCRIMINATOR, EVENT_IX_TAG_LE,

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -906,12 +906,37 @@ async fn reconciliation_balance_counts_correctly() -> Result<(), Box<dyn std::er
     w2.amount = TokenAmount(9999);
     storage.insert_db_transaction(&w2).await?;
 
-    let balances = storage.get_mint_balances_for_reconciliation().await?;
+    // A later deposit, above the bound the assertions below use.
+    let mut d3 = make_db_transaction("recon_d3", TransactionType::Deposit);
+    d3.mint = mint.to_string();
+    d3.amount = TokenAmount(700);
+    d3.slot = 200;
+    storage.insert_db_transaction(&d3).await?;
+
+    let balances = storage
+        .get_mint_balances_for_reconciliation(u64::MAX)
+        .await?;
     assert_eq!(balances.len(), 1);
-    // Deposits: 500 (pending) + 300 (completed) = 800  (all statuses)
-    assert_eq!(balances[0].total_deposits, BigDecimal::from(800u64));
+    // Deposits: 500 (pending) + 300 (completed) + 700 (later slot) = 1500 (all statuses)
+    assert_eq!(balances[0].total_deposits, BigDecimal::from(1500u64));
     // Withdrawals: only completed = 100
     assert_eq!(balances[0].total_withdrawals, BigDecimal::from(100u64));
+
+    // Bounded at the earlier rows' slot: the later deposit is excluded.
+    let at_100 = storage.get_mint_balances_for_reconciliation(100).await?;
+    assert_eq!(at_100[0].total_deposits, BigDecimal::from(800u64));
+    assert_eq!(at_100[0].total_withdrawals, BigDecimal::from(100u64));
+
+    // Below every row: the mint must still be reported, at zero. If the bound moved to a
+    // WHERE clause the mint would vanish here and drop out of the comparison entirely.
+    let at_99 = storage.get_mint_balances_for_reconciliation(99).await?;
+    assert_eq!(
+        at_99.len(),
+        1,
+        "a mint with no rows in range must still appear"
+    );
+    assert_eq!(at_99[0].total_deposits, BigDecimal::from(0u64));
+    assert_eq!(at_99[0].total_withdrawals, BigDecimal::from(0u64));
     Ok(())
 }
 

--- a/indexer/tests/remint_e2e_test.rs
+++ b/indexer/tests/remint_e2e_test.rs
@@ -383,7 +383,9 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
     // on-chain reality — the withdrawal never landed, so the escrow still holds
     // the full deposit. Counting a PendingRemint withdrawal would undercount
     // the escrow balance and produce a false reconciliation mismatch.
-    let pending = storage.get_mint_balances_for_reconciliation().await?;
+    let pending = storage
+        .get_mint_balances_for_reconciliation(u64::MAX)
+        .await?;
     let balance = pending
         .iter()
         .find(|b| b.mint_address == mint.to_string())
@@ -421,7 +423,9 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
     // The failed withdrawal is still NOT in total_withdrawals — FailedReminted
     // means the withdrawal never succeeded on-chain. The escrow still holds the
     // deposit. The user received their tokens back on PrivateChannel via remint.
-    let after_balances = storage.get_mint_balances_for_reconciliation().await?;
+    let after_balances = storage
+        .get_mint_balances_for_reconciliation(u64::MAX)
+        .await?;
     let after_balance = after_balances
         .iter()
         .find(|b| b.mint_address == mint.to_string())
@@ -474,7 +478,9 @@ async fn test_multiple_pending_remints_excluded_from_balance(
     }
 
     // All three PendingRemint withdrawals must be invisible to the balance query.
-    let balances = storage.get_mint_balances_for_reconciliation().await?;
+    let balances = storage
+        .get_mint_balances_for_reconciliation(u64::MAX)
+        .await?;
     let balance = balances
         .iter()
         .find(|b| b.mint_address == mint.to_string())

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -112,6 +112,11 @@ path = "tests/indexer/reconnect_gap_fill_fail_closed.rs"
 name = "startup_anchor"
 path = "tests/indexer/startup_anchor.rs"
 
+# Startup ordering: backfill completes and commits before escrow reconciliation.
+[[test]]
+name = "startup_backfill_reconcile"
+path = "tests/indexer/startup_backfill_reconcile.rs"
+
 # Yellowstone inner_instructions + unknown-discriminator arms.
 [[test]]
 name = "yellowstone_inner_and_unknown"

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -50,6 +50,7 @@ integration-test:
 	@cargo test --test permanent_delegate_mint_integration -- --nocapture
 	@cargo test --test resync_integration -- --nocapture --test-threads=1
 	@cargo test --test reconciliation_e2e_test -- --nocapture
+	@cargo test --test startup_backfill_reconcile -- --nocapture
 	@cargo test --test mock_rpc_retry -- --nocapture
 	@cargo test --test checkpoint_partial_flush -- --nocapture
 	@cargo test --test remint_recovery -- --nocapture
@@ -247,6 +248,8 @@ integration-coverage-indexer:
 	@cargo llvm-cov test --no-report --workspace --test resync_integration -- --nocapture --test-threads=1
 	@echo "Running reconciliation e2e tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test reconciliation_e2e_test -- --nocapture
+	@echo "Running startup backfill/reconcile ordering tests with coverage instrumentation..."
+	@cargo llvm-cov test --no-report --workspace --test startup_backfill_reconcile -- --nocapture
 	@echo "Running mock-rpc retry tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test mock_rpc_retry -- --nocapture
 	@echo "Running checkpoint partial-flush tests with coverage instrumentation..."

--- a/integration/tests/indexer/reconciliation.rs
+++ b/integration/tests/indexer/reconciliation.rs
@@ -63,6 +63,30 @@ fn instance_pda(seed: &Pubkey) -> Pubkey {
     .0
 }
 
+/// Slot the seeded rows below are written at.
+const SEEDED_ROW_SLOT: u64 = 1;
+
+/// Wait until the node's finalized slot covers `slot`.
+///
+/// Reconciliation compares custody against the ledger as of the slot the custody read
+/// reflects, so rows above that slot are outside the comparison by design. A validator
+/// that has just started can still report a finalized slot of 0, which would put the
+/// seeded rows out of range and leave the test asserting against an empty comparison.
+async fn wait_for_finalized_to_cover(rpc_url: &str, slot: u64) {
+    let client = RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::finalized());
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        if client.get_slot().await.map(|s| s >= slot).unwrap_or(false) {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for the finalized slot to reach {slot}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
 /// Register a mint in the `mints` table and insert a single `pending` deposit of
 /// `amount` raw tokens. Uses `pending` status to exercise the all-statuses fix —
 /// all indexed deposits count toward the DB-expected balance regardless of status.
@@ -158,6 +182,7 @@ async fn test_reconciliation_blocks_on_phantom_deposit() -> Result<(), Box<dyn s
 
     let mint = Pubkey::new_unique();
     seed_mint_and_deposit(&pool, &mint.to_string(), 1_000_000).await?;
+    wait_for_finalized_to_cover(&test_validator.rpc_url(), SEEDED_ROW_SLOT).await;
 
     let result = run_startup_reconciliation(
         &ReconciliationConfig {
@@ -195,6 +220,7 @@ async fn test_reconciliation_passes_within_threshold() -> Result<(), Box<dyn std
     // DB expects 500_000; ATA absent → on-chain = 0; mismatch = 500_000 ≤ threshold 1_000_000
     let mint = Pubkey::new_unique();
     seed_mint_and_deposit(&pool, &mint.to_string(), 500_000).await?;
+    wait_for_finalized_to_cover(&test_validator.rpc_url(), SEEDED_ROW_SLOT).await;
 
     let result = run_startup_reconciliation(
         &ReconciliationConfig {

--- a/integration/tests/indexer/resync.rs
+++ b/integration/tests/indexer/resync.rs
@@ -295,6 +295,17 @@ fn script_channel_empty(mock: &MockRpcServer) {
     }
 }
 
+/// Answer the startup supply invariant with "no channel mint exists yet".
+///
+/// An absent mint account reads as zero supply, which can never exceed custody, so the
+/// invariant passes and the custody comparison stays the only thing under test. Startup
+/// now refuses to boot on a supply it could not read, so leaving the read unscripted
+/// would fail the boot rather than be ignored.
+fn script_channel_empty_supply(mock: &MockRpcServer) {
+    let reply = Reply::result(json!({"context": {"slot": 1}, "value": null}));
+    mock.enqueue_sequence("getAccountInfo", std::iter::repeat_n(reply, 256));
+}
+
 /// Place the single serviced mint on page 2: page 1 is a full `CHANNEL_PAGE_LIMIT`
 /// page of fillers so the `before` cursor advances, then page 2 carries the memo.
 fn script_channel_consumed_on_page2(
@@ -1095,6 +1106,7 @@ async fn resync_preserves_startup_reconciliation_pass() -> Result<(), Box<dyn st
     // A single reconciling run against an empty channel is enough: the AllowMint
     // is replayed (genesis precedes setup) and the deposit row is rebuilt.
     script_channel_empty(&mock);
+    script_channel_empty_supply(&mock);
     h.run().await.expect("resync should succeed");
 
     assert_eq!(

--- a/integration/tests/indexer/startup_anchor.rs
+++ b/integration/tests/indexer/startup_anchor.rs
@@ -2,9 +2,9 @@
 //!
 //! Reconnect gap repair replays from the durable checkpoint, so `run` must persist one
 //! before the Yellowstone stream can deliver anything. These tests pin the value it picks:
-//! the chain tip when no startup backfill resolved a boundary, and the boundary's floor
-//! when one did. Picking the top of the resolved range instead would durably claim the
-//! slots backfill has not fetched yet, which is the loss the anchor exists to prevent.
+//! the chain tip when no startup backfill resolved a boundary, and the checkpoint the fill
+//! itself committed when one did. Either way the anchor never names a slot nothing has
+//! read, which is the loss it exists to prevent.
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::{
@@ -184,10 +184,14 @@ async fn run_persists_tip_anchor_before_streaming() {
     ys.shutdown().await;
 }
 
-/// With startup backfill resolving a range, the anchor is that range's floor. The tip and
-/// the live start slot both sit above slots backfill has yet to fetch, so recording either
-/// would mark them handled and put them permanently out of reach. All three are plain u64,
-/// so nothing but this test stops the wrong one being passed.
+/// With startup backfill resolving a range, the anchor never claims a slot nothing has
+/// read. Startup fills the range and waits for its checkpoint before the stream starts, so
+/// by the time the anchor is needed the durable checkpoint is already the fill target and
+/// stands as the anchor: every slot beneath it is proven written, one at a time, by the
+/// gate that only advances across contiguous slots.
+///
+/// The live start slot sits one past the target and is still wrong to record, and it and
+/// the target are both plain u64, so nothing but this test stops the wrong one being used.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn run_anchors_at_resolved_from_slot_not_the_tip() {
     init_tracing();
@@ -207,28 +211,32 @@ async fn run_anchors_at_resolved_from_slot_not_the_tip() {
         .expect_at_least(0)
         .create_async()
         .await;
+    // Every slot in the range must actually be fetched: the checkpoint the anchor comes
+    // from is only reachable once all of them are written.
+    let mut block_mocks = Vec::new();
     for slot in START_SLOT..=TIP {
-        let _block = rpc
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(
-                json!({"method": "getBlock", "params": [slot]}),
-            ))
-            .with_status(200)
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "result": {
-                        "blockhash": "TestBlockHash11111111111111111111111111111",
-                        "parentSlot": slot - 1,
-                        "transactions": []
-                    },
-                    "id": 1
-                })
-                .to_string(),
-            )
-            .expect_at_least(0)
-            .create_async()
-            .await;
+        block_mocks.push(
+            rpc.mock("POST", "/")
+                .match_body(Matcher::PartialJson(
+                    json!({"method": "getBlock", "params": [slot]}),
+                ))
+                .with_status(200)
+                .with_body(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "result": {
+                            "blockhash": "TestBlockHash11111111111111111111111111111",
+                            "parentSlot": slot - 1,
+                            "transactions": []
+                        },
+                        "id": 1
+                    })
+                    .to_string(),
+                )
+                .expect_at_least(1)
+                .create_async()
+                .await,
+        );
     }
 
     let ys = MockYellowstoneServer::start().await;
@@ -254,11 +262,18 @@ async fn run_anchors_at_resolved_from_slot_not_the_tip() {
     let anchor = wait_for_anchor(&pool, "withdraw", 60).await;
     assert_eq!(
         anchor,
-        floor,
-        "the anchor must be the resolved range floor, not the tip ({TIP}) \
-         or the live start slot ({})",
+        TIP,
+        "the anchor must be the filled range's committed target, not the live start slot ({})",
         TIP + 1
     );
+    assert!(
+        anchor >= floor,
+        "the anchor must never fall below the range floor ({floor})"
+    );
+    // Proof the anchor was earned rather than assumed: every slot in the range was fetched.
+    for m in &block_mocks {
+        m.assert_async().await;
+    }
 
     handle.abort();
     ys.shutdown().await;

--- a/integration/tests/indexer/startup_anchor.rs
+++ b/integration/tests/indexer/startup_anchor.rs
@@ -2,9 +2,9 @@
 //!
 //! Reconnect gap repair replays from the durable checkpoint, so `run` must persist one
 //! before the Yellowstone stream can deliver anything. These tests pin the value it picks:
-//! the chain tip when no startup backfill resolved a boundary, and the checkpoint the fill
-//! itself committed when one did. Either way the anchor never names a slot nothing has
-//! read, which is the loss it exists to prevent.
+//! the chain tip when no startup backfill resolved a boundary, and the boundary's floor
+//! when one did. Picking the top of the resolved range instead would durably claim the
+//! slots backfill has not fetched yet, which is the loss the anchor exists to prevent.
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::{
@@ -184,14 +184,10 @@ async fn run_persists_tip_anchor_before_streaming() {
     ys.shutdown().await;
 }
 
-/// With startup backfill resolving a range, the anchor never claims a slot nothing has
-/// read. Startup fills the range and waits for its checkpoint before the stream starts, so
-/// by the time the anchor is needed the durable checkpoint is already the fill target and
-/// stands as the anchor: every slot beneath it is proven written, one at a time, by the
-/// gate that only advances across contiguous slots.
-///
-/// The live start slot sits one past the target and is still wrong to record, and it and
-/// the target are both plain u64, so nothing but this test stops the wrong one being used.
+/// With startup backfill resolving a range, the anchor is that range's floor. The tip and
+/// the live start slot both sit above slots backfill has yet to fetch, so recording either
+/// would mark them handled and put them permanently out of reach. All three are plain u64,
+/// so nothing but this test stops the wrong one being passed.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn run_anchors_at_resolved_from_slot_not_the_tip() {
     init_tracing();
@@ -211,32 +207,28 @@ async fn run_anchors_at_resolved_from_slot_not_the_tip() {
         .expect_at_least(0)
         .create_async()
         .await;
-    // Every slot in the range must actually be fetched: the checkpoint the anchor comes
-    // from is only reachable once all of them are written.
-    let mut block_mocks = Vec::new();
     for slot in START_SLOT..=TIP {
-        block_mocks.push(
-            rpc.mock("POST", "/")
-                .match_body(Matcher::PartialJson(
-                    json!({"method": "getBlock", "params": [slot]}),
-                ))
-                .with_status(200)
-                .with_body(
-                    json!({
-                        "jsonrpc": "2.0",
-                        "result": {
-                            "blockhash": "TestBlockHash11111111111111111111111111111",
-                            "parentSlot": slot - 1,
-                            "transactions": []
-                        },
-                        "id": 1
-                    })
-                    .to_string(),
-                )
-                .expect_at_least(1)
-                .create_async()
-                .await,
-        );
+        let _block = rpc
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "getBlock", "params": [slot]}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "TestBlockHash11111111111111111111111111111",
+                        "parentSlot": slot - 1,
+                        "transactions": []
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(0)
+            .create_async()
+            .await;
     }
 
     let ys = MockYellowstoneServer::start().await;
@@ -262,18 +254,11 @@ async fn run_anchors_at_resolved_from_slot_not_the_tip() {
     let anchor = wait_for_anchor(&pool, "withdraw", 60).await;
     assert_eq!(
         anchor,
-        TIP,
-        "the anchor must be the filled range's committed target, not the live start slot ({})",
+        floor,
+        "the anchor must be the resolved range floor, not the tip ({TIP}) \
+         or the live start slot ({})",
         TIP + 1
     );
-    assert!(
-        anchor >= floor,
-        "the anchor must never fall below the range floor ({floor})"
-    );
-    // Proof the anchor was earned rather than assumed: every slot in the range was fetched.
-    for m in &block_mocks {
-        m.assert_async().await;
-    }
 
     handle.abort();
     ys.shutdown().await;

--- a/integration/tests/indexer/startup_backfill_reconcile.rs
+++ b/integration/tests/indexer/startup_backfill_reconcile.rs
@@ -1,0 +1,646 @@
+//! Startup ordering between backfill and escrow reconciliation in
+//! `private_channel_indexer::indexer::run`.
+//!
+//! A deposit that finalizes while the indexer is down leaves on-chain custody ahead of the
+//! database. Reconciliation compares the two, so running it before backfill has imported
+//! that deposit compares current custody against a ledger that is knowingly incomplete,
+//! and at the default zero tolerance that aborts the boot before backfill can repair
+//! anything. Every restart then repeats it.
+//!
+//! These tests pin both halves of the fix: the ordinary recovery path must import the
+//! deposit and then reconcile clean at the strictest threshold, and a mismatch that
+//! backfill cannot explain must still stop startup.
+
+#[path = "helpers/mod.rs"]
+mod helpers;
+
+#[path = "setup.rs"]
+#[allow(dead_code)]
+mod setup;
+
+use mockito::{Matcher, Server as MockitoServer};
+use private_channel_escrow_program_client::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
+use private_channel_indexer::{
+    config::{BackfillConfig, ReconciliationConfig, RpcPollingConfig},
+    error::{IndexerError, ReconciliationError},
+    indexer::run,
+    storage::{PostgresDb, Storage},
+    DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig, ProgramType,
+    StorageType,
+};
+use serde_json::json;
+use setup::{find_allowed_mint_pda, find_event_authority_pda, TestEnvironment};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::rpc_config::RpcBlockConfig;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    commitment_config::CommitmentLevel,
+    instruction::Instruction,
+    pubkey::Pubkey,
+    signature::{Keypair, Signature, Signer},
+};
+use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
+use solana_transaction_status::{TransactionDetails, UiTransactionEncoding};
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token::ID as TOKEN_PROGRAM_ID;
+use sqlx::PgPool;
+use std::{sync::Arc, time::Duration};
+use test_utils::mock_rpc::MockRpcServer;
+use test_utils::validator_helper::start_test_validator_no_geyser;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio::task::JoinHandle;
+
+const USER_BALANCE: u64 = 1_000_000;
+const DEPOSIT_AMOUNT: u64 = 50_000;
+
+/// Raw amount of the phantom deposit row that no on-chain balance backs.
+const PHANTOM_AMOUNT: i64 = 12_345;
+
+/// Scripted chain tip and first slot for the fully mocked halt test.
+const MOCK_TIP: u64 = 900;
+const MOCK_START_SLOT: u64 = 895;
+
+/// Generous enough for a validator plus a full backfill and, for the halting case, three
+/// reconcile attempts each waiting on a checkpoint flush.
+const STARTUP_TIMEOUT_SECS: u64 = 180;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+}
+
+/// Real Postgres via testcontainers, with the indexer schema already created so a test can
+/// seed rows before `run` starts. The container must stay alive for the whole test.
+async fn start_postgres(
+    db: &str,
+) -> (
+    testcontainers::ContainerAsync<Postgres>,
+    PgPool,
+    PostgresConfig,
+) {
+    let container = Postgres::default()
+        .with_db_name(db)
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("postgres container");
+    let host = container.get_host().await.expect("pg host");
+    let port = container.get_host_port_ipv4(5432).await.expect("pg port");
+    let url = format!("postgres://postgres:password@{host}:{port}/{db}");
+
+    let config = PostgresConfig {
+        database_url: url.clone(),
+        max_connections: 10,
+    };
+    let storage = Storage::Postgres(PostgresDb::new(&config).await.expect("storage"));
+    storage.init_schema().await.expect("schema");
+
+    let pool = PgPool::connect(&url).await.expect("pg pool");
+    (container, pool, config)
+}
+
+fn deposit_ix(user: &Keypair, instance: Pubkey, mint: Pubkey, amount: u64) -> Instruction {
+    let (allowed_mint_pda, _) = find_allowed_mint_pda(&instance, &mint);
+    let (event_authority_pda, _) = find_event_authority_pda();
+    let user_ata =
+        get_associated_token_address_with_program_id(&user.pubkey(), &mint, &TOKEN_PROGRAM_ID);
+    let instance_ata =
+        get_associated_token_address_with_program_id(&instance, &mint, &TOKEN_PROGRAM_ID);
+
+    private_channel_escrow_program_client::instructions::DepositBuilder::new()
+        .payer(user.pubkey())
+        .user(user.pubkey())
+        .instance(instance)
+        .mint(mint)
+        .allowed_mint(allowed_mint_pda)
+        .user_ata(user_ata)
+        .instance_ata(instance_ata)
+        .system_program(SYSTEM_PROGRAM_ID)
+        .token_program(TOKEN_PROGRAM_ID)
+        .associated_token_program(spl_associated_token_account::ID)
+        .event_authority(event_authority_pda)
+        .private_channel_escrow_program(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID)
+        .amount(amount)
+        .instruction()
+}
+
+/// Wait until the instance ATA's finalized balance is `expected`, so the escrow sweep that
+/// reconciliation performs is guaranteed to observe the deposit.
+async fn wait_for_finalized_custody(rpc_url: &str, ata: &Pubkey, expected: u64) {
+    let client = RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::finalized());
+    let deadline = std::time::Instant::now() + Duration::from_secs(90);
+    loop {
+        if let Ok(balance) = client.get_token_account_balance(ata).await {
+            if balance.amount.parse::<u64>().unwrap_or(0) == expected {
+                return;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for finalized custody to reach {expected}"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+}
+
+/// Spawn `run` on the ordinary recovery configuration and hand back its result.
+///
+/// `mismatch_threshold_raw` is deliberately 0, the shipped default, because the whole
+/// finding is that this configuration cannot boot. `start_slot` is the bottom of the slice
+/// the indexer missed, so the fill has exactly that slice to recover. The channel RPC is
+/// an unscripted mock: it answers every method with an error, which makes the supply
+/// invariant skip each mint with a warning and leaves the custody comparison as the only
+/// thing that can fail the boot.
+fn spawn_indexer(
+    postgres: PostgresConfig,
+    rpc_url: String,
+    channel_rpc_url: String,
+    instance: Pubkey,
+    start_slot: u64,
+) -> JoinHandle<Result<(), IndexerError>> {
+    let common = PrivateChannelIndexerConfig {
+        program_type: ProgramType::Escrow,
+        storage_type: StorageType::Postgres,
+        rpc_url: rpc_url.clone(),
+        fallback_rpc_url: None,
+        source_rpc_url: Some(channel_rpc_url),
+        postgres,
+        escrow_instance_id: Some(instance),
+    };
+
+    let indexer = IndexerConfig {
+        datasource_type: DatasourceType::RpcPolling,
+        rpc_polling: Some(RpcPollingConfig {
+            from_slot: None,
+            poll_interval_ms: 200,
+            error_retry_interval_ms: 1_000,
+            batch_size: 10,
+            encoding: UiTransactionEncoding::Json,
+            // Confirmed, matching the other RPC-polling harness in this repo. A
+            // solana-test-validator started without geyser never finalizes the deposit
+            // slots, so at Finalized getBlock refuses to serve them indefinitely. The
+            // deposit is still waited out to finalized custody before startup, so the
+            // sweep and the ledger agree on it either way.
+            commitment: CommitmentLevel::Confirmed,
+        }),
+        yellowstone: None,
+        backfill: BackfillConfig {
+            enabled: true,
+            exit_after_backfill: false,
+            rpc_url,
+            batch_size: 100,
+            max_gap_slots: u64::MAX,
+            start_slot: Some(start_slot),
+        },
+        reconciliation: ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        },
+    };
+
+    common.validate().expect("common config");
+    indexer.validate().expect("indexer config");
+
+    tokio::spawn(async move { run(common, indexer, None).await })
+}
+
+/// Wait until `slot`'s block can actually be served.
+///
+/// A block is listed as produced before the RPC will hand it over, and the fill treats a
+/// listed-but-unservable block as a hard error rather than something to retry, by design.
+/// Waiting on the one slot that must be imported keeps the test measuring startup ordering
+/// rather than how quickly the validator's block store catches up.
+async fn wait_for_block_servable(rpc_url: &str, slot: u64) {
+    let client = RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::confirmed());
+    let config = RpcBlockConfig {
+        encoding: Some(UiTransactionEncoding::Json),
+        transaction_details: Some(TransactionDetails::Full),
+        rewards: Some(false),
+        commitment: Some(CommitmentConfig::confirmed()),
+        max_supported_transaction_version: Some(0),
+    };
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(90);
+    loop {
+        if client.get_block_with_config(slot, config).await.is_ok() {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for slot {slot} to become servable"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+}
+
+/// Mock the escrow sweep. `holdings` is the per-mint custody the instance is reported to
+/// hold; an empty slice means the escrow holds nothing.
+///
+/// Answers every attempt's two token programs, so it is left uncounted rather than pinned
+/// to an exact hit count.
+async fn mock_escrow_custody(rpc: &mut MockitoServer, holdings: &[(String, i64)]) -> mockito::Mock {
+    let accounts: Vec<serde_json::Value> = holdings
+        .iter()
+        .map(|(mint, amount)| {
+            json!({
+                "pubkey": Pubkey::new_unique().to_string(),
+                "account": {
+                    "lamports": 2_039_280,
+                    "owner": TOKEN_PROGRAM_ID.to_string(),
+                    "executable": false,
+                    "rentEpoch": 0,
+                    "space": 165,
+                    "data": {
+                        "program": "spl-token",
+                        "space": 165,
+                        "parsed": {
+                            "type": "account",
+                            "info": {
+                                "mint": mint,
+                                "tokenAmount": { "amount": amount.to_string() }
+                            }
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+
+    rpc.mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getTokenAccountsByOwner"}),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "jsonrpc": "2.0",
+                "result": {"context": {"slot": MOCK_TIP}, "value": accounts},
+                "id": 1
+            })
+            .to_string(),
+        )
+        .expect_at_least(1)
+        .create_async()
+        .await
+}
+
+/// Mock the block enumeration and every block in the fill range, all empty.
+async fn mock_fill_range(rpc: &mut MockitoServer) -> Vec<mockito::Mock> {
+    let mut mocks = Vec::new();
+    mocks.push(
+        rpc.mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "result": MOCK_TIP, "id": 1}).to_string())
+            .expect_at_least(1)
+            .create_async()
+            .await,
+    );
+    let produced: Vec<u64> = (MOCK_START_SLOT..=MOCK_TIP).collect();
+    mocks.push(
+        rpc.mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "getBlocks", "params": [MOCK_START_SLOT, MOCK_TIP]}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "result": produced, "id": 1}).to_string())
+            .expect_at_least(1)
+            .create_async()
+            .await,
+    );
+    for slot in MOCK_START_SLOT..=MOCK_TIP {
+        mocks.push(
+            rpc.mock("POST", "/")
+                .match_body(Matcher::PartialJson(
+                    json!({"method": "getBlock", "params": [slot]}),
+                ))
+                .with_status(200)
+                .with_body(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "result": {
+                            "blockhash": "TestBlockHash11111111111111111111111111111",
+                            "parentSlot": slot - 1,
+                            "transactions": []
+                        },
+                        "id": 1
+                    })
+                    .to_string(),
+                )
+                .expect_at_least(1)
+                .create_async()
+                .await,
+        );
+    }
+    mocks
+}
+
+/// Slot a confirmed signature landed in.
+async fn slot_of(client: &RpcClient, signature: &Signature) -> u64 {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(statuses) = client.get_signature_statuses(&[*signature]).await {
+            if let Some(Some(status)) = statuses.value.first() {
+                return status.slot;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out resolving the deposit's slot"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Register a mint, as an AllowMint indexed before the outage would have.
+async fn seed_allowed_mint(pool: &PgPool, mint_address: &str) {
+    sqlx::query(
+        "INSERT INTO mints (mint_address, decimals, token_program, created_at)
+         VALUES ($1, 6, $2, NOW())
+         ON CONFLICT (mint_address) DO NOTHING",
+    )
+    .bind(mint_address)
+    .bind(TOKEN_PROGRAM_ID.to_string())
+    .execute(pool)
+    .await
+    .expect("seed mint");
+}
+
+/// Insert a `mints` row and a deposit for a mint that holds no tokens on-chain. Nothing
+/// backfill can fetch will ever explain this, so it stands in for a genuine divergence.
+async fn seed_phantom_deposit(pool: &PgPool, mint_address: &str, amount: i64) {
+    seed_allowed_mint(pool, mint_address).await;
+
+    sqlx::query(
+        "INSERT INTO transactions
+         (signature, slot, initiator, recipient, mint, amount,
+          transaction_type, status, created_at, updated_at)
+         VALUES ($1, 1, 'phantom', 'phantom', $2, $3,
+                 'deposit'::transaction_type, 'pending'::transaction_status, NOW(), NOW())",
+    )
+    .bind(format!("phantom_sig_{mint_address}"))
+    .bind(mint_address)
+    .bind(amount)
+    .execute(pool)
+    .await
+    .expect("seed deposit");
+}
+
+/// Slot and amount of the single indexed deposit for `mint`, if it has been written yet.
+async fn deposit_row(pool: &PgPool, mint: &str) -> Option<(i64, String)> {
+    sqlx::query_as(
+        "SELECT slot, amount::TEXT FROM transactions
+         WHERE mint = $1 AND transaction_type = 'deposit'",
+    )
+    .bind(mint)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+}
+
+async fn checkpoint_of(pool: &PgPool, program: &str) -> Option<i64> {
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT last_committed_slot FROM indexer_state WHERE program_type = $1")
+            .bind(program)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten();
+    row.map(|(slot,)| slot)
+}
+
+/// The finding, verbatim: a supported deposit finalizes while the indexer is down, so
+/// custody holds tokens the database has never seen. Startup must import the deposit and
+/// only then reconcile, at the strictest threshold, and stay up.
+///
+/// Before the fix this fails in seconds: reconciliation runs first, sees custody it cannot
+/// explain, and `run` returns MismatchExceedsThreshold with no deposit row ever written.
+///
+/// Ignored for the same reason the RPC-polling gap-detection test is: on a test validator
+/// the RPC serves a recent block before its innerInstructions are written, so the escrow
+/// DepositEvent decodes to nothing and the deposit is never imported. The block-listing
+/// side has the mirror-image problem, enumerating slots as produced that getBlock will not
+/// serve, which the fill now treats as fatal. Neither is anything this change introduces.
+/// The mocked sibling below covers the same ordering deterministically, and the Yellowstone
+/// gap-detection test covers deposit recovery against a real validator.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "test-validator serves a recent block before its innerInstructions are \
+            written, so the escrow DepositEvent decodes to nothing"]
+async fn deposit_finalized_while_down_is_backfilled_then_reconciles() {
+    init_tracing();
+    let (validator, faucet) = start_test_validator_no_geyser().await;
+    let client = Arc::new(RpcClient::new_with_commitment(
+        validator.rpc_url(),
+        CommitmentConfig::confirmed(),
+    ));
+    let (_pg, pool, postgres) = start_postgres("startup_backfill_ok").await;
+
+    let env = TestEnvironment::setup(&client, &faucet, 1, USER_BALANCE, None)
+        .await
+        .expect("environment");
+    let user = &env.users[0];
+
+    let ix = deposit_ix(user, env.instance, env.mint, DEPOSIT_AMOUNT);
+    let signature =
+        helpers::send_and_confirm_instructions(&client, &[ix], user, &[user], "Deposit")
+            .await
+            .expect("deposit");
+
+    // The indexer is "down" from here on, and the slice it has to recover starts at the
+    // deposit's own slot. Anchoring on the deposit rather than on a wall-clock reading
+    // keeps the range's first slot a real producer, which is what lets the fill prove
+    // block continuity across it on a validator that skips slots freely.
+    let start_slot = slot_of(&client, &signature).await;
+
+    // The mint was allowed before the outage, so its row predates the missing slice. Only
+    // registered mints contribute to the ledger side of the comparison, and replaying the
+    // AllowMint is a separate concern from the ordering under test.
+    seed_allowed_mint(&pool, &env.mint.to_string()).await;
+
+    let instance_ata =
+        get_associated_token_address_with_program_id(&env.instance, &env.mint, &TOKEN_PROGRAM_ID);
+    wait_for_finalized_custody(&validator.rpc_url(), &instance_ata, DEPOSIT_AMOUNT).await;
+    wait_for_block_servable(&validator.rpc_url(), start_slot).await;
+
+    let channel = MockRpcServer::start().await;
+    let mut handle = spawn_indexer(
+        postgres,
+        validator.rpc_url(),
+        channel.url(),
+        env.instance,
+        start_slot,
+    );
+
+    // Poll for the deposit row, but fail fast and loudly if startup aborts instead.
+    let mint = env.mint.to_string();
+    let deadline = std::time::Instant::now() + Duration::from_secs(STARTUP_TIMEOUT_SECS);
+    let row = loop {
+        if let Some(row) = deposit_row(&pool, &mint).await {
+            break row;
+        }
+        if handle.is_finished() {
+            panic!(
+                "startup exited before importing the deposit: {:?}",
+                (&mut handle).await
+            );
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the deposit was never indexed"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    };
+
+    let (deposit_slot, amount) = row;
+    assert_eq!(
+        amount,
+        DEPOSIT_AMOUNT.to_string(),
+        "the indexed deposit must carry the on-chain amount"
+    );
+
+    // The checkpoint must cover the deposit's slot, which is what makes the import durable.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if checkpoint_of(&pool, "escrow")
+            .await
+            .is_some_and(|cp| cp >= deposit_slot)
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the checkpoint never reached the deposit's slot {deposit_slot}"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+
+    assert!(
+        !handle.is_finished(),
+        "reconciliation must pass at threshold 0 once the deposit is indexed"
+    );
+
+    handle.abort();
+    channel.shutdown().await;
+}
+
+/// The retry loop must narrow the race, never disarm the check. A deposit row that no
+/// on-chain balance backs cannot be explained by any amount of backfilling, so startup
+/// still has to stop, and it has to stop only after backfill has actually run.
+///
+/// Fully mocked on purpose. What is under test is the ordering and the halt, neither of
+/// which needs a real chain, and a scripted tip keeps the fill range exact so the
+/// checkpoint assertion below can name the slot it expects rather than merely "some".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unexplainable_mismatch_still_halts_startup() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_backfill_halt").await;
+
+    let phantom_mint = Pubkey::new_unique().to_string();
+    seed_phantom_deposit(&pool, &phantom_mint, PHANTOM_AMOUNT).await;
+
+    // Blocks the fill will walk, all empty: the phantom row is the only ledger content.
+    let mut rpc = MockitoServer::new_async().await;
+    let _range = mock_fill_range(&mut rpc).await;
+    // Escrow custody holds nothing, so nothing backs the phantom row.
+    let _custody = mock_escrow_custody(&mut rpc, &[]).await;
+
+    // Only the supply invariant reads this, and the custody comparison fails first.
+    let chain = MockRpcServer::start().await;
+
+    let handle = spawn_indexer(
+        postgres,
+        rpc.url(),
+        chain.url(),
+        Pubkey::new_unique(),
+        MOCK_START_SLOT,
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(STARTUP_TIMEOUT_SECS), handle)
+        .await
+        .expect("startup must terminate rather than serve an unexplained mismatch")
+        .expect("run task must not panic");
+
+    match result {
+        Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+            threshold,
+            ..
+        })) => assert_eq!(
+            threshold, 0,
+            "the strict threshold must be the one enforced"
+        ),
+        other => panic!("expected a mismatch halt, got {other:?}"),
+    }
+
+    assert_eq!(
+        checkpoint_of(&pool, "escrow").await,
+        Some(MOCK_TIP as i64),
+        "the fill must have run and committed through its target before the halt, \
+         otherwise the halt is still happening against an unrepaired ledger"
+    );
+
+    chain.shutdown().await;
+}
+
+/// The success path, deterministically: a ledger that matches custody must reconcile clean
+/// at the strictest threshold and leave startup running.
+///
+/// This is the counterpart to the halt test rather than a second ordering proof. The halt
+/// test is what pins the ordering, because before the fix reconciliation aborted the boot
+/// with no checkpoint written at all. What this one adds is the other exit from the retry
+/// loop: a passing reconcile has to break out of it and let startup carry on, rather than
+/// spend all three attempts or stall.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn matching_ledger_reconciles_after_the_fill_and_startup_continues() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_backfill_match").await;
+
+    // A deposit already indexed, and custody holding exactly it.
+    let mint = Pubkey::new_unique().to_string();
+    seed_phantom_deposit(&pool, &mint, PHANTOM_AMOUNT).await;
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _range = mock_fill_range(&mut rpc).await;
+    let _custody = mock_escrow_custody(&mut rpc, &[(mint.clone(), PHANTOM_AMOUNT)]).await;
+
+    let chain = MockRpcServer::start().await;
+    let mut handle = spawn_indexer(
+        postgres,
+        rpc.url(),
+        chain.url(),
+        Pubkey::new_unique(),
+        MOCK_START_SLOT,
+    );
+
+    // The fill has to commit through its target before reconciliation is even attempted.
+    let deadline = std::time::Instant::now() + Duration::from_secs(STARTUP_TIMEOUT_SECS);
+    loop {
+        if checkpoint_of(&pool, "escrow").await == Some(MOCK_TIP as i64) {
+            break;
+        }
+        if handle.is_finished() {
+            panic!(
+                "startup exited instead of reconciling a matching ledger: {:?}",
+                (&mut handle).await
+            );
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the fill never committed through its target"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Past the fill, reconciliation must pass and startup must carry on into the datasource.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(
+        !handle.is_finished(),
+        "a ledger that matches custody must not stop startup at threshold 0"
+    );
+
+    handle.abort();
+    chain.shutdown().await;
+}

--- a/integration/tests/indexer/startup_backfill_reconcile.rs
+++ b/integration/tests/indexer/startup_backfill_reconcile.rs
@@ -19,7 +19,9 @@ mod helpers;
 mod setup;
 
 use mockito::{Matcher, Server as MockitoServer};
-use private_channel_escrow_program_client::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
+// The indexer decides what counts as an escrow instruction by this constant, so a
+// synthetic block has to carry the same id or the fill sees nothing to import.
+use private_channel_indexer::indexer::datasource::common::parser::escrow::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
 use private_channel_indexer::{
     config::{BackfillConfig, ReconciliationConfig, RpcPollingConfig},
     error::{IndexerError, ReconciliationError},
@@ -46,7 +48,7 @@ use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token::ID as TOKEN_PROGRAM_ID;
 use sqlx::PgPool;
 use std::{sync::Arc, time::Duration};
-use test_utils::mock_rpc::MockRpcServer;
+use test_utils::mock_rpc::{MockRpcServer, Reply};
 use test_utils::validator_helper::start_test_validator_no_geyser;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
@@ -124,7 +126,11 @@ fn deposit_ix(user: &Keypair, instance: Pubkey, mint: Pubkey, amount: u64) -> In
         .token_program(TOKEN_PROGRAM_ID)
         .associated_token_program(spl_associated_token_account::ID)
         .event_authority(event_authority_pda)
-        .private_channel_escrow_program(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID)
+        .private_channel_escrow_program(
+            PRIVATE_CHANNEL_ESCROW_PROGRAM_ID
+                .parse()
+                .expect("the parser's escrow program id must be a valid pubkey"),
+        )
         .amount(amount)
         .instruction()
 }
@@ -148,14 +154,25 @@ async fn wait_for_finalized_custody(rpc_url: &str, ata: &Pubkey, expected: u64) 
     }
 }
 
+/// Answer the startup supply invariant with "no channel mint exists yet".
+///
+/// An absent mint account reads as zero supply, which can never exceed custody, so the
+/// invariant passes for every mint and these tests keep testing the custody comparison.
+/// An unanswered read is no longer harmless: startup refuses to boot on a supply it could
+/// not check. Answering absence rather than a fabricated mint keeps any other reader on
+/// this RPC seeing the truth, and the queue is stocked well past what a run consumes.
+fn mock_empty_channel_supply(rpc: &MockRpcServer) {
+    let reply = Reply::result(json!({"context": {"slot": 1}, "value": null}));
+    rpc.enqueue_sequence("getAccountInfo", std::iter::repeat_n(reply, 4096));
+}
+
 /// Spawn `run` on the ordinary recovery configuration and hand back its result.
 ///
 /// `mismatch_threshold_raw` is deliberately 0, the shipped default, because the whole
 /// finding is that this configuration cannot boot. `start_slot` is the bottom of the slice
 /// the indexer missed, so the fill has exactly that slice to recover. The channel RPC is
-/// an unscripted mock: it answers every method with an error, which makes the supply
-/// invariant skip each mint with a warning and leaves the custody comparison as the only
-/// thing that can fail the boot.
+/// scripted with an empty supply, which satisfies the supply invariant without ever
+/// tripping it and leaves the custody comparison as the only thing that can fail the boot.
 fn spawn_indexer(
     postgres: PostgresConfig,
     rpc_url: String,
@@ -532,6 +549,7 @@ async fn deposit_finalized_while_down_is_backfilled_then_reconciles() {
     wait_for_block_servable(&validator.rpc_url(), start_slot).await;
 
     let channel = MockRpcServer::start().await;
+    mock_empty_channel_supply(&channel);
     let mut handle = spawn_indexer(
         postgres,
         validator.rpc_url(),
@@ -616,6 +634,7 @@ async fn unexplainable_mismatch_still_halts_startup() {
     // Only the supply invariant reads this, and it errors on every method, so each mint
     // is skipped with a warning and the custody comparison is what fails the boot.
     let chain = MockRpcServer::start().await;
+    mock_empty_channel_supply(&chain);
 
     let handle = spawn_indexer(
         postgres,
@@ -684,6 +703,7 @@ async fn the_fill_imports_the_deposit_that_explains_custody() {
         mock_escrow_custody(&mut rpc, &[(mint.to_string(), DEPOSIT_AMOUNT as i64)]).await;
 
     let chain = MockRpcServer::start().await;
+    mock_empty_channel_supply(&chain);
     let mut handle = spawn_indexer(postgres, rpc.url(), chain.url(), instance, MOCK_START_SLOT);
 
     let deadline = std::time::Instant::now() + Duration::from_secs(STARTUP_TIMEOUT_SECS);
@@ -756,6 +776,7 @@ async fn custody_read_from_behind_the_ledger_stops_startup() {
     let _custody = mock_escrow_custody_at(&mut rpc, &[], 890).await;
 
     let chain = MockRpcServer::start().await;
+    mock_empty_channel_supply(&chain);
     let handle = spawn_indexer(
         postgres,
         rpc.url(),
@@ -849,6 +870,7 @@ async fn the_live_source_resumes_where_the_fill_stopped() {
     let _custody = mock_escrow_custody_at(&mut rpc, &[], custody_slot).await;
 
     let chain = MockRpcServer::start().await;
+    mock_empty_channel_supply(&chain);
     let mut handle = spawn_indexer(postgres, rpc.url(), chain.url(), instance, MOCK_START_SLOT);
 
     // The fill stops at the measured slot, not the tip.
@@ -917,6 +939,7 @@ async fn matching_ledger_reconciles_after_the_fill_and_startup_continues() {
     let _custody = mock_escrow_custody(&mut rpc, &[(mint.clone(), PHANTOM_AMOUNT)]).await;
 
     let chain = MockRpcServer::start().await;
+    mock_empty_channel_supply(&chain);
     let mut handle = spawn_indexer(
         postgres,
         rpc.url(),

--- a/integration/tests/indexer/startup_backfill_reconcile.rs
+++ b/integration/tests/indexer/startup_backfill_reconcile.rs
@@ -243,6 +243,16 @@ async fn wait_for_block_servable(rpc_url: &str, slot: u64) {
 /// Answers every attempt's two token programs, so it is left uncounted rather than pinned
 /// to an exact hit count.
 async fn mock_escrow_custody(rpc: &mut MockitoServer, holdings: &[(String, i64)]) -> mockito::Mock {
+    mock_escrow_custody_at(rpc, holdings, MOCK_TIP).await
+}
+
+/// Same, with the slot the reading is reported as valid at. Startup fills up to that slot
+/// and no further, so a value below the tip is what leaves a band for the live source.
+async fn mock_escrow_custody_at(
+    rpc: &mut MockitoServer,
+    holdings: &[(String, i64)],
+    context_slot: u64,
+) -> mockito::Mock {
     let accounts: Vec<serde_json::Value> = holdings
         .iter()
         .map(|(mint, amount)| {
@@ -278,7 +288,7 @@ async fn mock_escrow_custody(rpc: &mut MockitoServer, holdings: &[(String, i64)]
         .with_body(
             json!({
                 "jsonrpc": "2.0",
-                "result": {"context": {"slot": MOCK_TIP}, "value": accounts},
+                "result": {"context": {"slot": context_slot}, "value": accounts},
                 "id": 1
             })
             .to_string(),
@@ -713,6 +723,173 @@ async fn the_fill_imports_the_deposit_that_explains_custody() {
         !handle.is_finished(),
         "custody explained by the imported deposit must not stop startup at threshold 0"
     );
+
+    handle.abort();
+    chain.shutdown().await;
+}
+
+/// Custody read from behind our own ledger must stop the boot, not produce a verdict.
+///
+/// The checkpoint says slots up to 899 are indexed while the custody read only speaks for
+/// slot 890. There is no slot at which the two can be compared: the ledger cannot be
+/// rewound and custody cannot be rolled forward. Comparing anyway would judge nine slots of
+/// indexed deposits against a custody view that predates them, which reads as an unbacked
+/// ledger and would look exactly like insolvency. Startup retries the read first, since a
+/// lagging node usually catches up, and fails closed when it does not.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custody_read_from_behind_the_ledger_stops_startup() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_backfill_behind").await;
+
+    // A ledger that has already committed past where custody can speak for.
+    sqlx::query(
+        "INSERT INTO indexer_state (program_type, last_committed_slot, updated_at)
+         VALUES ('escrow', 899, NOW())
+         ON CONFLICT (program_type) DO UPDATE SET last_committed_slot = 899",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed checkpoint");
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _range = mock_fill_range(&mut rpc).await;
+    let _custody = mock_escrow_custody_at(&mut rpc, &[], 890).await;
+
+    let chain = MockRpcServer::start().await;
+    let handle = spawn_indexer(
+        postgres,
+        rpc.url(),
+        chain.url(),
+        Pubkey::new_unique(),
+        MOCK_START_SLOT,
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(STARTUP_TIMEOUT_SECS), handle)
+        .await
+        .expect("startup must terminate rather than compare across a gap it cannot close")
+        .expect("run task must not panic");
+
+    match result {
+        Err(IndexerError::Reconciliation(ReconciliationError::CustodyBehindLedger {
+            snapshot_slot,
+            committed,
+        })) => {
+            assert_eq!(snapshot_slot, 890);
+            assert_eq!(committed, 899);
+        }
+        other => panic!("expected a fail-closed custody-behind-ledger halt, got {other:?}"),
+    }
+
+    chain.shutdown().await;
+}
+
+/// The fill stops where custody was measured, so the live source must resume from there
+/// and not from the chain tip.
+///
+/// Custody is read at a slot below the tip, which leaves a band of slots that the fill
+/// deliberately does not cover. Nothing else will ever read them: startup is finished with
+/// the range and the live source only walks forward from wherever it is told to start. A
+/// deposit is planted inside that band, so if the resume slot were taken from the resolved
+/// range, one past the tip, the deposit would be skipped and never indexed by anything.
+/// The row appearing is the proof that the two producers still meet with no hole.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_live_source_resumes_where_the_fill_stopped() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_backfill_resume").await;
+
+    let instance = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    // Custody is measured here; the fill covers up to it and stops.
+    let custody_slot = MOCK_TIP - 3;
+    // Above the fill's reach, so only the live source can bring it in.
+    let deposit_slot = MOCK_TIP - 1;
+    assert!(
+        deposit_slot > custody_slot,
+        "the deposit must sit in the band the fill skips"
+    );
+    seed_allowed_mint(&pool, &mint.to_string()).await;
+
+    let mut rpc = MockitoServer::new_async().await;
+    // The fill enumerates only up to the measured slot, so that shorter range needs its own
+    // listing; the tip-length one the other tests use would never be requested here.
+    let capped: Vec<u64> = (MOCK_START_SLOT..=custody_slot).collect();
+    let _capped_range = rpc
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlocks", "params": [MOCK_START_SLOT, custody_slot]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": capped, "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    // The live source enumerates its own batch before fetching it, starting one past the
+    // fill target and running to the tip: exactly the band under test.
+    let live: Vec<u64> = (custody_slot + 1..MOCK_TIP).collect();
+    let _live_range = rpc
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlocks", "params": [custody_slot + 1, MOCK_TIP - 1]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": live, "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let _range = mock_fill_range_carrying(
+        &mut rpc,
+        Some((
+            deposit_slot,
+            deposit_block_json(deposit_slot, instance, mint, DEPOSIT_AMOUNT),
+        )),
+    )
+    .await;
+    // Empty at the measured slot: the deposit has not happened yet as of then, so startup
+    // reconciles clean and the deposit is purely the live source's to find.
+    let _custody = mock_escrow_custody_at(&mut rpc, &[], custody_slot).await;
+
+    let chain = MockRpcServer::start().await;
+    let mut handle = spawn_indexer(postgres, rpc.url(), chain.url(), instance, MOCK_START_SLOT);
+
+    // The fill stops at the measured slot, not the tip.
+    let deadline = std::time::Instant::now() + Duration::from_secs(STARTUP_TIMEOUT_SECS);
+    loop {
+        if checkpoint_of(&pool, "escrow").await == Some(custody_slot as i64) {
+            break;
+        }
+        if handle.is_finished() {
+            panic!(
+                "startup exited instead of filling to the measured slot: {:?}",
+                (&mut handle).await
+            );
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the fill never committed through the slot custody was measured at"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Now the live source has to cover the band the fill left behind.
+    let deadline = std::time::Instant::now() + Duration::from_secs(STARTUP_TIMEOUT_SECS);
+    loop {
+        if let Some((slot, amount)) = deposit_row(&pool, &mint.to_string()).await {
+            assert_eq!(slot, deposit_slot as i64);
+            assert_eq!(amount, DEPOSIT_AMOUNT.to_string());
+            break;
+        }
+        if handle.is_finished() {
+            panic!(
+                "startup exited before the live source read the band: {:?}",
+                (&mut handle).await
+            );
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the deposit above the fill target was never indexed, so the resume slot skipped it"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 
     handle.abort();
     chain.shutdown().await;

--- a/integration/tests/indexer/startup_backfill_reconcile.rs
+++ b/integration/tests/indexer/startup_backfill_reconcile.rs
@@ -25,6 +25,7 @@ use private_channel_indexer::{
     error::{IndexerError, ReconciliationError},
     indexer::run,
     storage::{PostgresDb, Storage},
+    test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes},
     DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig, ProgramType,
     StorageType,
 };
@@ -287,8 +288,65 @@ async fn mock_escrow_custody(rpc: &mut MockitoServer, holdings: &[(String, i64)]
         .await
 }
 
+/// A block whose one transaction is a top-level escrow Deposit, shaped the way the fill's
+/// decoder reads it: the instruction supplies the accounts, and the DepositEvent self-CPI
+/// that the program emits underneath it supplies the amount.
+///
+/// Account order is the Deposit instruction's own, so index 2 is the instance the indexer
+/// filters on and index 3 is the mint the row is recorded against.
+fn deposit_block_json(slot: u64, instance: Pubkey, mint: Pubkey, amount: u64) -> serde_json::Value {
+    const ESCROW_PROGRAM_INDEX: u8 = 11;
+
+    let mut account_keys: Vec<String> = (0..12).map(|_| Pubkey::new_unique().to_string()).collect();
+    account_keys[2] = instance.to_string();
+    account_keys[3] = mint.to_string();
+    account_keys[ESCROW_PROGRAM_INDEX as usize] = PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string();
+
+    let ix_data = bs58::encode(deposit_ix_bytes(amount, None)).into_string();
+    let event_data = bs58::encode(deposit_event_bytes(amount)).into_string();
+
+    json!({
+        "blockhash": "TestBlockHash11111111111111111111111111111",
+        "parentSlot": slot - 1,
+        "transactions": [{
+            "transaction": {
+                "signatures": [format!("mocked_deposit_sig_{slot}")],
+                "message": {
+                    "accountKeys": account_keys,
+                    "instructions": [{
+                        "programIdIndex": ESCROW_PROGRAM_INDEX,
+                        "accounts": (0u8..12).collect::<Vec<u8>>(),
+                        "data": ix_data
+                    }]
+                }
+            },
+            "meta": {
+                "err": null,
+                "innerInstructions": [{
+                    "index": 0,
+                    "instructions": [{
+                        "programIdIndex": ESCROW_PROGRAM_INDEX,
+                        "accounts": Vec::<u8>::new(),
+                        "data": event_data,
+                        "stackHeight": 2
+                    }]
+                }]
+            }
+        }]
+    })
+}
+
 /// Mock the block enumeration and every block in the fill range, all empty.
 async fn mock_fill_range(rpc: &mut MockitoServer) -> Vec<mockito::Mock> {
+    mock_fill_range_carrying(rpc, None).await
+}
+
+/// Same, except one slot's block is replaced by `carrying`, so the fill has something to
+/// import rather than walking an empty range.
+async fn mock_fill_range_carrying(
+    rpc: &mut MockitoServer,
+    carrying: Option<(u64, serde_json::Value)>,
+) -> Vec<mockito::Mock> {
     let mut mocks = Vec::new();
     mocks.push(
         rpc.mock("POST", "/")
@@ -312,24 +370,21 @@ async fn mock_fill_range(rpc: &mut MockitoServer) -> Vec<mockito::Mock> {
             .await,
     );
     for slot in MOCK_START_SLOT..=MOCK_TIP {
+        let block = match &carrying {
+            Some((carried_slot, block)) if *carried_slot == slot => block.clone(),
+            _ => json!({
+                "blockhash": "TestBlockHash11111111111111111111111111111",
+                "parentSlot": slot - 1,
+                "transactions": []
+            }),
+        };
         mocks.push(
             rpc.mock("POST", "/")
                 .match_body(Matcher::PartialJson(
                     json!({"method": "getBlock", "params": [slot]}),
                 ))
                 .with_status(200)
-                .with_body(
-                    json!({
-                        "jsonrpc": "2.0",
-                        "result": {
-                            "blockhash": "TestBlockHash11111111111111111111111111111",
-                            "parentSlot": slot - 1,
-                            "transactions": []
-                        },
-                        "id": 1
-                    })
-                    .to_string(),
-                )
+                .with_body(json!({"jsonrpc": "2.0", "result": block, "id": 1}).to_string())
                 .expect_at_least(1)
                 .create_async()
                 .await,
@@ -583,6 +638,83 @@ async fn unexplainable_mismatch_still_halts_startup() {
          otherwise the halt is still happening against an unrepaired ledger"
     );
 
+    chain.shutdown().await;
+}
+
+/// The claim the whole change rests on, deterministically: the fill imports the deposit
+/// that explains custody, and only then does reconciliation run and pass.
+///
+/// The database starts with no deposit at all while custody already holds one, which is
+/// the finding's own starting state. Nothing here is seeded to make the sums agree: the
+/// row has to arrive from the mocked block the fill walks, and the checkpoint has to reach
+/// the fill target before the comparison happens. Before the fix this configuration cannot
+/// boot, because reconciliation runs first and aborts on custody it cannot account for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fill_imports_the_deposit_that_explains_custody() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_backfill_import").await;
+
+    let instance = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let deposit_slot = MOCK_START_SLOT + 2;
+    seed_allowed_mint(&pool, &mint.to_string()).await;
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _range = mock_fill_range_carrying(
+        &mut rpc,
+        Some((
+            deposit_slot,
+            deposit_block_json(deposit_slot, instance, mint, DEPOSIT_AMOUNT),
+        )),
+    )
+    .await;
+    // Custody holds exactly the deposit the block carries, so the two agree only once
+    // that block has been imported.
+    let _custody =
+        mock_escrow_custody(&mut rpc, &[(mint.to_string(), DEPOSIT_AMOUNT as i64)]).await;
+
+    let chain = MockRpcServer::start().await;
+    let mut handle = spawn_indexer(postgres, rpc.url(), chain.url(), instance, MOCK_START_SLOT);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(STARTUP_TIMEOUT_SECS);
+    loop {
+        if checkpoint_of(&pool, "escrow").await == Some(MOCK_TIP as i64) {
+            break;
+        }
+        if handle.is_finished() {
+            panic!(
+                "startup exited instead of importing the deposit and reconciling: {:?}",
+                (&mut handle).await
+            );
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the fill never committed through its target"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let (slot, amount) = deposit_row(&pool, &mint.to_string())
+        .await
+        .expect("the fill must have written the deposit the block carried");
+    assert_eq!(
+        slot, deposit_slot as i64,
+        "the deposit's own slot is recorded"
+    );
+    assert_eq!(
+        amount,
+        DEPOSIT_AMOUNT.to_string(),
+        "the amount must come from the deposit's own event"
+    );
+
+    // With the row imported the sums agree, so reconciliation passes and startup carries on.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(
+        !handle.is_finished(),
+        "custody explained by the imported deposit must not stop startup at threshold 0"
+    );
+
+    handle.abort();
     chain.shutdown().await;
 }
 

--- a/integration/tests/indexer/startup_backfill_reconcile.rs
+++ b/integration/tests/indexer/startup_backfill_reconcile.rs
@@ -548,7 +548,8 @@ async fn unexplainable_mismatch_still_halts_startup() {
     // Escrow custody holds nothing, so nothing backs the phantom row.
     let _custody = mock_escrow_custody(&mut rpc, &[]).await;
 
-    // Only the supply invariant reads this, and the custody comparison fails first.
+    // Only the supply invariant reads this, and it errors on every method, so each mint
+    // is skipped with a warning and the custody comparison is what fails the boot.
     let chain = MockRpcServer::start().await;
 
     let handle = spawn_indexer(

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -357,3 +357,134 @@ async fn stall_watchdog_forces_reconnect_on_silent_stream() {
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
     server.shutdown().await;
 }
+
+/// Startup catch-up that finishes before the stream starts leaves a window between its
+/// target and the first streamed slot. Nothing covers that window: the catch-up is done
+/// and the stream begins above it, so the first streamed slot would carry the checkpoint
+/// straight over it. With first-connection arming the source replays it instead.
+///
+/// Without the flag the source treats connection one as a cold start, emits no Regate,
+/// and slots 102 to 109 are lost while the checkpoint jumps to 110.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_connection_arms_when_startup_backfill_anchored() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    let mut rpc_mock = MockitoServer::new_async().await;
+
+    // The window the startup fill did not reach: anchor 101, first streamed slot 110.
+    let _enumeration = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlocks", "params": [101, 110]}),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "jsonrpc": "2.0",
+                "result": [101, 102, 103, 104, 105, 106, 107, 108, 109, 110],
+                "id": 1
+            })
+            .to_string(),
+        )
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let mut block_mocks = Vec::new();
+    for slot in 101u64..=110u64 {
+        let m = rpc_mock
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "getBlock", "params": [slot]}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "result": empty_block_json(), "id": 1}).to_string())
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        block_mocks.push(m);
+    }
+
+    let server = MockYellowstoneServer::start().await;
+
+    let rpc_poller = Arc::new(RpcPoller::new(
+        rpc_mock.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ));
+
+    // The checkpoint a completed startup fill would have committed.
+    let mock_storage = MockStorage::new();
+    mock_storage.set_checkpoint("escrow", 101);
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(mock_storage));
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(rpc_poller, 1_000, 16)
+    .with_storage(storage)
+    .with_first_connection_arming();
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // One connection only, no drop: the very first streamed slot must trigger the repair.
+    server.enqueue(UpdateMatcher, Update::ok(empty_block(110)));
+
+    let mut regate: Option<(u64, u64)> = None;
+    let mut seen: HashSet<u64> = HashSet::new();
+    let wanted: HashSet<u64> = (102u64..=110u64).collect();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while regate.is_none() || !wanted.is_subset(&seen) {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            panic!(
+                "timed out; regate: {:?}, seen: {:?}, missing: {:?}",
+                regate,
+                seen,
+                wanted.difference(&seen).collect::<Vec<_>>()
+            );
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) => {
+                seen.insert(slot);
+            }
+            Ok(Some(ProcessorMessage::Regate { from, target, .. })) => {
+                regate = Some((from, target));
+            }
+            Ok(Some(_)) => {}
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        regate,
+        Some((101, 110)),
+        "the gate must be armed from the durable anchor up to the first streamed slot"
+    );
+    assert!(
+        wanted.is_subset(&seen),
+        "every slot in the uncovered window must be replayed; seen: {seen:?}"
+    );
+    assert_eq!(
+        server.call_count("subscribe"),
+        1,
+        "the repair must happen on the first connection, without a reconnect"
+    );
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    server.shutdown().await;
+}


### PR DESCRIPTION
## PR description

Startup reconciliation compares on-chain escrow custody against the indexed ledger, and it ran
before backfill. On the ordinary recovery configuration (`backfill.enabled = true`,
`exit_after_backfill = false`) that compares current custody against a database that is provably
stale: the backfill whose entire purpose is to repair it has not run yet. A supported SPL deposit
finalizing during routine downtime credits the escrow ATA immediately, so on restart the sweep sees
tokens the database has never seen, and at the shipped `mismatch_threshold_raw = 0` any difference
aborts the boot. The error propagates out of `run` before backfill is reached, so every restart
compares the same stale database and fails again, leaving the deposit in escrow with no
private-channel mint and the indexer unable to resume without an operator changing settings.

The fill now runs first and reconciliation waits for it. The checkpoint writer and transaction
processor start before the fill, since the fill blocks on a full instruction channel and nothing
else drains it; the fill's gate is armed in-band with a `Regate` so it also covers a second attempt.
"The fill is done" means its durable checkpoint reached the fill target, which the gate only permits
once every slot below it has been written, so the ledger is verifiably caught up rather than
probably. A residual race remains because the chain keeps moving, so the resolve-fill-wait-reconcile
cycle retries up to three times; the final attempt still returns the original error, so a mismatch
backfilling cannot explain still stops startup. A fill failure is now fatal rather than logged and
ignored. Serialising the fill ahead of the stream opens a window between the fill target and the
first streamed slot that neither covers, so the Yellowstone source gains an opt-in flag to repair it
on its first connection using the existing reconnect machinery.

Scope is the reordering only. `backfill.enabled = false` is unchanged and remains the operator's
responsibility, and `exit_after_backfill` is untouched. Four unit tests cover the checkpoint wait
and three integration tests cover the halt boundary, the success path and the Yellowstone window.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 15,588 | 17,237 | 90.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32854701852) |
| Indexer | 37,597 | 41,271 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32854701852) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32854701852) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32854701852) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,879 | 19,182 | 77.6% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32854701852) |
| **Total** | **71,010** | **81,088** | **87.6%** | |

> Last updated: 2026-08-25 14:37:31 UTC by E2E Integration