### PR TITLE
docs(runbooks): forbid re-arming a withdrawal with no source burn (finding-216)

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -115,7 +115,7 @@ pins the relevant contract.
 | `drill_1_error_message_contracts_present_in_source` | both | Source contains every `error_message` substring the dispatch tables match on. |
 | `drill_2_path_a_data_error_recovery` | withdrawal | Triage SQL orders the trigger row first; recovery SQL reaches the documented end-state. |
 | `drill_3_path_b_landed_marks_completed_with_signature` | withdrawal | On `LANDED`, mark `completed` with the observed signature (prevents double-credit). |
-| `drill_4_path_c_not_landed_re_arms_with_same_nonce` | withdrawal | Re-arm preserves `withdrawal_nonce`; nonce-uniqueness index still enforces. |
+| `drill_4_path_c_not_landed_recovery_flows` | withdrawal | `withdrawal_manual_review.md` § Path C Step 3: burned branch re-arms preserving `withdrawal_nonce` (nonce-uniqueness index still enforces); not-burned branch terminalizes the row and never returns it to the fetcher's pending queue. |
 | `drill_5_halt_sweep_excludes_poison_only` | withdrawal | Bulk-quarantine flips every active withdrawal except the excluded poison id. |
 | `drill_6_recovery_query_skips_terminal_statuses` | withdrawal | Recovery query skips rows already resolved to a terminal status. |
 | `drill_7_halt_sweep_does_not_touch_terminals` | withdrawal | Bulk-quarantine leaves terminal-status rows alone. |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -113,7 +113,7 @@ pins the relevant contract.
 | Drill | Side | Verifies |
 |---|---|---|
 | `drill_1_error_message_contracts_present_in_source` | both | Source contains every `error_message` substring the dispatch tables match on. |
-| `drill_2_path_a_data_error_recovery` | withdrawal | Triage SQL orders the trigger row first; recovery SQL reaches the documented end-state. |
+| `drill_2_path_a_data_error_recovery` | withdrawal | Triage SQL orders the trigger row first; recovery SQL reaches the documented end-state, and `id <> ALL(:excluded_ids)` leaves held rows quarantined. |
 | `drill_3_path_b_landed_marks_completed_with_signature` | withdrawal | On `LANDED`, mark `completed` with the observed signature (prevents double-credit). |
 | `drill_4_path_c_not_landed_recovery_flows` | withdrawal | `withdrawal_manual_review.md` § Path C Step 3: burned branch re-arms preserving `withdrawal_nonce` (nonce-uniqueness index still enforces); not-burned branch terminalizes the row and never returns it to the fetcher's pending queue. |
 | `drill_5_halt_sweep_excludes_poison_only` | withdrawal | Bulk-quarantine flips every active withdrawal except the excluded poison id. |

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -22,7 +22,7 @@ store.
 Pull the row's DB-side state:
 
 ```sql
-SELECT id, signature, withdrawal_nonce, status, counterpart_signature,
+SELECT id, signature, slot, withdrawal_nonce, status, counterpart_signature,
        remint_signatures, updated_at
   FROM transactions
  WHERE id = :transaction_id;
@@ -256,15 +256,25 @@ committing the row to manual review. Sub-triggers below; same recovery.
 3. **If `NOT_LANDED`:** withdrawal did not happen. The user's private channel tokens
    may or may not be burned (depends on the trigger sub-site). Confirm burn
    state before deciding - `signature` is the originating PrivateChannel
-   burn, so `solana confirm -v <signature> --url <private-channel-rpc>`
-   settles it (same check as Path F Step 2):
+   burn:
+   ```bash
+   solana confirm -v <signature> --url <private-channel-rpc>
+   ```
+   `Finalized` with no error means burned. A `not found` is **not** proof of
+   non-inclusion: it counts only if the endpoint's ledger covers the row's
+   `slot`, i.e. `getFirstAvailableBlock` is at or below it. A pruned,
+   non-archival or lagging node returns the same `not found` for a burn that
+   did land. The operator applies this exact floor check before calling a
+   signature dead by absence (`sender/remint.rs::coverage_verdict`); honor
+   it here.
    - Burned, no release → re-arm to `pending` and restart operator. The
      withdrawal will be re-attempted; the channel-side burn is idempotent.
-   - Not burned → **do not re-arm.** Nothing backs the row: a re-arm
-     releases escrowed target-chain funds against a burn that never
-     happened, and neither the builder nor the escrow program can detect
-     it. Capture the row, its `signature` and the `solana confirm` output
-     in the incident record, then mark the row terminal:
+   - Not burned, proven absent → **do not re-arm.** Nothing backs the
+     row: a re-arm releases escrowed target-chain funds against a burn
+     that never happened, and neither the builder nor the escrow program
+     can detect it. Capture the row, its `signature` and the
+     `solana confirm` output in the incident record, then mark the row
+     terminal:
      ```sql
      UPDATE transactions SET status = 'failed', updated_at = NOW()
       WHERE id = :transaction_id;
