### PR TITLE
ci: Publish the app image to GHCR on merge to main

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,90 @@
+name: Publish Image
+
+# Build the app image on every merge to main (and on release tags) and push it
+# to GHCR tagged with the commit sha, so deploys pin a real, traceable artifact
+# instead of a locally-built one. The repo is public, so GHCR storage/bandwidth
+# is free; the prune job below just keeps the registry tidy.
+#
+# To deploy a published image: set image_registry: ghcr.io/solana-foundation and
+# image_tag: sha-<short> (or a release tag) in the stack's vars, and leave the
+# GHCR pull path on. No local build needed.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build + push app image
+    runs-on: private-channel-runner-1
+    steps:
+      - uses: actions/checkout@v4
+
+      # versions.env pins the build-arg tool versions the Dockerfile expects.
+      - name: Load pinned tool versions
+        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # sha tag on every build; :latest only on main; v<semver> on release tags.
+      - name: Image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/private-channel-app
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern=v{{version}}
+
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            SOLANA_VERSION=${{ env.SOLANA_VERSION }}
+            PNPM_VERSION=${{ env.PNPM_VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Nothing expires in GHCR on its own. Free on a public repo, but prune the
+  # dangling untagged manifests (from overwritten :latest, etc.) so they don't
+  # accumulate. Keeps the 50 most recent versions regardless. Best-effort.
+  prune:
+    name: Prune untagged versions
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete untagged image versions
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: private-channel-app
+          package-type: container
+          min-versions-to-keep: 50
+          delete-only-untagged-versions: true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -33,6 +33,13 @@ jobs:
     timeout-minutes: 90
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/private-channel-app
+    # Expose the pushed manifest digest so dependent jobs (and operators pinning a
+    # deploy) can reference the exact bytes that were scanned and signed, rather
+    # than a mutable tag.
+    outputs:
+      image: ghcr.io/${{ github.repository_owner }}/private-channel-app
+      digest: ${{ steps.push.outputs.digest }}
+      tags: ${{ steps.tags.outputs.tags }}
     steps:
       # Actions are pinned to commit SHAs (supply-chain hardening); the trailing
       # comment is the human-readable version. Reused from the vetted pins in
@@ -123,3 +130,28 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      # Surface the immutable digest in the run summary so a deploy can pin
+      # image_registry/private-channel-app@<digest> (what cosign verified and
+      # signed) instead of trusting a mutable tag at pull time.
+      - name: Record published digest
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Published image"
+            echo
+            echo "Pin the deploy to this digest (verified + signed):"
+            echo
+            echo '```'
+            echo "${IMAGE}@${DIGEST}"
+            echo '```'
+            echo
+            echo "Tags pointing at it:"
+            echo
+            echo '```'
+            echo "${TAGS}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,23 +1,26 @@
 name: Publish Image
 
-# Build the app image on every merge to main (and on release tags) and push it
-# to GHCR tagged with the commit sha, so deploys pin a real, traceable artifact
-# instead of a locally-built one. The repo is public, so GHCR storage/bandwidth
-# is free; the prune job below just keeps the registry tidy.
+# Build the app image on every merge to main (and release tags), scan it, push it
+# to GHCR tagged with the commit sha, and sign it keyless with cosign, so deploys
+# can pin a real, traceable, signed artifact instead of a locally-built one.
+#
+# Auth is entirely GitHub-native: the ephemeral GITHUB_TOKEN pushes to GHCR
+# (packages: write), and id-token: write lets cosign sign via OIDC (no stored
+# keys or PATs). Repo is public, so GHCR storage/bandwidth is free.
 #
 # To deploy a published image: set image_registry: ghcr.io/solana-foundation and
-# image_tag: sha-<short> (or a release tag) in the stack's vars, and leave the
-# GHCR pull path on. No local build needed.
+# image_tag: sha-<short> (or a release tag) in the stack's vars. No local build.
 
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+    tags: ["v*.*.*"]
   workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
+  id-token: write # cosign keyless signing via OIDC
 
 concurrency:
   group: publish-image-${{ github.ref }}
@@ -25,66 +28,98 @@ concurrency:
 
 jobs:
   publish:
-    name: Build + push app image
-    runs-on: private-channel-runner-1
+    name: Build, scan, push, sign app image
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/private-channel-app
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to commit SHAs (supply-chain hardening); the trailing
+      # comment is the human-readable version. Reused from the vetted pins in
+      # solana-developer-platform/.github/workflows/release-images.yml.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
 
       # versions.env pins the build-arg tool versions the Dockerfile expects.
       - name: Load pinned tool versions
         run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
 
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          short="${GITHUB_SHA::7}"
+          tags="${IMAGE}:sha-${short}"
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            tags="${tags}"$'\n'"${IMAGE}:latest"
+          fi
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            tags="${tags}"$'\n'"${IMAGE}:${GITHUB_REF_NAME}"
+          fi
+          echo "scan_tag=${IMAGE}:sha-${short}" >> "$GITHUB_OUTPUT"
+          { echo "tags<<EOF"; echo "${tags}"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # sha tag on every build; :latest only on main; v<semver> on release tags.
-      - name: Image tags
-        id: meta
-        uses: docker/metadata-action@v5
+      # Build locally and scan before anything is pushed.
+      - name: Build (local, for scan)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/private-channel-app
-          tags: |
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern=v{{version}}
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          load: true
+          provenance: false
+          sbom: false
+          build-args: |
+            SOLANA_VERSION=${{ env.SOLANA_VERSION }}
+            PNPM_VERSION=${{ env.PNPM_VERSION }}
+          tags: ${{ steps.tags.outputs.scan_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Build + push
-        uses: docker/build-push-action@v6
+      - name: Scan (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.tags.outputs.scan_tag }}
+          severity: CRITICAL
+          exit-code: "1"
+          ignore-unfixed: true
+
+      # Scan passed: push (layers reused from the cache above).
+      - name: Push
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64
           push: true
+          provenance: false
+          sbom: false
           build-args: |
             SOLANA_VERSION=${{ env.SOLANA_VERSION }}
             PNPM_VERSION=${{ env.PNPM_VERSION }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Nothing expires in GHCR on its own. Free on a public repo, but prune the
-  # dangling untagged manifests (from overwritten :latest, etc.) so they don't
-  # accumulate. Keeps the 50 most recent versions regardless. Best-effort.
-  prune:
-    name: Prune untagged versions
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Delete untagged image versions
-        continue-on-error: true
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: private-channel-app
-          package-type: container
-          min-versions-to-keep: 50
-          delete-only-untagged-versions: true
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image (keyless OIDC)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"


### PR DESCRIPTION
Adds a CI workflow that builds the app image and pushes it to `ghcr.io/solana-foundation/private-channel-app` tagged with the commit sha (plus `latest` on main and `v<semver>` on release tags). Deploys can then pin a real, traceable, CI-built artifact instead of a locally-built one.

This is the "deploy from something real" direction, replacing the `skip_pull` local-build approach in #222 (closing that). It is unblocked now that #221 committed the 9tgHa1 escrow program id to main, so an image built from main is correct for the deployed stacks.

Notes:
- Repo is public, so GHCR storage + bandwidth are free. Nothing expires on its own, so a best-effort prune job trims dangling untagged manifests while keeping the 50 most recent versions.
- Build-args (SOLANA_VERSION, PNPM_VERSION) come from versions.env, same as the manual build in the deploy README.
- Runs on the self-hosted private-channel-runner-1 (matches the other workflows); flip to ubuntu-latest if that runner lacks Docker/buildx.
- Deploy side is unchanged: a stack pulls a published image by setting image_registry + image_tag in its vars. Follow-ups: point the devnet/sdp stacks at pinned tags, and redo the audit/sdp inventory + per-stack <env>-secrets.yml loading correctly (the still-needed, non-skip_pull parts of #222, per huzaifa).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...