### PR TITLE
feat(deploy): Opt-in cosign verification of the app image

### DIFF
--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -80,6 +80,10 @@ The deploy pulls images from GHCR. Build + push them once from the control node,
 
 GHCR docs: [ref](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 
+### Verifying image signatures
+
+Images published by [`.github/workflows/publish-image.yml`](../.github/workflows/publish-image.yml) are signed keyless with cosign (OIDC, no stored keys). Set `verify_image_signature: true` in a stack's vars to make preflight refuse an app image that wasn't built and signed by that workflow: cosign resolves the tag to its digest and checks the signature's Fulcio identity + Rekor entry, so a tampered, unsigned, or foreign image aborts the deploy before any pull. Requires `cosign` on the control node (`brew install cosign`). Override the expected signer via `image_signer_identity` (a cosign `--certificate-identity-regexp`); the default matches this repo's workflow on main or a release tag.
+
 ## Operating
 
 Cluster-agnostic by design, the commands don't change between localnet, devnet/mainnet. The deploy target is set once in [`vars/dev.yml`](./vars/dev.yml) (`network` + `rpc_url`); the playbook auto-selects the matching compose file ([`docker-compose.yml`](../docker-compose.yml) for localnet, [`docker-compose.devnet.yml`](../docker-compose.devnet.yml) for devnet/mainnet) and renders a per-env `.env` from `vars/dev.yml` + `secrets.yml`.

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -333,6 +333,15 @@
             Verified {{ image_registry }}/private-channel-app:{{ image_tag }}
             @ {{ (_cosign_verify.stdout | from_json)[0].critical.image['docker-manifest-digest'] }}
 
+    # Pin the render + deploy to the exact digest cosign just verified, so the
+    # phase-4 pull can't fetch a tag that moved between verify and pull. Set on
+    # the target host (not delegated) so the render task can read it.
+    - name: Record the verified image digest for digest-pinned deploy
+      when: verify_image_signature | default(false) | bool
+      ansible.builtin.set_fact:
+        pc_app_image_digest: "{{ (_cosign_verify.stdout | from_json)[0].critical.image['docker-manifest-digest'] }}"
+      tags: [ preflight, deploy ]
+
     - name: Assert network is set
       ansible.builtin.assert:
         that: network | default('') | length > 0

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -290,14 +290,17 @@
     # deploy an app image that wasn't built + signed by our publish workflow
     # (.github/workflows/publish-image.yml). cosign resolves the tag to its
     # digest and checks the keyless signature (Fulcio cert identity + Rekor), so
-    # a tampered, unsigned, or foreign image fails preflight before any pull.
+    # a tampered, unsigned, or foreign image fails before any pull.
     # Off by default; set `verify_image_signature: true` on stacks that pull the
     # signed org image from GHCR.
+    # Tagged `deploy` as well as `preflight` so the gate still runs when an
+    # operator invokes the deploy phase standalone (`--tags deploy`); otherwise
+    # the phase-4 pull below would fetch the mutable tag unverified.
     - name: Verify app image signature (cosign)
       when: verify_image_signature | default(false) | bool
       delegate_to: localhost
       run_once: true
-      tags: [ preflight ]
+      tags: [ preflight, deploy ]
       block:
       - name: Probe cosign on the control node
         ansible.builtin.command: cosign version

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -286,6 +286,50 @@
           `image_tag` empty in vars/<env>.yml. Deploy phase uses it as the docker image tag.
           Fix: set `image_tag: <tag>` in vars/dev.yml, or pass `-e image_tag=<tag>` on the CLI.
 
+    # Opt-in supply-chain gate. When verify_image_signature is set, refuse to
+    # deploy an app image that wasn't built + signed by our publish workflow
+    # (.github/workflows/publish-image.yml). cosign resolves the tag to its
+    # digest and checks the keyless signature (Fulcio cert identity + Rekor), so
+    # a tampered, unsigned, or foreign image fails preflight before any pull.
+    # Off by default; set `verify_image_signature: true` on stacks that pull the
+    # signed org image from GHCR.
+    - name: Verify app image signature (cosign)
+      when: verify_image_signature | default(false) | bool
+      delegate_to: localhost
+      run_once: true
+      tags: [ preflight ]
+      block:
+      - name: Probe cosign on the control node
+        ansible.builtin.command: cosign version
+        changed_when: false
+        failed_when: false
+        register: _cosign_probe
+
+      - name: Assert cosign is installed
+        ansible.builtin.assert:
+          that: _cosign_probe.rc == 0
+          fail_msg: |
+            `verify_image_signature` is set but cosign isn't on the control node.
+            Install: brew install cosign  (or https://docs.sigstore.dev/cosign/system_config/installation)
+
+      - name: cosign verify the app image
+        ansible.builtin.command:
+          argv:
+            - cosign
+            - verify
+            - --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+            - "--certificate-identity-regexp={{ image_signer_identity }}"
+            - --output=json
+            - "{{ image_registry }}/private-channel-app:{{ image_tag }}"
+        changed_when: false
+        register: _cosign_verify
+
+      - name: Report the verified digest
+        ansible.builtin.debug:
+          msg: >-
+            Verified {{ image_registry }}/private-channel-app:{{ image_tag }}
+            @ {{ (_cosign_verify.stdout | from_json)[0].critical.image['docker-manifest-digest'] }}
+
     - name: Assert network is set
       ansible.builtin.assert:
         that: network | default('') | length > 0

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -640,11 +640,15 @@
         dest: "{{ target_versions_env_file }}"
         mode: "0644"
 
+    # Also tagged `deploy` so a standalone `--tags deploy` re-renders the override
+    # with the digest that this invocation's verify step just captured, instead of
+    # reusing a stale override from a prior render.
     - name: Render compose override
       ansible.builtin.template:
         src: templates/compose.yml.j2
         dest: "{{ target_override_file }}"
         mode: "0644"
+      tags: [ render, deploy ]
 
     # If a prior run wrote a real escrow instance ID into the .env file,
     # preserve it across re-renders. Otherwise the next deploy overwrites it

--- a/private-channel-deploy/templates/compose.yml.j2
+++ b/private-channel-deploy/templates/compose.yml.j2
@@ -16,8 +16,15 @@ services:
 {% for svc in ['write-node', 'read-node', 'gateway', 'streamer', 'auth',
                'indexer-solana', 'indexer-private-channel', 'operator-solana', 'operator-private-channel'] %}
   {{ svc }}:
-    # Pin every Solana Private Channels-app service to the deployed image tag.
+    # Pin every Solana Private Channels-app service to the deployed image. With
+    # signature verification on, pin the exact digest cosign verified in preflight
+    # (pc_app_image_digest) so `compose pull` can't resolve a tag that moved after
+    # the check; otherwise pin the tag.
+{% if verify_image_signature | default(false) | bool and pc_app_image_digest is defined %}
+    image: {{ img_prefix }}private-channel-app@{{ pc_app_image_digest }}
+{% else %}
     image: {{ img_prefix }}private-channel-app:{{ image_tag }}
+{% endif %}
 {% endfor %}
 
   # Stamp the deployed tag onto the validator image too (built from validator.Dockerfile).

--- a/private-channel-deploy/templates/compose.yml.j2
+++ b/private-channel-deploy/templates/compose.yml.j2
@@ -19,9 +19,11 @@ services:
     # Pin every Solana Private Channels-app service to the deployed image. With
     # signature verification on, pin the exact digest cosign verified in preflight
     # (pc_app_image_digest) so `compose pull` can't resolve a tag that moved after
-    # the check; otherwise pin the tag.
-{% if verify_image_signature | default(false) | bool and pc_app_image_digest is defined %}
-    image: {{ img_prefix }}private-channel-app@{{ pc_app_image_digest }}
+    # the check. If verification is on but no digest was captured (e.g. a render
+    # run without the verify phase), fail loudly rather than silently pinning the
+    # tag and leaving the operator thinking they're digest-pinned.
+{% if verify_image_signature | default(false) | bool %}
+    image: {{ img_prefix }}private-channel-app@{{ pc_app_image_digest | mandatory('verify_image_signature is enabled but no cosign-verified digest was recorded. Run the verify (preflight) phase before rendering so the digest is captured.') }}
 {% else %}
     image: {{ img_prefix }}private-channel-app:{{ image_tag }}
 {% endif %}

--- a/private-channel-deploy/vars/common.yml
+++ b/private-channel-deploy/vars/common.yml
@@ -94,3 +94,12 @@ target_config_dir: "{{ host_data_dir }}/config"
 target_compose_file: "{{ target_config_dir }}/{{ compose_file }}"
 target_versions_env_file: "{{ target_config_dir }}/versions.env"
 target_override_file: "{{ target_config_dir }}/compose.override.yml"
+
+# --- Image signature verification (opt-in; see verify_image_signature) --------
+# verify_image_signature gates the cosign preflight check. Off here so existing
+# stacks are unaffected; set `verify_image_signature: true` in a stack's vars to
+# require a signed image. image_signer_identity is the cosign
+# --certificate-identity-regexp the image must have been signed by: our publish
+# workflow on main or a release tag.
+verify_image_signature: false
+image_signer_identity: '^https://github\.com/solana-foundation/solana-private-channels/\.github/workflows/publish-image\.yml@refs/(heads/main|tags/.*)$'


### PR DESCRIPTION
Preflight supply-chain gate for the deploy. When `verify_image_signature: true` is set on a stack, the playbook runs `cosign verify` against the app image and aborts the deploy if it was not built and signed by our publish workflow.

How it works: cosign resolves the tag to its digest and checks the keyless signature, the Fulcio cert identity (must be `.github/workflows/publish-image.yml` in this repo, on main or a release tag) plus the Rekor transparency-log entry. So a tampered, unsigned, or foreign image fails preflight before any `docker compose pull`. No keys or tokens: it verifies public signatures.

Off by default, so existing stacks are unaffected. Requires `cosign` on the control node. The expected signer is `image_signer_identity` in `vars/common.yml` (a cosign `--certificate-identity-regexp`), overridable per stack.

Pairs with #270 (which produces the signed images). The deploy now pins to the verified digest: preflight records the `docker-manifest-digest` cosign resolved and the compose override renders `private-channel-app@sha256:<digest>`, so `compose pull` and `up` run exactly the bytes that were verified rather than re-resolving a tag that could move in between. Falls back to the tag when verification is off.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...