@@ -272,6 +282,11 @@ committing the row to manual review. Sub-triggers below; same recovery.
      No refund is owed - the user still holds their channel tokens.
      [Escalate](_escalation.md) (Tier 3): a row with no finalized burn
      means the ingestion or write path has a defect.
+   - Burn state unproven (RPC error, or `not found` with a ledger floor
+     above the row's `slot`) → stop. [Escalate](_escalation.md) (Tier 2).
+     Do not terminalize: marking a genuinely burned row `failed` strands
+     the user's tokens with no restoration path. Re-run once the endpoint
+     covers the slot, or from an archival node.
 4. **If `AMBIGUOUS`:** stop. [Escalate](_escalation.md) (Tier 2). Wait
    for RPC visibility to recover. Do not act.
 
@@ -297,7 +312,7 @@ re-arm.** The processor would reject the row identically on every tick.
 ### Step 1 - confirm the corruption
 
 ```sql
-SELECT id, signature, withdrawal_nonce, mint, amount, recipient,
+SELECT id, signature, slot, withdrawal_nonce, mint, amount, recipient,
        created_at, updated_at
   FROM transactions
  WHERE id = :transaction_id;
@@ -321,6 +336,11 @@ Otherwise proceed.
 solana confirm -v <signature> --url <private-channel-rpc>
 ```
 
+`not found` proves non-inclusion only if the endpoint's ledger covers the
+row's `slot` (`getFirstAvailableBlock` at or below it) - a pruned or
+lagging node returns the same `not found` for a burn that did land. Same
+rule as Path C Step 3.
+
 ### Step 3 - branch on burn verdict
 
 #### Burn landed
@@ -343,6 +363,14 @@ write-or-classify path has a defect. Capture the row, then delete:
 ```sql
 DELETE FROM transactions WHERE id = :transaction_id;
 ```
+
+#### Burn state unproven
+
+The RPC failed, or `not found` came back without ledger coverage of the
+row's `slot`. Stop. [Escalate](_escalation.md) (Tier 2). **Do not delete
+the row** - the burn may have landed, and this row is the only record of
+it. Re-run Step 2 once the endpoint covers the slot, or against an
+archival node.
 
 ## Path G - requeue cap exhausted (release never landed)
 
@@ -425,7 +453,8 @@ defect.
 ### Step 2 - confirm the burn, then escalate for refund
 
 `signature` is the originating PrivateChannel burn. Confirm whether the user's
-tokens were burned (channel read node). Burned, release can never land -> the
+tokens were burned (`solana confirm -v <signature> --url <private-channel-rpc>`,
+as in Path F Step 2). Burned, release can never land -> the
 user's funds are stuck and there is no automated recovery: forward rotation
 will not reopen the tree. [Escalate](_escalation.md) (Tier 1) for out-of-band
 restoration (manual `release_funds` to the depositor or a manual remint of the
@@ -436,8 +465,12 @@ UPDATE transactions SET status = 'failed', updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
-If the burn did not land, there is no user impact; close the alert and mark
-`failed`.
+If the burn is proven not to have landed (`not found` with ledger coverage of
+the row's `slot`, per Path C Step 3), there is no user impact; close the alert
+and mark `failed`. If coverage cannot be established, do not close the alert:
+[escalate](_escalation.md) (Tier 2) to resolve the verdict first. The tree
+window is already closed, so a burned row closed as a non-event leaves the
+user's funds stuck with nobody looking.
 
 ### Step 3 - capture why the sender fell behind its own tree
 

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -96,13 +96,16 @@ collateral.
       SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
     WHERE transaction_type = 'withdrawal'
       AND status = 'manual_review'
-      AND id <> :poison_id;
+      AND id <> ALL(:excluded_ids);
    ```
+   `:excluded_ids` is `:poison_id` plus every row a prior escalation left
+   held in `manual_review` (each recorded in its own incident record).
+   Re-arming a held row releases escrowed funds against a burn nobody
+   proved happened.
    The `transactions` table does not store `error_message` - it lives in the
    alert payload only. Distinguishing trigger from collateral happens in
    triage (Step 2: oldest `updated_at` is the trigger), not in the re-arm
-   query. If you have *multiple* unresolved trigger rows from different
-   incidents, recover them one at a time and exclude each via `id <> :id`.
+   query.
 5. **Restart the withdraw operator** (Docker, from the repo root: `docker compose
    restart operator-private-channel`; or by container: `docker restart
    private-channel-operator-private-channel`). The fetcher picks up `pending` rows and
@@ -291,7 +294,9 @@ committing the row to manual review. Sub-triggers below; same recovery.
      stop. [Escalate](_escalation.md) (Tier 2).
      Do not terminalize: marking a genuinely burned row `failed` strands
      the user's tokens with no restoration path. Re-run once the endpoint
-     covers the slot, or from an archival node.
+     covers the slot, or from an archival node. Record the id as held in
+     the incident record - it stays in `manual_review`, so a later halt's
+     Path A Step 4 must exclude it.
 4. **If `AMBIGUOUS`:** stop. [Escalate](_escalation.md) (Tier 2). Wait
    for RPC visibility to recover. Do not act.
 
@@ -375,7 +380,9 @@ The RPC failed, or `not found` came back without ledger coverage of the
 row's `slot`. Stop. [Escalate](_escalation.md) (Tier 2). **Do not delete
 the row** - the burn may have landed, and this row is the only record of
 it. Re-run Step 2 once the endpoint covers the slot, or against an
-archival node.
+archival node. Record the id as held in the incident record, as in Path C
+Step 3: the row stays in `manual_review`, so a later halt's Path A Step 4
+must exclude it.
 
 ## Path G - requeue cap exhausted (release never landed)
 

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -261,12 +261,16 @@ committing the row to manual review. Sub-triggers below; same recovery.
    solana confirm -v <signature> --url <private-channel-rpc>
    ```
    `Finalized` with no error means burned. A `not found` is **not** proof of
-   non-inclusion: it counts only if the endpoint's ledger covers the row's
-   `slot`, i.e. `getFirstAvailableBlock` is at or below it. A pruned,
-   non-archival or lagging node returns the same `not found` for a burn that
-   did land. The operator applies this exact floor check before calling a
-   signature dead by absence (`sender/remint.rs::coverage_verdict`); honor
-   it here.
+   non-inclusion. It counts only if the endpoint observed the row's `slot`,
+   which takes both bounds against `<private-channel-rpc>`:
+   `solana first-available-block` at or below the row's `slot`, else the slot
+   was pruned away, **and** `solana slot --commitment finalized` at or above
+   it, else the node never reached it. Either bound alone is worthless: a
+   pruned node and a lagging node return the same `not found` for a burn that
+   did land. The operator enforces both before calling a signature dead by
+   absence, the top via the blockhash-expiry check that produces
+   `DeadByAbsence` and the bottom via the ledger floor in
+   `sender/remint.rs::coverage_verdict`. Honor both here.
    - Burned, no release → re-arm to `pending` and restart operator. The
      withdrawal will be re-attempted; the channel-side burn is idempotent.
    - Not burned, proven absent → **do not re-arm.** Nothing backs the
@@ -282,8 +286,9 @@ committing the row to manual review. Sub-triggers below; same recovery.
      No refund is owed - the user still holds their channel tokens.
      [Escalate](_escalation.md) (Tier 3): a row with no finalized burn
      means the ingestion or write path has a defect.
-   - Burn state unproven (RPC error, or `not found` with a ledger floor
-     above the row's `slot`) → stop. [Escalate](_escalation.md) (Tier 2).
+   - Burn state unproven (RPC error, or `not found` with either bound
+     unmet: floor above the row's `slot`, or finalized tip below it) →
+     stop. [Escalate](_escalation.md) (Tier 2).
      Do not terminalize: marking a genuinely burned row `failed` strands
      the user's tokens with no restoration path. Re-run once the endpoint
      covers the slot, or from an archival node.
@@ -336,10 +341,10 @@ Otherwise proceed.
 solana confirm -v <signature> --url <private-channel-rpc>
 ```
 
-`not found` proves non-inclusion only if the endpoint's ledger covers the
-row's `slot` (`getFirstAvailableBlock` at or below it) - a pruned or
-lagging node returns the same `not found` for a burn that did land. Same
-rule as Path C Step 3.
+`not found` proves non-inclusion only if the endpoint observed the row's
+`slot`: first-available-block at or below it **and** finalized tip at or
+above it. A pruned node and a lagging node both return the same `not found`
+for a burn that did land. Same two bounds as Path C Step 3.
 
 ### Step 3 - branch on burn verdict
 

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -258,7 +258,19 @@ committing the row to manual review. Sub-triggers below; same recovery.
    state via channel read node before deciding:
    - Burned, no release → re-arm to `pending` and restart operator. The
      withdrawal will be re-attempted; the channel-side burn is idempotent.
-   - Not burned → no user impact; close the alert and re-arm.
+   - Not burned → **do not re-arm.** Nothing backs the row: a re-arm
+     releases escrowed target-chain funds against a burn that never
+     happened, and neither the builder nor the escrow program can detect
+     it. Capture the row, its `signature` (the originating PrivateChannel
+     burn) and the burn-verification output in the incident record, then
+     mark the row terminal:
+     ```sql
+     UPDATE transactions SET status = 'failed', updated_at = NOW()
+      WHERE id = :transaction_id;
+     ```
+     No refund is owed - the user still holds their channel tokens.
+     [Escalate](_escalation.md) (Tier 3): a row with no finalized burn
+     means the ingestion or write path has a defect.
 4. **If `AMBIGUOUS`:** stop. [Escalate](_escalation.md) (Tier 2). Wait
    for RPC visibility to recover. Do not act.
 
@@ -441,6 +453,8 @@ Capture in the incident record:
 - Full `error_message` content.
 - Trigger site (which row of the dispatch table).
 - On-chain verdict (`LANDED <sig>` / `NOT_LANDED` / `AMBIGUOUS`).
+- Burn verdict on the source side (`signature` + `solana confirm` output),
+  when the path branched on it.
 - Recovery action taken (SQL run, sig used, escalation path).
 - RPC endpoint used for verification.
 

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -22,7 +22,7 @@ store.
 Pull the row's DB-side state:
 
 ```sql
-SELECT id, withdrawal_nonce, status, counterpart_signature,
+SELECT id, signature, withdrawal_nonce, status, counterpart_signature,
        remint_signatures, updated_at
   FROM transactions
  WHERE id = :transaction_id;
@@ -255,15 +255,16 @@ committing the row to manual review. Sub-triggers below; same recovery.
    ```
 3. **If `NOT_LANDED`:** withdrawal did not happen. The user's private channel tokens
    may or may not be burned (depends on the trigger sub-site). Confirm burn
-   state via channel read node before deciding:
+   state before deciding - `signature` is the originating PrivateChannel
+   burn, so `solana confirm -v <signature> --url <private-channel-rpc>`
+   settles it (same check as Path F Step 2):
    - Burned, no release → re-arm to `pending` and restart operator. The
      withdrawal will be re-attempted; the channel-side burn is idempotent.
    - Not burned → **do not re-arm.** Nothing backs the row: a re-arm
      releases escrowed target-chain funds against a burn that never
      happened, and neither the builder nor the escrow program can detect
-     it. Capture the row, its `signature` (the originating PrivateChannel
-     burn) and the burn-verification output in the incident record, then
-     mark the row terminal:
+     it. Capture the row, its `signature` and the `solana confirm` output
+     in the incident record, then mark the row terminal:
      ```sql
      UPDATE transactions SET status = 'failed', updated_at = NOW()
       WHERE id = :transaction_id;

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -687,6 +687,16 @@ async fn drill_4_path_c_not_landed_recovery_flows() -> Result<(), Box<dyn std::e
         "Step 3 must route an unproven burn verdict to Tier 2 instead of \
          terminalizing a possibly-burned row; got:\n{branch}"
     );
+    // Coverage takes both bounds. A ledger floor below the row's slot only
+    // proves nothing was pruned; a node that never advanced to that slot
+    // returns the same `not found`. Dropping either bound silently restores
+    // the misclassification, so pin both.
+    let step_3 = &path_c[..branch_start];
+    assert!(
+        step_3.contains("first-available-block") && step_3.contains("--commitment finalized"),
+        "Step 3 must require both coverage bounds (ledger floor below the \
+         row's slot AND finalized tip above it); got:\n{step_3}"
+    );
 
     eprintln!("(2) not-burned branch: terminal only on proven absence, unproven escalates.");
     Ok(())

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -652,13 +652,23 @@ async fn drill_4_path_c_not_landed_recovery_flows() -> Result<(), Box<dyn std::e
     let runbook_path = workspace_root.join("docs/runbooks/withdrawal_manual_review.md");
     let runbook = std::fs::read_to_string(&runbook_path)
         .unwrap_or_else(|e| panic!("read {runbook_path:?}: {e}"));
-    let branch_start = runbook
+    // Narrow to the Path C section first. A bare search for the bullet
+    // would silently follow a `Not burned` bullet added to any earlier
+    // path, and pass while Path C itself regressed.
+    let section_start = runbook
+        .find("\n## Path C ")
+        .expect("withdrawal_manual_review.md must contain a Path C section");
+    let section_len = runbook[section_start + 1..]
+        .find("\n## ")
+        .expect("Path C must be followed by another section heading");
+    let path_c = &runbook[section_start..section_start + 1 + section_len];
+    let branch_start = path_c
         .find("- Not burned")
         .expect("Path C Step 3 must contain a `Not burned` branch");
-    let branch_end = runbook[branch_start..]
+    let branch_end = path_c[branch_start..]
         .find("\n4. ")
         .expect("the `Not burned` branch must be followed by Step 4");
-    let branch = &runbook[branch_start..branch_start + branch_end];
+    let branch = &path_c[branch_start..branch_start + branch_end];
     assert!(
         branch.contains("do not re-arm"),
         "the `Not burned` branch must forbid re-arming; got:\n{branch}"

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -677,8 +677,18 @@ async fn drill_4_path_c_not_landed_recovery_flows() -> Result<(), Box<dyn std::e
         !branch.contains("'pending'"),
         "the `Not burned` branch must contain no re-arm SQL; got:\n{branch}"
     );
+    // Terminalizing is only safe on a *proven* absence. `solana confirm`
+    // returns `not found` both for a burn that never happened and for one
+    // the endpoint no longer covers, so an unproven verdict has to escalate
+    // rather than mark the row failed - the same fence
+    // `sender/remint.rs::coverage_verdict` applies to absent signatures.
+    assert!(
+        branch.contains("Tier 2"),
+        "Step 3 must route an unproven burn verdict to Tier 2 instead of \
+         terminalizing a possibly-burned row; got:\n{branch}"
+    );
 
-    eprintln!("(2) not-burned branch: terminal, absent from pending queue, no re-arm in runbook.");
+    eprintln!("(2) not-burned branch: terminal only on proven absence, unproven escalates.");
     Ok(())
 }
 
@@ -1855,6 +1865,32 @@ async fn drill_16_withdrawal_manual_review_recovery_missing_nonce_flow(
         "manual_review",
         "Path F terminal SQL must NOT touch sibling manual_review rows"
     );
+
+    // ── Path F Step 3 must not DELETE on an unproven burn verdict ──
+    // `solana confirm` returns `not found` both for a burn that never
+    // happened and for one the endpoint no longer covers. This path's
+    // not-landed branch deletes the row, which is the only record of the
+    // burn, so an unproven verdict has to escalate instead.
+    let runbook_path = workspace_root.join("docs/runbooks/withdrawal_manual_review.md");
+    let runbook = std::fs::read_to_string(&runbook_path)
+        .unwrap_or_else(|e| panic!("read {runbook_path:?}: {e}"));
+    let section_start = runbook
+        .find("\n## Path F ")
+        .expect("withdrawal_manual_review.md must contain a Path F section");
+    let section_len = runbook[section_start + 1..]
+        .find("\n## ")
+        .expect("Path F must be followed by another section heading");
+    let path_f = &runbook[section_start..section_start + 1 + section_len];
+    let unproven_start = path_f
+        .find("Burn state unproven")
+        .expect("Path F must carry an unproven-burn branch, not just landed/not-landed");
+    let unproven = &path_f[unproven_start..];
+    assert!(
+        unproven.contains("Tier 2") && !unproven.contains("DELETE"),
+        "Path F's unproven-burn branch must escalate Tier 2 and must not \
+         delete the row; got:\n{unproven}"
+    );
+    eprintln!("OK   Path F § Step 3: unproven burn escalates without deleting");
 
     eprintln!("Path F triage substring + terminal SQL verified.");
     Ok(())

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -342,7 +342,7 @@ fn drill_1_error_message_contracts_present_in_source() {
 //   1. Triage query returns rows in the right order (poison row first).
 //   2. Mark-failed SQL terminates the trigger row.
 //   3. Re-arm SQL flips collateral rows back to `pending`, leaves the
-//      trigger row alone.
+//      trigger row and every held row alone (`id <> ALL(:excluded_ids)`).
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
@@ -369,6 +369,12 @@ async fn drill_2_path_a_data_error_recovery() -> Result<(), Box<dyn std::error::
         collateral_ids.push(id);
     }
 
+    // A row an earlier incident left held in `manual_review`: Path C Step 3
+    // could not prove its source burn either way, so it must not re-enter
+    // the queue. The halt sweep does not restamp `manual_review` rows, so
+    // held rows outlive their incident and land in this triage.
+    let held_id = seed_withdrawal(&pool, "manual_review", 6, None).await?;
+
     // ── Triage query (verbatim from runbook) ────────────────────────────
     let rows = sqlx::query(
         r#"
@@ -388,7 +394,7 @@ async fn drill_2_path_a_data_error_recovery() -> Result<(), Box<dyn std::error::
         first_id, poison_id,
         "triage must return poison row first (oldest updated_at)"
     );
-    assert_eq!(rows.len(), 5, "all 5 manual_review rows visible");
+    assert_eq!(rows.len(), 6, "all 6 manual_review rows visible");
 
     // ── Mark trigger as failed (verbatim from runbook step 3) ──────────
     sqlx::query("UPDATE transactions SET status = 'failed', updated_at = NOW() WHERE id = $1")
@@ -402,16 +408,17 @@ async fn drill_2_path_a_data_error_recovery() -> Result<(), Box<dyn std::error::
     // `error_message IS NULL` filter applies cleanly. (The DB schema has no
     // error_message column today; the runbook semantics rely on the alert
     // payload, but the recovery SQL itself is column-free for the dispatch.)
+    let excluded_ids = vec![poison_id, held_id];
     let updated = sqlx::query(
         r#"
         UPDATE transactions
            SET status = 'pending', updated_at = NOW()
          WHERE transaction_type = 'withdrawal'
            AND status = 'manual_review'
-           AND id <> $1
+           AND id <> ALL($1)
         "#,
     )
-    .bind(poison_id)
+    .bind(&excluded_ids[..])
     .execute(&pool)
     .await?;
     assert_eq!(
@@ -421,14 +428,20 @@ async fn drill_2_path_a_data_error_recovery() -> Result<(), Box<dyn std::error::
     );
 
     // ── Post-state assertions ──────────────────────────────────────────
-    assert_eq!(count_status(&pool, "manual_review").await?, 0);
+    assert_eq!(count_status(&pool, "manual_review").await?, 1);
     assert_eq!(count_status(&pool, "failed").await?, 1);
     assert_eq!(count_status(&pool, "pending").await?, 4);
     for id in collateral_ids {
         assert_eq!(status_of(&pool, id).await?, "pending");
     }
+    assert_eq!(
+        status_of(&pool, held_id).await?,
+        "manual_review",
+        "a held row must survive Path A recovery; re-arming it would release \
+         escrowed funds against an unproven burn"
+    );
 
-    eprintln!("Path A recovery SQL verified end-to-end.");
+    eprintln!("Path A recovery SQL verified end-to-end; held row not re-armed.");
     Ok(())
 }
 

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -19,7 +19,7 @@
 
 use chrono::Utc;
 use private_channel_indexer::{
-    storage::{PostgresDb, Storage},
+    storage::{PostgresDb, Storage, TransactionType},
     PostgresConfig,
 };
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
@@ -493,25 +493,35 @@ async fn drill_3_path_b_landed_marks_completed_with_signature(
     Ok(())
 }
 
-// ── Drill 4: Path C — ambiguous, NOT_LANDED → re-arm to pending ─────────────
+// ── Drill 4: Path C, NOT_LANDED - both Step 3 branches ──────────────────────
 //
-// Verifies that re-arming a `manual_review` withdrawal back to `pending`
-// preserves `withdrawal_nonce` — the on-chain SMT leaf is keyed on this,
-// and a re-attempt must hit the same leaf. Also verifies the schema's
-// unique-nonce-per-withdrawal constraint does not block re-arming (the
-// row keeps the same nonce; no new row is inserted).
+// Step 3 branches on whether the source-side burn landed, and the two
+// branches must stay asymmetric:
+//
+//   (1) Burned, no release -> re-arm to `pending`. The re-arm must preserve
+//       `withdrawal_nonce` (the on-chain leaf is keyed on it, so a
+//       re-attempt has to hit the same leaf), and the unique-nonce
+//       constraint must not block re-arming the same row.
+//   (2) Not burned -> terminal, never re-armed. Nothing backs such a row:
+//       `build_release_funds` reads mint/recipient/amount/nonce straight
+//       off it, and the escrow program cannot verify a burn on another
+//       chain, so a re-arm releases escrowed funds against a withdrawal
+//       that was never requested.
+//
+// Both branches sit in one drill so the asymmetry is visible in one place;
+// splitting them is how the runbook drifted into re-arming branch (2).
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn drill_4_path_c_not_landed_re_arms_with_same_nonce(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn drill_4_path_c_not_landed_recovery_flows() -> Result<(), Box<dyn std::error::Error>> {
     drill_header(
         "withdrawal_manual_review.md",
-        "Path C — ambiguous; NOT_LANDED branch (re-arm)",
+        "Path C - NOT_LANDED (Step 3 branches)",
     );
 
-    let (pool, _storage, _pg) = start_postgres().await?;
+    let (pool, storage, _pg) = start_postgres().await?;
 
+    // ── (1) Burned, no release -> re-arm to pending ────────────────────
     // Seed: row in manual_review with a specific nonce. Webhook
     // error_message would be e.g. "no signatures to verify — remint unsafe".
     let original_nonce: i64 = 42;
@@ -580,7 +590,85 @@ async fn drill_4_path_c_not_landed_re_arms_with_same_nonce(
         "nonce uniqueness must reject a second withdrawal with the same nonce"
     );
 
-    eprintln!("Path C NOT_LANDED re-arm verified; nonce identity preserved.");
+    eprintln!("(1) burned branch: re-arm verified; nonce identity preserved.");
+
+    // ── (2) Not burned -> terminal; never re-armed ─────────────────────
+    // A withdrawal row whose source burn never finalized has nothing
+    // backing it. The runbook marks it `failed`; this pins that the row
+    // leaves the executable queue and that the runbook offers no re-arm.
+    let unburned_nonce: i64 = 43;
+    let unburned_id = seed_withdrawal(
+        &pool,
+        "manual_review",
+        unburned_nonce,
+        Some("could not verify release landed ("),
+    )
+    .await?;
+    let sibling_nonce: i64 = 44;
+    let sibling_id = seed_withdrawal(&pool, "manual_review", sibling_nonce, None).await?;
+
+    eprintln!("simulated verification: release NOT_LANDED, source burn NOT landed");
+
+    sqlx::query("UPDATE transactions SET status = 'failed', updated_at = NOW() WHERE id = $1")
+        .bind(unburned_id)
+        .execute(&pool)
+        .await?;
+
+    assert_eq!(
+        status_of(&pool, unburned_id).await?,
+        "failed",
+        "not-burned branch must terminalize the row, never re-arm it"
+    );
+    assert_eq!(
+        status_of(&pool, sibling_id).await?,
+        "manual_review",
+        "terminal SQL must be row-scoped and leave sibling manual_review rows alone"
+    );
+
+    // The assertion that carries the branch: the fetcher's own query must
+    // not return the row. Driven through the real storage method so a
+    // future change to the pending-selection SQL is caught here. The
+    // branch-(1) row is the positive control - it was re-armed, so the
+    // query must return it, which proves the absence check is not vacuous.
+    let queued = storage
+        .get_pending_db_transactions(TransactionType::Withdrawal, 100)
+        .await?;
+    assert!(
+        queued.iter().any(|txn| txn.id == id),
+        "the re-armed branch-(1) row must be in the fetcher's pending queue"
+    );
+    assert!(
+        !queued.iter().any(|txn| txn.id == unburned_id),
+        "a row with no source burn must never re-enter the executable withdrawal queue"
+    );
+
+    // The runbook text itself must offer no re-arm in this branch. Scoped
+    // to the branch: Paths A, C-burned and G all re-arm legitimately, so a
+    // whole-file scan would be meaningless here.
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    let runbook_path = workspace_root.join("docs/runbooks/withdrawal_manual_review.md");
+    let runbook = std::fs::read_to_string(&runbook_path)
+        .unwrap_or_else(|e| panic!("read {runbook_path:?}: {e}"));
+    let branch_start = runbook
+        .find("- Not burned")
+        .expect("Path C Step 3 must contain a `Not burned` branch");
+    let branch_end = runbook[branch_start..]
+        .find("\n4. ")
+        .expect("the `Not burned` branch must be followed by Step 4");
+    let branch = &runbook[branch_start..branch_start + branch_end];
+    assert!(
+        branch.contains("do not re-arm"),
+        "the `Not burned` branch must forbid re-arming; got:\n{branch}"
+    );
+    assert!(
+        !branch.contains("'pending'"),
+        "the `Not burned` branch must contain no re-arm SQL; got:\n{branch}"
+    );
+
+    eprintln!("(2) not-burned branch: terminal, absent from pending queue, no re-arm in runbook.");
     Ok(())
 }
 


### PR DESCRIPTION
## Finding 216

`withdrawal_manual_review.md` Path C Step 3 told operators that a withdrawal whose source burn did not land had "no user impact; close the alert and re-arm."

Re-arming returns the row to `pending`. `build_release_funds` then builds a target-chain `ReleaseFunds` straight from the row's mint, recipient, amount and nonce. The escrow program verifies the operator, the allowed-mint PDA, the ATA derivations and nonce exclusion, but a cross-chain burn cannot be proven on-chain. Following the documented branch would release escrowed funds for a withdrawal that was never requested.

## Fix

The not-burned branch now forbids re-arming. It requires capturing the row, its source burn signature and the verification output, then marks the row terminal and escalates Tier 3, since a row with no finalized burn means the ingestion or write path has a defect. Paths F and H already handled the identical verdict this way, so Path C was the outlier.

Post-incident artifacts now also require the source-side burn verdict.

## Drill

`drill_4` is renamed to `drill_4_path_c_not_landed_recovery_flows` and covers both Step 3 branches, so the asymmetry between them stays visible in one place. The new branch asserts the row is absent from `get_pending_db_transactions`, the fetcher's own queue, with branch1's re-armed row as the positive control, and that the runbook bullet contains no re-arm SQL.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 15,588 | 17,237 | 90.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32510019074) |
| Indexer | 36,841 | 40,456 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32510019074) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32510019074) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32510019074) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,589 | 18,739 | 77.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32510019074) |
| **Total** | **69,964** | **79,830** | **87.6%** | |

> Last updated: 2026-08-21 18:52:01 UTC by E2E Integration