### PR TITLE
fix(indexer): drop the cold-start exemption that left the startup anchor unread (issue-278)

### DIFF
--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -40,10 +40,11 @@ Recovers missed slots on indexer restart or network issues:
    - Process blocks in order
    - Update checkpoint per slot via `CheckpointWriter` (driven by `SlotComplete` events)
 4. For the Yellowstone datasource, persist a startup anchor before the live stream runs, so a
-   durable checkpoint always exists: reconnect gap repair replays from it and withholds live slots
-   rather than advancing the checkpoint without one. The anchor is the resolved backfill range's
-   floor, or the current chain tip when backfill is disabled. RPC polling has no reconnect repair
-   and writes no anchor; it resumes from its configured start slot
+   durable checkpoint always exists: every connection, the first one included, replays from it up
+   to the slot the stream opened at, and withholds live slots rather than advancing the checkpoint
+   without one. The anchor is the resolved backfill range's floor, or the current chain tip when
+   backfill is disabled. RPC polling has no reconnect repair and writes no anchor; it resumes from
+   its configured start slot
 5. Switch to real-time mode (Yellowstone or polling)
 
 **Location**: [`indexer/src/indexer/backfill.rs`](../indexer/src/indexer/backfill.rs)

--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -280,20 +280,19 @@ pub async fn ensure_startup_anchor(
 }
 
 /// Highest slot startup owns, one below the live boundary, or the anchor with no backfill.
-/// Bounded both ways: the first gate waits on this slot, so above the tip it waits forever.
+/// Not capped at the chain tip: a node lagging the provider that wrote the checkpoint is normal.
 #[cfg(feature = "datasource-yellowstone")]
 pub fn resolve_startup_floor(
     live_start_slot: Option<u64>,
     anchor: u64,
-    tip: u64,
 ) -> Result<u64, IndexerError> {
     let floor = live_start_slot.map_or(anchor, |slot| slot.saturating_sub(1));
 
-    if floor > tip || floor < anchor {
+    if floor < anchor {
         return Err(DataSourceError::InvalidConfig {
             reason: format!(
-                "startup floor {floor} is outside the recoverable range [{anchor}, {tip}]; \
-                 check backfill.from_slot against the chain the RPC endpoint serves"
+                "startup floor {floor} is below the durable anchor {anchor}; the live boundary \
+                 and the anchor were resolved from different ranges"
             ),
         }
         .into());
@@ -390,6 +389,18 @@ impl BackfillService {
         };
 
         let current_slot = latest_slot_with_retry(&self.rpc_poller).await?;
+
+        // A boundary this far past the chain is a misconfiguration, not lag. Warn rather than
+        // refuse, because a node trailing the provider that wrote the checkpoint is routine.
+        if from_slot.saturating_sub(current_slot) > self.config.max_gap_slots {
+            warn!(
+                "Startup boundary {} is {} slots past the tip {} this endpoint reports; check \
+                 backfill.start_slot against the chain it serves",
+                from_slot,
+                from_slot - current_slot,
+                current_slot
+            );
+        }
 
         // One past the highest slot backfill covers (gap) or the durable checkpoint
         // (no gap); max guards against an RPC node lagging behind the checkpoint.
@@ -617,40 +628,14 @@ mod tests {
     #[cfg(feature = "datasource-yellowstone")]
     #[test]
     fn startup_floor_is_the_slot_below_the_live_boundary() {
-        assert_eq!(
-            resolve_startup_floor(Some(1_001), 500, 2_000).unwrap(),
-            1_000
-        );
+        assert_eq!(resolve_startup_floor(Some(1_001), 500).unwrap(), 1_000);
     }
 
     /// With no backfill there is no range to inherit and the anchor is the boundary itself.
     #[cfg(feature = "datasource-yellowstone")]
     #[test]
     fn startup_floor_falls_back_to_the_anchor() {
-        assert_eq!(resolve_startup_floor(None, 500, 2_000).unwrap(), 500);
-    }
-
-    /// A from_slot set past the chain would gate on slots that can never be produced, which
-    /// freezes the checkpoint for good. Refuse to start rather than stall silently.
-    #[cfg(feature = "datasource-yellowstone")]
-    #[test]
-    fn startup_floor_rejects_a_boundary_above_the_chain_tip() {
-        let err = resolve_startup_floor(Some(9_001), 500, 2_000).unwrap_err();
-        assert!(
-            err.to_string().contains("9000"),
-            "the error must name the rejected floor: {err}"
-        );
-    }
-
-    /// The tip is read after the boundary is resolved, so equality is the normal case for a
-    /// deployment starting at the tip and must not be mistaken for a misconfiguration.
-    #[cfg(feature = "datasource-yellowstone")]
-    #[test]
-    fn startup_floor_accepts_a_boundary_at_the_chain_tip() {
-        assert_eq!(
-            resolve_startup_floor(Some(2_001), 500, 2_000).unwrap(),
-            2_000
-        );
+        assert_eq!(resolve_startup_floor(None, 500).unwrap(), 500);
     }
 
     /// The anchor is the lowest slot startup owns, so a floor under it means the two were
@@ -658,7 +643,7 @@ mod tests {
     #[cfg(feature = "datasource-yellowstone")]
     #[test]
     fn startup_floor_rejects_a_boundary_below_the_anchor() {
-        assert!(resolve_startup_floor(Some(401), 500, 2_000).is_err());
+        assert!(resolve_startup_floor(Some(401), 500).is_err());
     }
 
     // ============================================================================

--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -279,6 +279,29 @@ pub async fn ensure_startup_anchor(
     Ok(anchor)
 }
 
+/// Highest slot startup owns, one below the live boundary, or the anchor with no backfill.
+/// Bounded both ways: the first gate waits on this slot, so above the tip it waits forever.
+#[cfg(feature = "datasource-yellowstone")]
+pub fn resolve_startup_floor(
+    live_start_slot: Option<u64>,
+    anchor: u64,
+    tip: u64,
+) -> Result<u64, IndexerError> {
+    let floor = live_start_slot.map_or(anchor, |slot| slot.saturating_sub(1));
+
+    if floor > tip || floor < anchor {
+        return Err(DataSourceError::InvalidConfig {
+            reason: format!(
+                "startup floor {floor} is outside the recoverable range [{anchor}, {tip}]; \
+                 check backfill.from_slot against the chain the RPC endpoint serves"
+            ),
+        }
+        .into());
+    }
+
+    Ok(floor)
+}
+
 /// Resolved startup boundary shared by both producers. Backfill fills `gap` and the
 /// live RPC source resumes at `live_start_slot`, so the two meet with no hole and no
 /// overlap: `live_start_slot` is one past the highest slot backfill covers (or one past
@@ -584,6 +607,58 @@ mod tests {
 
         assert!(result.is_err(), "a failed anchor write must abort startup");
         assert_eq!(stored_checkpoint(&storage).await, None);
+    }
+
+    // ============================================================================
+    // resolve_startup_floor Tests
+    // ============================================================================
+
+    /// Backfill owns everything below the live boundary, so the floor sits one slot under it.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[test]
+    fn startup_floor_is_the_slot_below_the_live_boundary() {
+        assert_eq!(
+            resolve_startup_floor(Some(1_001), 500, 2_000).unwrap(),
+            1_000
+        );
+    }
+
+    /// With no backfill there is no range to inherit and the anchor is the boundary itself.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[test]
+    fn startup_floor_falls_back_to_the_anchor() {
+        assert_eq!(resolve_startup_floor(None, 500, 2_000).unwrap(), 500);
+    }
+
+    /// A from_slot set past the chain would gate on slots that can never be produced, which
+    /// freezes the checkpoint for good. Refuse to start rather than stall silently.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[test]
+    fn startup_floor_rejects_a_boundary_above_the_chain_tip() {
+        let err = resolve_startup_floor(Some(9_001), 500, 2_000).unwrap_err();
+        assert!(
+            err.to_string().contains("9000"),
+            "the error must name the rejected floor: {err}"
+        );
+    }
+
+    /// The tip is read after the boundary is resolved, so equality is the normal case for a
+    /// deployment starting at the tip and must not be mistaken for a misconfiguration.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[test]
+    fn startup_floor_accepts_a_boundary_at_the_chain_tip() {
+        assert_eq!(
+            resolve_startup_floor(Some(2_001), 500, 2_000).unwrap(),
+            2_000
+        );
+    }
+
+    /// The anchor is the lowest slot startup owns, so a floor under it means the two were
+    /// derived from different ranges and the fill would replay below the durable checkpoint.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[test]
+    fn startup_floor_rejects_a_boundary_below_the_anchor() {
+        assert!(resolve_startup_floor(Some(401), 500, 2_000).is_err());
     }
 
     // ============================================================================

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -537,6 +537,30 @@ mod tests {
         assert_eq!(state.lag(), 0);
     }
 
+    /// A cold-start regate carries a lower `from` and a higher target than the startup gate.
+    /// The widened gate must still fold contiguously, so neither end lets a slot through.
+    #[test]
+    fn regate_over_open_startup_gate_widens_without_skipping() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        // Startup backfill is mid-flight: the gate to T0 is still open.
+        assert_eq!(drive(&mut state, &[FROM + 1, FROM + 2, FROM + 3]), FROM + 3);
+
+        // Cold start arms from the durable checkpoint, which sits below from_slot.
+        state.regate(FROM - 10, T0 + 20);
+        assert_eq!(
+            state.frontier,
+            FROM + 3,
+            "a lower from never pulls the frontier back over the unfilled startup range"
+        );
+
+        // The resume slot alone is a hole away from the frontier, so it cannot move it.
+        assert_eq!(drive(&mut state, &[T0 + 20]), FROM + 3);
+
+        // Only the full contiguous run up to the widened target hands off.
+        let rest: Vec<u64> = (FROM + 4..=T0 + 20).collect();
+        assert_eq!(drive(&mut state, &rest), T0 + 20);
+    }
+
     /// The writer's Regate handling re-gates the correct per-program state: after
     /// record_regate the gated frontier stays put and lag reflects the new target.
     #[test]

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, warn};
 use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcClient};
 use yellowstone_grpc_proto::geyser::{
     subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest, SubscribeRequestFilterBlocks,
-    SubscribeRequestPing, SubscribeUpdateTransactionInfo,
+    SubscribeRequestFilterSlots, SubscribeRequestPing, SubscribeUpdateTransactionInfo,
 };
 
 use crate::channel_utils::send_guaranteed;
@@ -616,8 +616,20 @@ async fn connect_and_stream(
         },
     );
 
+    // Slots carry the point the stream resumed at, which is what the gap gate arms on. Blocks
+    // are program-filtered, so waiting for one would measure idle time instead of the outage.
+    let mut slots = HashMap::new();
+    slots.insert(
+        "private_channel_slots".to_string(),
+        SubscribeRequestFilterSlots {
+            // Same commitment as the blocks, so the armed target is a slot they can reach.
+            filter_by_commitment: Some(true),
+            interslot_updates: Some(false),
+        },
+    );
+
     let subscribe_request = SubscribeRequest {
-        slots: HashMap::new(),
+        slots,
         accounts: HashMap::new(),
         transactions: HashMap::new(),
         transactions_status: HashMap::new(),
@@ -676,6 +688,33 @@ async fn connect_and_stream(
                     None => break,
                     Some(message) => match message {
             Ok(msg) => match msg.update_oneof {
+                // Where this stream actually resumed, so the gap is the outage and nothing
+                // else. Slots carry no transactions, so none is forwarded from here.
+                Some(UpdateOneof::Slot(slot_update)) => {
+                    #[cfg(feature = "datasource-rpc")]
+                    if let Some(ctx) = gap_ctx {
+                        if !armed {
+                            armed = true;
+                            let safe_to_forward = arm_reconnect_gap(
+                                slot_update.slot,
+                                startup_floor,
+                                ctx,
+                                &tx,
+                                &cancellation_token,
+                                RECONNECT_GAP_RETRY_BACKOFF,
+                                backfill_handle,
+                            )
+                            .await
+                            .map_err(DataSourceError::Rpc)?;
+                            // Cancelled mid-arm, so stop rather than stream on ungated.
+                            if !safe_to_forward {
+                                break;
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "datasource-rpc"))]
+                    let _ = slot_update;
+                }
                 Some(UpdateOneof::Block(block)) => {
                     metrics::INDEXER_CHAIN_TIP_SLOT
                         .with_label_values(&[program_type.as_label()])

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -53,6 +53,8 @@ pub struct YellowstoneSource {
     batch_size: usize,
     #[cfg(feature = "datasource-rpc")]
     storage: Option<Arc<Storage>>,
+    #[cfg(feature = "datasource-rpc")]
+    startup_floor: Option<u64>,
     health: Option<Arc<private_channel_metrics::HealthState>>,
     /// Silent-stream watchdog window. Defaults to STREAM_STALL_TIMEOUT; overridable
     /// (mainly so tests can drive the reconnect path without a 120s wait).
@@ -81,6 +83,8 @@ impl YellowstoneSource {
             batch_size: 0,
             #[cfg(feature = "datasource-rpc")]
             storage: None,
+            #[cfg(feature = "datasource-rpc")]
+            startup_floor: None,
             health: None,
             stall_timeout: STREAM_STALL_TIMEOUT,
         }
@@ -110,11 +114,18 @@ impl YellowstoneSource {
         self
     }
 
-    /// Storage holds the durable checkpoint that anchors reconnect backfill.
-    /// Without it, reconnect gap-fill is a no-op.
+    /// Holds the durable checkpoint that anchors gap repair; without it the gate never arms.
     #[cfg(feature = "datasource-rpc")]
     pub fn with_storage(mut self, storage: Arc<Storage>) -> Self {
         self.storage = Some(storage);
+        self
+    }
+
+    /// Highest slot startup already owns, taken once by whichever connection arms the gate first.
+    /// It raises that gate's target so a cold start cannot narrow a startup gate, and bounds the fill.
+    #[cfg(feature = "datasource-rpc")]
+    pub fn with_startup_floor(mut self, slot: u64) -> Self {
+        self.startup_floor = Some(slot);
         self
     }
 }
@@ -158,6 +169,7 @@ enum GapFillOutcome {
 #[allow(clippy::too_many_arguments)]
 async fn fill_reconnect_gap_to<F, Fut>(
     target: u64,
+    floor: Option<u64>,
     get_checkpoint: F,
     rpc_poller: &RpcPoller,
     max_gap_slots: u64,
@@ -177,36 +189,38 @@ where
             return GapFillOutcome::Cancelled;
         }
 
-        // Re-read every cycle so an operator resync moves the anchor without a restart.
-        let checkpoint = match get_checkpoint().await {
-            Ok(Some(slot)) => slot,
-            // No anchor means no lower bound to replay from, so resolving here would let
-            // the caller forward live slots over an interval nothing has covered. Retry
-            // instead: startup writes an anchor before any live block, so this only shows
-            // up if the checkpoint row was destroyed underneath a running indexer.
-            Ok(None) => {
-                error!(
-                    "Reconnect gap-fill: no durable checkpoint anchor for {:?}; holding the \
-                     checkpoint rather than skipping the gap",
-                    program_type
-                );
-                record_missing_anchor(program_type);
-                if backoff_cancelled(cancel, backoff).await {
-                    return GapFillOutcome::Cancelled;
+        // A cold start is handed the slot startup already owns, so there is nothing to derive.
+        let checkpoint = match floor {
+            Some(slot) => slot,
+            // Re-read every cycle so an operator resync moves the anchor without a restart.
+            None => match get_checkpoint().await {
+                Ok(Some(slot)) => slot,
+                // With no anchor there is no lower bound to replay from, so resolving here
+                // would forward live slots over an interval nobody read. Retry instead.
+                Ok(None) => {
+                    error!(
+                        "Reconnect gap-fill: no durable checkpoint anchor for {:?}; holding the \
+                         checkpoint rather than skipping the gap",
+                        program_type
+                    );
+                    record_missing_anchor(program_type);
+                    if backoff_cancelled(cancel, backoff).await {
+                        return GapFillOutcome::Cancelled;
+                    }
+                    continue;
                 }
-                continue;
-            }
-            Err(e) => {
-                warn!(
-                    "Reconnect gap-fill: checkpoint read failed, retrying: {}",
-                    e
-                );
-                record_gap_fill_error(program_type);
-                if backoff_cancelled(cancel, backoff).await {
-                    return GapFillOutcome::Cancelled;
+                Err(e) => {
+                    warn!(
+                        "Reconnect gap-fill: checkpoint read failed, retrying: {}",
+                        e
+                    );
+                    record_gap_fill_error(program_type);
+                    if backoff_cancelled(cancel, backoff).await {
+                        return GapFillOutcome::Cancelled;
+                    }
+                    continue;
                 }
-                continue;
-            }
+            },
         };
 
         let gap = match validate_gap(target, checkpoint, max_gap_slots) {
@@ -281,8 +295,8 @@ where
     }
 }
 
-/// Context threaded to `connect_and_stream` so it can, on the first live block of a
-/// reconnect, observe the resume slot and arm the gate + concurrent backfill.
+/// What `connect_and_stream` needs to arm the gate and backfill on a connection's first block.
+/// Built once per source task; `None` when storage or the poller is missing, disabling repair.
 #[cfg(feature = "datasource-rpc")]
 struct ReconnectGapCtx {
     poller: Arc<RpcPoller>,
@@ -293,9 +307,8 @@ struct ReconnectGapCtx {
     escrow_instance_id: Option<Pubkey>,
 }
 
-/// Arm the reconnect gate over `(checkpoint, t_sub]` carrying `from` so the writer anchors
-/// the fold at the durable checkpoint, then spawn a bounded backfill (one in-flight; any
-/// prior is aborted). Sent before the first live block so the gate wins the FIFO race.
+/// Gate the checkpoint up to the slot this stream opened at, or to `floor` when that is higher,
+/// then spawn a backfill for the window. Sent first so the gate beats that block's SlotComplete.
 #[cfg(feature = "datasource-rpc")]
 /// Returns whether it is safe to forward the block that triggered this arm. `false`
 /// means cancellation ended the wait before the gate was armed, so the caller must NOT
@@ -304,20 +317,22 @@ struct ReconnectGapCtx {
 /// the gate is armed and the block is safe to hand on.
 async fn arm_reconnect_gap(
     t_sub: u64,
+    floor: Option<u64>,
     ctx: &ReconnectGapCtx,
     tx: &InstructionSender,
     cancel: &CancellationToken,
     backoff: Duration,
     prev: &mut Option<tokio::task::JoinHandle<()>>,
 ) -> Result<bool, DataSourceRpcError> {
+    // Never below what startup still owes, so its gate is widened rather than narrowed.
+    let target = floor.map_or(t_sub, |slot| t_sub.max(slot));
+
     // Resolve the anchor before arming, because the gate seeds its frontier from it.
     let checkpoint = loop {
         match get_last_checkpoint(&ctx.storage, ctx.program_type).await {
             Ok(Some(slot)) => break slot,
-            // An anchor at slot zero is a real anchor and gets repaired like any other.
-            // Absence is different: without a lower bound there is nothing to replay
-            // from, so forwarding this block would let its SlotComplete carry the
-            // checkpoint over slots no one has read. Wait for an anchor instead.
+            // Slot zero is a real anchor and repairs like any other, but absence has no lower
+            // bound, so forwarding here would carry the checkpoint over unread slots. Hold.
             Ok(None) => {
                 error!(
                     "Reconnect gap: no durable checkpoint anchor for {:?}; withholding live \
@@ -344,7 +359,7 @@ async fn arm_reconnect_gap(
         ProcessorMessage::Regate {
             program_type: ctx.program_type,
             from: checkpoint,
-            target: t_sub,
+            target,
         },
         "Regate (yellowstone)",
     )
@@ -369,7 +384,8 @@ async fn arm_reconnect_gap(
 
     let handle = tokio::spawn(async move {
         fill_reconnect_gap_to(
-            t_sub,
+            target,
+            floor,
             || get_last_checkpoint(&storage, program_type),
             &poller,
             max_gap_slots,
@@ -450,9 +466,11 @@ impl DataSource for YellowstoneSource {
         let batch_size = self.batch_size;
         #[cfg(feature = "datasource-rpc")]
         let storage = self.storage.clone();
+        #[cfg(feature = "datasource-rpc")]
+        let startup_floor = self.startup_floor;
 
         let handle = tokio::spawn(async move {
-            // Reconnect gate context, built once; None disables reconnect gating.
+            // Gap gate context, built once; None disables gap gating for this source.
             #[cfg(feature = "datasource-rpc")]
             let gap_ctx_opt = match (rpc_poller, storage) {
                 (Some(poller), Some(storage)) => Some(ReconnectGapCtx {
@@ -465,29 +483,18 @@ impl DataSource for YellowstoneSource {
                 }),
                 _ => None,
             };
-            // One in-flight reconnect backfill, owned here and superseded on each reconnect.
+            // One in-flight gap backfill, owned here and superseded on each connection.
             #[cfg(feature = "datasource-rpc")]
             let mut backfill_handle: Option<tokio::task::JoinHandle<()>> = None;
-            // True once some connection has subscribed. Only later connections arm the
-            // reconnect gate; the first stream is a cold start that startup backfill
-            // already covers. A connect that fails before subscribing does not count.
+            // Taken by whichever connection arms first; every later one anchors on the checkpoint.
             #[cfg(feature = "datasource-rpc")]
-            let mut ever_streamed = false;
+            let mut startup_floor = startup_floor;
 
             loop {
                 if cancellation_token.is_cancelled() {
                     info!("Yellowstone source received cancellation signal, stopping...");
                     break;
                 }
-
-                #[cfg(feature = "datasource-rpc")]
-                let gap_ctx = if ever_streamed {
-                    gap_ctx_opt.as_ref()
-                } else {
-                    None
-                };
-                #[cfg(feature = "datasource-rpc")]
-                let mut subscribed = false;
 
                 match connect_and_stream(
                     &endpoint,
@@ -499,11 +506,11 @@ impl DataSource for YellowstoneSource {
                     health.as_ref(),
                     stall_timeout,
                     #[cfg(feature = "datasource-rpc")]
-                    gap_ctx,
+                    gap_ctx_opt.as_ref(),
                     #[cfg(feature = "datasource-rpc")]
                     &mut backfill_handle,
                     #[cfg(feature = "datasource-rpc")]
-                    &mut subscribed,
+                    &mut startup_floor,
                 )
                 .await
                 {
@@ -532,11 +539,6 @@ impl DataSource for YellowstoneSource {
                         }
                     }
                 }
-
-                #[cfg(feature = "datasource-rpc")]
-                if subscribed {
-                    ever_streamed = true;
-                }
             }
 
             info!("Yellowstone source stopped gracefully");
@@ -561,13 +563,12 @@ async fn connect_and_stream(
     cancellation_token: CancellationToken,
     health: Option<&Arc<private_channel_metrics::HealthState>>,
     stall_timeout: std::time::Duration,
-    // Present only on reconnects (after the first connection). When set, the first
-    // live block arms the gate + backfill so the residual window cannot be leapfrogged.
+    // Set on every connection, the first one included, so that connection's first live block
+    // gates the window below it. A process start and a stream resume are the same event here.
     #[cfg(feature = "datasource-rpc")] gap_ctx: Option<&ReconnectGapCtx>,
     #[cfg(feature = "datasource-rpc")] backfill_handle: &mut Option<tokio::task::JoinHandle<()>>,
-    // Set true once this connection subscribes, so the caller can tell a real streaming
-    // session apart from a connect failure that never reached the reconnect-gating state.
-    #[cfg(feature = "datasource-rpc")] subscribed: &mut bool,
+    // The slot startup already owns, consumed by whichever connection arms the gate first.
+    #[cfg(feature = "datasource-rpc")] startup_floor: &mut Option<u64>,
 ) -> Result<(), DataSourceError> {
     let mut client = GeyserGrpcClient::build_from_shared(endpoint.to_string())
         .map_err(|e| DataSourceRpcError::Protocol {
@@ -633,13 +634,7 @@ async fn connect_and_stream(
             reason: e.to_string(),
         })?;
 
-    // A subscribe handshake succeeded; from here the next connection is a reconnect.
-    #[cfg(feature = "datasource-rpc")]
-    {
-        *subscribed = true;
-    }
-
-    // Arm the reconnect gate on the first live block of this connection only.
+    // Arm the gap gate on the first live block of this connection only.
     #[cfg(feature = "datasource-rpc")]
     let mut armed = false;
 
@@ -690,15 +685,15 @@ async fn connect_and_stream(
                         block.transactions.len()
                     );
 
-                    // First live block after a reconnect: observe the resume slot and
-                    // arm the gate + concurrent backfill BEFORE forwarding this block,
-                    // so its SlotComplete cannot leapfrog the still-unfilled window.
+                    // Arm the gate and backfill BEFORE forwarding this block, so its
+                    // SlotComplete cannot leapfrog the window still unfilled underneath it.
                     #[cfg(feature = "datasource-rpc")]
                     if let Some(ctx) = gap_ctx {
                         if !armed {
                             armed = true;
                             let safe_to_forward = arm_reconnect_gap(
                                 block.slot,
+                                startup_floor.take(),
                                 ctx,
                                 &tx,
                                 &cancellation_token,
@@ -858,6 +853,7 @@ mod tests {
 
         let outcome = fill_reconnect_gap_to(
             100,
+            None,
             checkpoint_ok(100),
             &poller,
             1000,
@@ -895,6 +891,7 @@ mod tests {
 
         let outcome = fill_reconnect_gap_to(
             103,
+            None,
             checkpoint_ok(100),
             &poller,
             1000,
@@ -933,6 +930,7 @@ mod tests {
         let mut handle = tokio::spawn(async move {
             fill_reconnect_gap_to(
                 100,
+                None,
                 checkpoint_absent(),
                 &poller,
                 1000,
@@ -983,6 +981,7 @@ mod tests {
 
         let outcome = fill_reconnect_gap_to(
             3,
+            None,
             checkpoint_ok(0),
             &poller,
             1000,
@@ -1034,6 +1033,7 @@ mod tests {
         // target == checkpoint => no gap once the read heals.
         let outcome = fill_reconnect_gap_to(
             100,
+            None,
             get_checkpoint,
             &poller,
             1000,
@@ -1087,6 +1087,7 @@ mod tests {
         let mut handle = tokio::spawn(async move {
             fill_reconnect_gap_to(
                 103,
+                None,
                 checkpoint_ok(100),
                 &poller,
                 1000,
@@ -1150,6 +1151,7 @@ mod tests {
         let mut handle = tokio::spawn(async move {
             fill_reconnect_gap_to(
                 200,
+                None,
                 checkpoint_ok(100),
                 &poller,
                 10,
@@ -1199,6 +1201,7 @@ mod tests {
         let handle = tokio::spawn(async move {
             fill_reconnect_gap_to(
                 103,
+                None,
                 get_checkpoint,
                 &poller,
                 1000,
@@ -1238,7 +1241,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        arm_reconnect_gap(103, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
@@ -1263,6 +1266,94 @@ mod tests {
         assert_eq!(slots, vec![100, 101, 102, 103]);
     }
 
+    /// A lagging provider can open the stream below the slot startup backfill is still filling.
+    /// Gating there would free the checkpoint over that range, so the floor has to win.
+    #[tokio::test]
+    async fn arm_cold_start_raises_target_to_the_startup_floor() {
+        let mut server = Server::new_async().await;
+        let no_blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let ctx = test_gap_ctx(&server, storage_with_checkpoint(100), 1000);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+
+        // Startup owns up to 110; the stream opened at 103, seven slots behind it.
+        arm_reconnect_gap(103, Some(110), &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut msgs = vec![];
+        while let Some(m) = rx.recv().await {
+            msgs.push(m);
+        }
+        prev.unwrap().await.unwrap();
+
+        assert!(
+            matches!(
+                msgs[0],
+                ProcessorMessage::Regate {
+                    from: 100,
+                    target: 110,
+                    ..
+                }
+            ),
+            "the gate must widen to the floor, not narrow to the resume slot: {:?}",
+            msgs[0]
+        );
+        // Startup backfill covers everything up to the floor, so this fill has nothing to do.
+        assert_eq!(msgs.len(), 1, "no slot may be refetched below the floor");
+        no_blocks.assert_async().await;
+    }
+
+    /// The checkpoint can sit far below the floor, so replaying from it would refetch slots
+    /// startup owns or that start_slot meant to skip. The fill anchors on the floor instead.
+    #[tokio::test]
+    async fn cold_start_fill_starts_at_the_floor_not_the_checkpoint() {
+        let mut server = Server::new_async().await;
+        let _enum = mock_dense_range(&mut server, 100, 103);
+        let _blocks: Vec<_> = (100..=103)
+            .map(|s| mock_get_block_success(&mut server, s))
+            .collect();
+
+        let poller = test_poller(&server);
+        let (tx, mut rx) = mpsc::channel(256);
+        let cancel = CancellationToken::new();
+
+        let outcome = fill_reconnect_gap_to(
+            103,
+            Some(100),
+            checkpoint_ok(10),
+            &poller,
+            1000,
+            10,
+            ProgramType::Escrow,
+            None,
+            &tx,
+            &cancel,
+            TEST_BACKOFF,
+        )
+        .await;
+        drop(tx);
+
+        assert_eq!(outcome, GapFillOutcome::Resolved);
+        let mut slots = vec![];
+        while let Some(ProcessorMessage::SlotComplete { slot, .. }) = rx.recv().await {
+            slots.push(slot);
+        }
+        assert_eq!(
+            slots,
+            vec![100, 101, 102, 103],
+            "the fill must start at the floor, not walk up from checkpoint 10"
+        );
+    }
+
     /// No anchor means the block is unsafe to forward; letting it through was the bug.
     #[tokio::test]
     async fn arm_reconnect_gap_missing_anchor_withholds_block() {
@@ -1282,7 +1373,7 @@ mod tests {
         cancel.cancel();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        let safe = arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        let safe = arm_reconnect_gap(103, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
@@ -1326,7 +1417,7 @@ mod tests {
         cancel.cancel();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        let safe = arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        let safe = arm_reconnect_gap(103, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
@@ -1357,13 +1448,13 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        arm_reconnect_gap(1000, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        arm_reconnect_gap(1000, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         let first = prev.as_ref().unwrap().abort_handle();
         assert!(!first.is_finished(), "first backfill is still in flight");
 
-        arm_reconnect_gap(1000, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        arm_reconnect_gap(1000, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
 

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -189,15 +189,15 @@ where
             return GapFillOutcome::Cancelled;
         }
 
-        // A cold start is handed the slot startup already owns, so there is nothing to derive.
-        let checkpoint = match floor {
-            Some(slot) => slot,
-            // Re-read every cycle so an operator resync moves the anchor without a restart.
-            None => match get_checkpoint().await {
-                Ok(Some(slot)) => slot,
-                // With no anchor there is no lower bound to replay from, so resolving here
-                // would forward live slots over an interval nobody read. Retry instead.
-                Ok(None) => {
+        // Re-read every cycle so an operator resync moves the anchor without a restart. A cold
+        // start keeps its floor as the lower bound, so a stale checkpoint cannot drag it down.
+        let checkpoint = match get_checkpoint().await {
+            Ok(Some(slot)) => floor.map_or(slot, |f| f.max(slot)),
+            // With no anchor there is no lower bound to replay from, so resolving here
+            // would forward live slots over an interval nobody read. Retry instead.
+            Ok(None) => match floor {
+                Some(slot) => slot,
+                None => {
                     error!(
                         "Reconnect gap-fill: no durable checkpoint anchor for {:?}; holding the \
                          checkpoint rather than skipping the gap",
@@ -209,7 +209,11 @@ where
                     }
                     continue;
                 }
-                Err(e) => {
+            },
+            // The floor is a durable bound of its own, so a failed read need not stall a cold start.
+            Err(e) => match floor {
+                Some(slot) => slot,
+                None => {
                     warn!(
                         "Reconnect gap-fill: checkpoint read failed, retrying: {}",
                         e
@@ -806,6 +810,13 @@ mod tests {
         )
     }
 
+    /// An anchor an operator can move mid-run, so the retry loop can be seen re-reading it.
+    fn checkpoint_shared(
+        slot: Arc<std::sync::atomic::AtomicU64>,
+    ) -> impl Fn() -> std::future::Ready<Result<Option<u64>, CheckpointError>> {
+        move || std::future::ready(Ok(Some(slot.load(std::sync::atomic::Ordering::SeqCst))))
+    }
+
     /// A durable anchor at `slot`.
     fn checkpoint_ok(
         slot: u64,
@@ -1350,6 +1361,62 @@ mod tests {
 
         assert!(armed);
         assert_eq!(floor, None, "a spent floor must not be reused");
+    }
+
+    /// An oversized gap clears when an operator resyncs the checkpoint above the floor. Pinning
+    /// the anchor to the floor would make every retry read the same slot and never recover.
+    #[tokio::test]
+    async fn cold_start_fill_recovers_when_the_checkpoint_is_resynced() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let mut server = Server::new_async().await;
+        let _enum = mock_dense_range(&mut server, 995, 1000);
+        let _blocks: Vec<_> = (995..=1000)
+            .map(|s| mock_get_block_success(&mut server, s))
+            .collect();
+
+        let poller = test_poller(&server);
+        let (tx, _rx) = mpsc::channel(256);
+        let cancel = CancellationToken::new();
+        // Gap 1000 - 100 is far over the bound, so the fill can only spin here.
+        let checkpoint = Arc::new(AtomicU64::new(100));
+
+        let fill = tokio::spawn({
+            let checkpoint = checkpoint.clone();
+            let cancel = cancel.clone();
+            let url = server.url();
+            async move {
+                let poller =
+                    RpcPoller::new(url, UiTransactionEncoding::Json, CommitmentLevel::Finalized);
+                fill_reconnect_gap_to(
+                    1000,
+                    Some(100),
+                    checkpoint_shared(checkpoint),
+                    &poller,
+                    10,
+                    10,
+                    ProgramType::Escrow,
+                    None,
+                    &tx,
+                    &cancel,
+                    TEST_BACKOFF,
+                )
+                .await
+            }
+        });
+
+        // Several retries at this backoff, so the first verdict is provably not the last.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!fill.is_finished(), "an oversized gap must not resolve");
+
+        checkpoint.store(995, Ordering::SeqCst);
+
+        let outcome = tokio::time::timeout(Duration::from_secs(10), fill)
+            .await
+            .expect("the resynced checkpoint must let the fill proceed")
+            .unwrap();
+        assert!(matches!(outcome, GapFillOutcome::Resolved));
+        drop(poller);
     }
 
     /// An arm that gives up leaves no gate behind, so the next connection still needs the

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -317,15 +317,17 @@ struct ReconnectGapCtx {
 /// the gate is armed and the block is safe to hand on.
 async fn arm_reconnect_gap(
     t_sub: u64,
-    floor: Option<u64>,
+    floor: &mut Option<u64>,
     ctx: &ReconnectGapCtx,
     tx: &InstructionSender,
     cancel: &CancellationToken,
     backoff: Duration,
     prev: &mut Option<tokio::task::JoinHandle<()>>,
 ) -> Result<bool, DataSourceRpcError> {
+    // Held rather than taken: every path that leaves without a gate must return it unspent.
+    let floor_slot = *floor;
     // Never below what startup still owes, so its gate is widened rather than narrowed.
-    let target = floor.map_or(t_sub, |slot| t_sub.max(slot));
+    let target = floor_slot.map_or(t_sub, |slot| t_sub.max(slot));
 
     // Resolve the anchor before arming, because the gate seeds its frontier from it.
     let checkpoint = loop {
@@ -385,7 +387,7 @@ async fn arm_reconnect_gap(
     let handle = tokio::spawn(async move {
         fill_reconnect_gap_to(
             target,
-            floor,
+            floor_slot,
             || get_last_checkpoint(&storage, program_type),
             &poller,
             max_gap_slots,
@@ -399,6 +401,8 @@ async fn arm_reconnect_gap(
         .await;
     });
     *prev = Some(handle);
+    // The gate is set and the fill owns the range, so no later connection may claim it again.
+    *floor = None;
     Ok(true)
 }
 
@@ -693,7 +697,7 @@ async fn connect_and_stream(
                             armed = true;
                             let safe_to_forward = arm_reconnect_gap(
                                 block.slot,
-                                startup_floor.take(),
+                                startup_floor,
                                 ctx,
                                 &tx,
                                 &cancellation_token,
@@ -1241,7 +1245,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        arm_reconnect_gap(103, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        arm_reconnect_gap(103, &mut None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
@@ -1284,9 +1288,17 @@ mod tests {
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
         // Startup owns up to 110; the stream opened at 103, seven slots behind it.
-        arm_reconnect_gap(103, Some(110), &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
-            .await
-            .unwrap();
+        arm_reconnect_gap(
+            103,
+            &mut Some(110),
+            &ctx,
+            &tx,
+            &cancel,
+            TEST_BACKOFF,
+            &mut prev,
+        )
+        .await
+        .unwrap();
         drop(tx);
 
         let mut msgs = vec![];
@@ -1310,6 +1322,57 @@ mod tests {
         // Startup backfill covers everything up to the floor, so this fill has nothing to do.
         assert_eq!(msgs.len(), 1, "no slot may be refetched below the floor");
         no_blocks.assert_async().await;
+    }
+
+    /// Only one connection may spend the floor, so a completed arm has to clear it.
+    #[tokio::test]
+    async fn arm_clears_the_startup_floor_once_the_gate_is_set() {
+        let mut server = Server::new_async().await;
+        let _no_blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let ctx = test_gap_ctx(&server, storage_with_checkpoint(100), 1000);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+        let mut floor = Some(110);
+
+        let armed = arm_reconnect_gap(103, &mut floor, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+        drop(tx);
+        while rx.recv().await.is_some() {}
+        prev.unwrap().await.unwrap();
+
+        assert!(armed);
+        assert_eq!(floor, None, "a spent floor must not be reused");
+    }
+
+    /// An arm that gives up leaves no gate behind, so the next connection still needs the
+    /// floor. Dropping it there would let that connection gate below what startup owes.
+    #[tokio::test]
+    async fn arm_keeps_the_startup_floor_when_it_cannot_arm() {
+        use crate::storage::common::storage::mock::MockStorage;
+
+        let server = Server::new_async().await;
+        // No checkpoint to anchor on, so the arm parks until cancellation ends it.
+        let ctx = test_gap_ctx(&server, Arc::new(Storage::Mock(MockStorage::new())), 1000);
+        let (tx, _rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+        let mut floor = Some(110);
+
+        let armed = arm_reconnect_gap(103, &mut floor, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+
+        assert!(!armed, "no gate was set");
+        assert_eq!(floor, Some(110), "the floor must survive for the next arm");
     }
 
     /// The checkpoint can sit far below the floor, so replaying from it would refetch slots
@@ -1373,7 +1436,7 @@ mod tests {
         cancel.cancel();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        let safe = arm_reconnect_gap(103, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        let safe = arm_reconnect_gap(103, &mut None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
@@ -1417,7 +1480,7 @@ mod tests {
         cancel.cancel();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        let safe = arm_reconnect_gap(103, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        let safe = arm_reconnect_gap(103, &mut None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         drop(tx);
@@ -1448,13 +1511,13 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut prev: Option<tokio::task::JoinHandle<()>> = None;
 
-        arm_reconnect_gap(1000, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        arm_reconnect_gap(1000, &mut None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
         let first = prev.as_ref().unwrap().abort_handle();
         assert!(!first.is_finished(), "first backfill is still in flight");
 
-        arm_reconnect_gap(1000, None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+        arm_reconnect_gap(1000, &mut None, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
             .await
             .unwrap();
 

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -318,7 +318,7 @@ pub async fn run(
                 // before the stream can deliver anything. Failing here refuses to start,
                 // which beats streaming past a window that could never be recovered: once a
                 // later slot is checkpointed, the slots below it stop being reachable.
-                ensure_startup_anchor(
+                let anchor = ensure_startup_anchor(
                     &storage,
                     common_config.program_type,
                     &gap_rpc_poller,
@@ -326,7 +326,13 @@ pub async fn run(
                 )
                 .await?;
 
+                // Startup owns everything below its live boundary, so the first stream only
+                // replays above it. With no backfill the anchor is that boundary itself.
+                let startup_floor =
+                    rpc_live_start_slot.map_or(anchor, |slot| slot.saturating_sub(1));
+
                 source
+                    .with_startup_floor(startup_floor)
                     .with_gap_detection(
                         gap_rpc_poller,
                         indexer_config.backfill.max_gap_slots,

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -30,7 +30,9 @@ use crate::{
 use std::time::Duration;
 
 #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
-use crate::indexer::backfill::ensure_startup_anchor;
+use crate::indexer::backfill::{
+    ensure_startup_anchor, latest_slot_with_retry, resolve_startup_floor,
+};
 
 #[cfg(feature = "datasource-rpc")]
 use crate::indexer::datasource::rpc_polling::{rpc::RpcPoller, RpcPollingSource};
@@ -666,9 +668,10 @@ pub async fn run(
                 .await?;
 
                 // Startup owns everything below its live boundary, so the first stream only
-                // replays above it. With no backfill the anchor is that boundary itself.
-                let startup_floor =
-                    rpc_live_start_slot.map_or(anchor, |slot| slot.saturating_sub(1));
+                // replays above it. Checked against the chain the endpoint actually serves,
+                // because a floor past the tip would gate on slots that never arrive.
+                let tip = latest_slot_with_retry(&gap_rpc_poller).await?;
+                let startup_floor = resolve_startup_floor(rpc_live_start_slot, anchor, tip)?;
 
                 source
                     .with_startup_floor(startup_floor)

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -30,9 +30,7 @@ use crate::{
 use std::time::Duration;
 
 #[cfg(all(feature = "datasource-rpc", feature = "datasource-yellowstone"))]
-use crate::indexer::backfill::{
-    ensure_startup_anchor, latest_slot_with_retry, resolve_startup_floor,
-};
+use crate::indexer::backfill::{ensure_startup_anchor, resolve_startup_floor};
 
 #[cfg(feature = "datasource-rpc")]
 use crate::indexer::datasource::rpc_polling::{rpc::RpcPoller, RpcPollingSource};
@@ -668,10 +666,8 @@ pub async fn run(
                 .await?;
 
                 // Startup owns everything below its live boundary, so the first stream only
-                // replays above it. Checked against the chain the endpoint actually serves,
-                // because a floor past the tip would gate on slots that never arrive.
-                let tip = latest_slot_with_retry(&gap_rpc_poller).await?;
-                let startup_floor = resolve_startup_floor(rpc_live_start_slot, anchor, tip)?;
+                // replays above it. With no backfill the anchor is that boundary itself.
+                let startup_floor = resolve_startup_floor(rpc_live_start_slot, anchor)?;
 
                 source
                     .with_startup_floor(startup_floor)

--- a/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
+++ b/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
@@ -1,9 +1,5 @@
-//! Reconnect gap gating for `YellowstoneSource`: after a stream drop the source
-//! resubscribes immediately, but on the first live block it arms the checkpoint gate
-//! to the observed resume slot before forwarding that block. A concurrent RPC backfill
-//! closes the residual window `(checkpoint, resume]`, and until it does the gate holds
-//! the durable checkpoint, so no live `SlotComplete` can advance it over the still
-//! missing range. An un-fillable boundary keeps the checkpoint frozen (fail-closed).
+//! Gap gating for `YellowstoneSource`. The first live block of every connection, the very first
+//! included, holds the checkpoint until a backfill closes the window below it. Fail-closed.
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::config::ProgramType;
@@ -221,6 +217,8 @@ fn make_source(ys_url: String, rpc: &MockitoServer, storage: Arc<Storage>) -> Ye
     )
     .with_gap_detection(poller(rpc), 1_000, 16)
     .with_storage(storage)
+    // What `run` passes: startup accounted for everything up to the seeded anchor.
+    .with_startup_floor(CHECKPOINT)
 }
 
 /// While the boundary slot stays pruned the gate holds the durable checkpoint at the
@@ -230,6 +228,11 @@ fn make_source(ys_url: String, rpc: &MockitoServer, storage: Arc<Storage>) -> Ye
 async fn stalled_gap_fill_gates_checkpoint_then_recovers() {
     init_tracing();
     let (_pg, storage) = start_postgres().await;
+    // The anchor `run` writes before the stream opens; without it nothing is forwarded.
+    storage
+        .update_committed_checkpoint("escrow", CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
 
     let mut rpc = MockitoServer::new_async().await;
     for s in (CHECKPOINT + 1)..=TIP {
@@ -354,6 +357,11 @@ async fn shutdown_while_gap_fill_stalled_joins_promptly() {
 async fn stalled_gap_fill_never_advances_checkpoint_over_live_tip() {
     init_tracing();
     let (_pg, storage) = start_postgres().await;
+    // The anchor `run` writes before the stream opens; without it nothing is forwarded.
+    storage
+        .update_committed_checkpoint("escrow", CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
 
     let mut rpc = MockitoServer::new_async().await;
     for s in (CHECKPOINT + 1)..=TIP {
@@ -403,6 +411,78 @@ async fn stalled_gap_fill_never_advances_checkpoint_over_live_tip() {
         ys.call_count("subscribe") >= 2,
         "the source resubscribes; the gate, not a blocked resubscribe, is the guard"
     );
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    drop(tx);
+    let _ = tokio::time::timeout(Duration::from_secs(3), processor_handle).await;
+    let _ = tokio::time::timeout(Duration::from_secs(3), writer_handle).await;
+    ys.shutdown().await;
+}
+
+/// A cold start is a reconnect as far as the checkpoint is concerned, so the very first block
+/// must gate `(checkpoint, resume]` first, or it carries the checkpoint past unread slots.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cold_start_gap_gates_checkpoint_on_first_connection() {
+    init_tracing();
+    let (_pg, storage) = start_postgres().await;
+    // The startup anchor, exactly as `ensure_startup_anchor` leaves it before `start()`.
+    storage
+        .update_committed_checkpoint("escrow", CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
+
+    let mut rpc = MockitoServer::new_async().await;
+    for s in (CHECKPOINT + 1)..=TIP {
+        let _m = mock_block_ok(&mut rpc, s).await;
+    }
+    let _produced = mock_produced_slots(&mut rpc, CHECKPOINT, TIP, &GAP_FILL_SLOTS).await;
+    let pruned = mock_block_pruned(&mut rpc, CHECKPOINT, 1).await;
+
+    let ys = MockYellowstoneServer::start().await;
+    let (tx, processor_handle, writer_handle) = spawn_pipeline(storage.clone());
+    let cancel = CancellationToken::new();
+    let mut source = make_source(ys.url(), &rpc, storage.clone());
+    let handle = source
+        .start(tx.clone(), cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // No drop_stream anywhere: every assertion below is about connection #1.
+    wait_for_subscribes(&ys, 1, 10).await;
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP)));
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP + 1)));
+
+    // A fill was attempted, so the cold start armed rather than streaming straight through.
+    wait_until_matched(
+        &pruned,
+        20,
+        "a cold-start gap-fill attempt on the pruned slot",
+    )
+    .await;
+    assert_eq!(
+        ys.call_count("subscribe"),
+        1,
+        "the gate must arm on the first connection, with no reconnect involved"
+    );
+
+    // The gate holds the anchor while the window is unfilled, though both live slots landed.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        assert_eq!(
+            storage
+                .get_committed_checkpoint("escrow")
+                .await
+                .expect("read checkpoint"),
+            Some(CHECKPOINT),
+            "checkpoint must never advance past the unfilled cold-start window"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // Heal the boundary; the fill closes (CHECKPOINT, TIP] and the gate hands off.
+    let _healed = mock_block_ok(&mut rpc, CHECKPOINT).await;
+    wait_for_checkpoint(&storage, "escrow", TIP, 30).await;
 
     cancel.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;

--- a/integration/tests/indexer/startup_anchor.rs
+++ b/integration/tests/indexer/startup_anchor.rs
@@ -10,6 +10,7 @@ use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::{
     config::{BackfillConfig, ReconciliationConfig, RpcPollingConfig, YellowstoneConfig},
     indexer::run,
+    storage::{PostgresDb, Storage},
     DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig, ProgramType,
     StorageType,
 };
@@ -32,6 +33,8 @@ const TIP: u64 = 900;
 const START_SLOT: u64 = 898;
 /// Slot the cold-start stream opens at, well above the tip so a real window sits under it.
 const COLD_START_TIP: u64 = 910;
+/// A durable checkpoint the mock RPC node has not caught up to, so the floor lands above it.
+const LAGGING_CHECKPOINT: u64 = 1_000;
 
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
@@ -428,6 +431,58 @@ async fn run_gates_the_first_block_when_backfill_is_disabled() {
     // Heal the boundary; the fill closes the window and the gate hands off.
     let _healed = mock_block_ok(&mut rpc, TIP).await;
     wait_for_checkpoint(&pool, "withdraw", COLD_START_TIP, 60).await;
+
+    handle.abort();
+    ys.shutdown().await;
+}
+
+/// An RPC node trailing the Geyser provider that wrote the checkpoint is routine, so the
+/// floor sitting above the tip it reports must not stop the boot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_starts_when_the_rpc_node_lags_the_durable_checkpoint() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("startup_anchor_lagging_rpc").await;
+
+    // Seed a checkpoint the endpoint below has not caught up to yet.
+    let seeded = Storage::Postgres(PostgresDb::new(&postgres).await.expect("postgres storage"));
+    seeded.init_schema().await.expect("init schema");
+    seeded
+        .update_committed_checkpoint("withdraw", LAGGING_CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
+    drop(seeded);
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut rpc, LAGGING_CHECKPOINT - 2).await;
+
+    let ys = MockYellowstoneServer::start().await;
+    let backfill = BackfillConfig {
+        enabled: false,
+        exit_after_backfill: false,
+        rpc_url: rpc.url(),
+        batch_size: 100,
+        max_gap_slots: 1_000,
+        start_slot: None,
+    };
+    let indexer = indexer_config(ys.url(), backfill);
+    let common = common_config(postgres, rpc.url());
+
+    let (err_tx, mut err_rx) = tokio::sync::mpsc::channel::<String>(1);
+    let handle = tokio::spawn(async move {
+        if let Err(e) = run(common, indexer, None).await {
+            let _ = err_tx.send(e.to_string()).await;
+        }
+    });
+
+    // A startup that refuses the lag would land here well inside the window.
+    if let Ok(Some(e)) = tokio::time::timeout(Duration::from_secs(20), err_rx.recv()).await {
+        panic!("a lagging RPC node must not stop startup: {e}");
+    }
+    assert_eq!(
+        anchor_of(&pool, "withdraw").await,
+        Some(LAGGING_CHECKPOINT),
+        "the durable checkpoint must survive a tip read below it"
+    );
 
     handle.abort();
     ys.shutdown().await;

--- a/integration/tests/indexer/startup_anchor.rs
+++ b/integration/tests/indexer/startup_anchor.rs
@@ -18,14 +18,20 @@ use solana_sdk::commitment_config::CommitmentLevel;
 use solana_transaction_status::UiTransactionEncoding;
 use sqlx::PgPool;
 use std::time::Duration;
-use test_utils::mock_yellowstone::MockYellowstoneServer;
+use test_utils::mock_yellowstone::{MockYellowstoneServer, Update, UpdateMatcher};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
+
+#[path = "yellowstone_helpers.rs"]
+mod yellowstone_helpers;
+use yellowstone_helpers::empty_block;
 
 /// Chain tip both tests' mock RPC reports.
 const TIP: u64 = 900;
 /// First slot to process when backfill is on, so the floor 897 stays distinct from the tip.
 const START_SLOT: u64 = 898;
+/// Slot the cold-start stream opens at, well above the tip so a real window sits under it.
+const COLD_START_TIP: u64 = 910;
 
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
@@ -131,6 +137,90 @@ async fn mock_get_slot(rpc: &mut MockitoServer, slot: u64) -> mockito::Mock {
         .with_body(json!({"jsonrpc": "2.0", "result": slot, "id": 1}).to_string())
         .create_async()
         .await
+}
+
+fn empty_block_json() -> serde_json::Value {
+    json!({
+        "blockhash": "TestBlockHash11111111111111111111111111111",
+        "parentSlot": 0,
+        "transactions": []
+    })
+}
+
+async fn mock_block_ok(rpc: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    rpc.mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [slot]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": empty_block_json(), "id": 1}).to_string())
+        .create_async()
+        .await
+}
+
+/// The enumeration lists this slot as a producer but getBlock will not serve it, so the
+/// poller reports it unavailable and the fill stalls with the gate still closed.
+async fn mock_block_pruned(rpc: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    rpc.mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [slot]}),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "jsonrpc": "2.0",
+                "error": { "code": -32009, "message": "Slot was skipped" },
+                "id": 1
+            })
+            .to_string(),
+        )
+        .expect_at_least(1)
+        .create_async()
+        .await
+}
+
+async fn wait_for_subscribes(ys: &MockYellowstoneServer, n: usize, secs: u64) {
+    tokio::time::timeout(Duration::from_secs(secs), async {
+        while ys.call_count("subscribe") < n {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "expected {} subscribe handshakes, got {}",
+            n,
+            ys.call_count("subscribe")
+        )
+    });
+}
+
+async fn wait_until_matched(mock: &mockito::Mock, secs: u64, what: &str) {
+    tokio::time::timeout(Duration::from_secs(secs), async {
+        while !mock.matched_async().await {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
+}
+
+async fn wait_for_checkpoint(pool: &PgPool, program: &str, want: u64, secs: u64) {
+    let mut last = None;
+    let reached = tokio::time::timeout(Duration::from_secs(secs), async {
+        loop {
+            last = anchor_of(pool, program).await;
+            if last == Some(want) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await;
+    assert!(
+        reached.is_ok(),
+        "checkpoint never reached {want}; last was {last:?}"
+    );
 }
 
 /// The shipped Yellowstone deployment runs with backfill disabled. Nothing resolves a
@@ -259,6 +349,85 @@ async fn run_anchors_at_resolved_from_slot_not_the_tip() {
          or the live start slot ({})",
         TIP + 1
     );
+
+    handle.abort();
+    ys.shutdown().await;
+}
+
+/// With backfill disabled nothing fills the window between the anchor and the slot the stream
+/// opens at, so without cold-start arming the first live block checkpoints straight over it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_gates_the_first_block_when_backfill_is_disabled() {
+    init_tracing();
+    let (_pg, pool, postgres) = start_postgres("cold_start_no_backfill").await;
+
+    let mut rpc = MockitoServer::new_async().await;
+    // No backfill resolves a boundary, so the anchor and the floor are both the tip.
+    let _slot = mock_get_slot(&mut rpc, TIP).await;
+    // The fill replays the anchor itself, so its range starts one slot below.
+    let produced: Vec<u64> = (TIP - 1..=COLD_START_TIP).collect();
+    let _enumeration = rpc
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getBlocks"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": produced, "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    for slot in TIP + 1..=COLD_START_TIP {
+        let _block = mock_block_ok(&mut rpc, slot).await;
+    }
+    // Holds the window open so the gate can be observed doing its job.
+    let pruned = mock_block_pruned(&mut rpc, TIP).await;
+
+    let ys = MockYellowstoneServer::start().await;
+
+    let backfill = BackfillConfig {
+        enabled: false,
+        exit_after_backfill: false,
+        rpc_url: rpc.url(),
+        batch_size: 100,
+        max_gap_slots: 1_000,
+        start_slot: None,
+    };
+    let indexer = indexer_config(ys.url(), backfill);
+    let common = common_config(postgres, rpc.url());
+
+    // Surface a startup failure instead of letting it look like a missing anchor.
+    let handle = tokio::spawn(async move {
+        if let Err(e) = run(common, indexer, None).await {
+            eprintln!("indexer run exited: {e}");
+        }
+    });
+
+    assert_eq!(wait_for_anchor(&pool, "withdraw", 60).await, TIP);
+
+    // One connection, no drop: everything below is about the very first stream.
+    wait_for_subscribes(&ys, 1, 30).await;
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(COLD_START_TIP)));
+
+    // A fill was attempted, so the cold start armed even with backfill switched off.
+    wait_until_matched(&pruned, 30, "a cold-start gap-fill attempt").await;
+    assert_eq!(
+        ys.call_count("subscribe"),
+        1,
+        "the gate must arm on the first connection, with no reconnect involved"
+    );
+
+    // The live block landed, but the checkpoint may not pass the window under it.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        assert_eq!(
+            anchor_of(&pool, "withdraw").await,
+            Some(TIP),
+            "checkpoint must never advance past the unfilled cold-start window"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // Heal the boundary; the fill closes the window and the gate hands off.
+    let _healed = mock_block_ok(&mut rpc, TIP).await;
+    wait_for_checkpoint(&pool, "withdraw", COLD_START_TIP, 60).await;
 
     handle.abort();
     ys.shutdown().await;

--- a/integration/tests/indexer/yellowstone_helpers.rs
+++ b/integration/tests/indexer/yellowstone_helpers.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use private_channel_indexer::indexer::datasource::common::parser::escrow::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
 use yellowstone_grpc_proto::geyser::{
-    subscribe_update::UpdateOneof, SubscribeUpdate, SubscribeUpdateBlock,
+    subscribe_update::UpdateOneof, SubscribeUpdate, SubscribeUpdateBlock, SubscribeUpdateSlot,
     SubscribeUpdateTransactionInfo,
 };
 use yellowstone_grpc_proto::solana::storage::confirmed_block::{
@@ -35,6 +35,18 @@ pub fn block(slot: u64, txs: Vec<SubscribeUpdateTransactionInfo>) -> SubscribeUp
 /// A produced block with no program transactions still completes its slot.
 pub fn empty_block(slot: u64) -> SubscribeUpdate {
     block(slot, vec![])
+}
+
+/// The stream's own resume point. Carries no transactions, so it only arms the gap gate.
+pub fn slot_update(slot: u64) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: vec!["private_channel_slots".to_string()],
+        update_oneof: Some(UpdateOneof::Slot(SubscribeUpdateSlot {
+            slot,
+            ..Default::default()
+        })),
+        created_at: None,
+    }
 }
 
 /// The DepositEvent CPI payload the escrow parser reads the authoritative

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -1,9 +1,5 @@
-//! Reconnect-gap recovery for `YellowstoneSource`.
-//!
-//! After a Yellowstone disconnect, the source reads the durable checkpoint
-//! from storage and passes `checkpoint - 1`
-//! to `fill_slot_range` so the boundary slot is replayed via RPC. Tx/mint
-//! inserts are idempotent, so replaying is safe.
+//! Gap recovery for `YellowstoneSource`. On the first live block of any connection, cold start or
+//! reconnect, it replays from `checkpoint - 1`; inserts are idempotent, so refetching is safe.
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::config::ProgramType;
@@ -188,12 +184,10 @@ async fn gap_fill_runs_after_drop_stream() {
     server.shutdown().await;
 }
 
-/// The bug, end to end. With no durable anchor there is no lower bound to replay from, so
-/// the slot the replacement stream resumes at must be withheld. Forwarding it is what used
-/// to carry the checkpoint over the slots that arrived while nothing was listening, and
-/// once the checkpoint passed them nothing revisited them on any later restart.
+/// The bug, end to end. With no anchor there is no lower bound, so the resuming slot must be
+/// withheld; forwarding it is what carried the checkpoint over slots nothing was listening for.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn reconnect_without_anchor_withholds_live_slots() {
+async fn cold_start_without_anchor_withholds_live_slots() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter("info,private_channel_indexer=debug")
         .with_test_writer()
@@ -246,20 +240,28 @@ async fn reconnect_without_anchor_withholds_live_slots() {
         .await
         .expect("yellowstone source start");
 
-    // The first connection is a cold start and forwards its block without arming.
+    // Phase 1: the cold start must withhold too; hold well past the 5s arm backoff.
     server.enqueue(UpdateMatcher, Update::ok(empty_block(100)));
-    let first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
-        .await
-        .expect("slot 100 must be forwarded on the first connection");
+    let cold_deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+    let mut cold_leaked = vec![];
+    while tokio::time::Instant::now() < cold_deadline {
+        if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            cold_leaked.push(slot);
+        }
+    }
     assert!(
-        matches!(
-            first,
-            Some(ProcessorMessage::SlotComplete { slot: 100, .. })
-        ),
-        "expected SlotComplete for slot 100, got {first:?}"
+        cold_leaked.is_empty(),
+        "the first connection may not forward without a durable anchor; leaked: {cold_leaked:?}"
+    );
+    assert_eq!(
+        server.remaining_scripted(),
+        0,
+        "slot 100 must have been delivered to the source and withheld, not left unsent"
     );
 
-    // Drop, then resume at a later slot. Slot 101 is the value-bearing slot nobody saw.
+    // Phase 2: drop and resume at 102, the slot that would carry the checkpoint over 101.
     server.drop_stream();
     server.enqueue(UpdateMatcher, Update::ok(empty_block(102)));
 
@@ -279,9 +281,12 @@ async fn reconnect_without_anchor_withholds_live_slots() {
         "no slot may be forwarded without a durable anchor; leaked: {leaked:?}"
     );
     no_blocks.assert_async().await;
-    assert!(
-        server.call_count("subscribe") >= 2,
-        "the source resubscribes; the withheld block, not a blocked resubscribe, is the guard"
+    // Waiting for an anchor parks inside the live connection, so the drop is never seen and
+    // nothing resubscribes. Phase 1 already proved the block reached the source and was held.
+    assert_eq!(
+        server.call_count("subscribe"),
+        1,
+        "the anchor wait holds the connection open instead of cycling it"
     );
 
     cancel.cancel();

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -1,5 +1,5 @@
-//! Gap recovery for `YellowstoneSource`. On the first live block of any connection, cold start or
-//! reconnect, it replays from `checkpoint - 1`; inserts are idempotent, so refetching is safe.
+//! Gap recovery for `YellowstoneSource`. Every connection, cold start or reconnect, arms on the
+//! slot it resumed at and replays from `checkpoint - 1`; inserts are idempotent, so that is safe.
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::config::ProgramType;
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 
 #[path = "yellowstone_helpers.rs"]
 mod yellowstone_helpers;
-use yellowstone_helpers::empty_block;
+use yellowstone_helpers::{empty_block, slot_update};
 
 fn empty_block_json() -> serde_json::Value {
     json!({
@@ -490,5 +490,214 @@ async fn first_connection_arms_when_startup_backfill_anchored() {
 
     cancel.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    server.shutdown().await;
+}
+
+/// Blocks are program-filtered, so a quiet program leaves a long stretch between the resume
+/// slot and the first block. Arming on the block would measure idle time and trip the bound.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn quiet_program_arms_on_the_resume_slot_not_the_first_block() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    const CHECKPOINT: u64 = 100;
+    const RESUME: u64 = 103;
+    // Far above the resume slot, as a program left idle for a long stretch would be.
+    const FIRST_BLOCK: u64 = 5_000;
+    // Comfortably smaller than FIRST_BLOCK - CHECKPOINT, so arming there would fail closed.
+    const MAX_GAP: u64 = 100;
+
+    let mut rpc_mock = MockitoServer::new_async().await;
+    let _enumeration = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlocks", "params": [CHECKPOINT, RESUME]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": [100, 101, 102, 103], "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let mut block_mocks = Vec::new();
+    for slot in CHECKPOINT..=RESUME {
+        block_mocks.push(
+            rpc_mock
+                .mock("POST", "/")
+                .match_body(Matcher::PartialJson(
+                    json!({"method": "getBlock", "params": [slot]}),
+                ))
+                .with_status(200)
+                .with_body(
+                    json!({"jsonrpc": "2.0", "result": empty_block_json(), "id": 1}).to_string(),
+                )
+                .expect_at_least(1)
+                .create_async()
+                .await,
+        );
+    }
+    // Nothing may be fetched from the idle stretch above the resume slot.
+    let idle_stretch = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [FIRST_BLOCK]}),
+        ))
+        .expect(0)
+        .create_async()
+        .await;
+
+    let server = MockYellowstoneServer::start().await;
+    let rpc_poller = Arc::new(RpcPoller::new(
+        rpc_mock.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ));
+    let mock_storage = MockStorage::new();
+    mock_storage.set_checkpoint("escrow", CHECKPOINT);
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(mock_storage));
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
+    let cancel = CancellationToken::new();
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(rpc_poller, MAX_GAP, 16)
+    .with_storage(storage);
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // The stream resumes at RESUME, then the program stays silent until FIRST_BLOCK.
+    server.enqueue(UpdateMatcher, Update::ok(slot_update(RESUME)));
+    server.enqueue(UpdateMatcher, Update::ok(empty_block(FIRST_BLOCK)));
+
+    let mut regate: Option<(u64, u64)> = None;
+    let mut seen: HashSet<u64> = HashSet::new();
+    let wanted: HashSet<u64> = (CHECKPOINT..=RESUME).collect();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while regate.is_none() || !wanted.is_subset(&seen) {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            panic!("timed out; regate: {regate:?}, seen: {seen:?}");
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) => {
+                seen.insert(slot);
+            }
+            Ok(Some(ProcessorMessage::Regate { from, target, .. })) => {
+                regate = Some((from, target));
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("channel closed early"),
+            Err(_) => panic!("timed out; regate: {regate:?}, seen: {seen:?}"),
+        }
+    }
+
+    assert_eq!(
+        regate,
+        Some((CHECKPOINT, RESUME)),
+        "the gate must target the resume slot, not the first program block"
+    );
+    idle_stretch.assert_async().await;
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    server.shutdown().await;
+}
+
+/// A provider that sends no slot updates must still gate, falling back to the first block.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_block_still_arms_when_no_slot_update_arrives() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    const CHECKPOINT: u64 = 100;
+    const TIP: u64 = 103;
+
+    let mut rpc_mock = MockitoServer::new_async().await;
+    let _enumeration = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlocks", "params": [CHECKPOINT, TIP]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": [100, 101, 102, 103], "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let mut block_mocks = Vec::new();
+    for slot in CHECKPOINT..=TIP {
+        block_mocks.push(
+            rpc_mock
+                .mock("POST", "/")
+                .match_body(Matcher::PartialJson(
+                    json!({"method": "getBlock", "params": [slot]}),
+                ))
+                .with_status(200)
+                .with_body(
+                    json!({"jsonrpc": "2.0", "result": empty_block_json(), "id": 1}).to_string(),
+                )
+                .expect_at_least(1)
+                .create_async()
+                .await,
+        );
+    }
+
+    let server = MockYellowstoneServer::start().await;
+    let rpc_poller = Arc::new(RpcPoller::new(
+        rpc_mock.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ));
+    let mock_storage = MockStorage::new();
+    mock_storage.set_checkpoint("escrow", CHECKPOINT);
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(mock_storage));
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
+    let cancel = CancellationToken::new();
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(rpc_poller, 1_000, 16)
+    .with_storage(storage);
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // Blocks only: no slot update is ever delivered on this stream.
+    server.enqueue(UpdateMatcher, Update::ok(empty_block(TIP)));
+
+    let mut regate: Option<(u64, u64)> = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while regate.is_none() {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(ProcessorMessage::Regate { from, target, .. })) => {
+                regate = Some((from, target));
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("channel closed early"),
+            Err(_) => panic!("no gate was armed without a slot update"),
+        }
+    }
+    assert_eq!(regate, Some((CHECKPOINT, TIP)));
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
     server.shutdown().await;
 }

--- a/test_utils/src/indexer_helper.rs
+++ b/test_utils/src/indexer_helper.rs
@@ -222,7 +222,7 @@ pub async fn start_solana_indexer(
     let backfill_config = BackfillConfig {
         enabled: true,
         batch_size: 100,
-        max_gap_slots: 100,
+        max_gap_slots: 1_000,
         exit_after_backfill: false,
         rpc_url: rpc_url.clone(),
         start_slot: None,


### PR DESCRIPTION
## Summary

The previous fix persisted a startup anchor before the Yellowstone stream opened, but an `ever_streamed` flag exempted the first connection from the gap gate. The anchor was therefore written but never used, leaving the window between startup and the first streamed block unowned. With backfill disabled, the first `SlotComplete` could advance the checkpoint straight past that gap. With backfill enabled, the live-start boundary was only consumed by RPC polling, leaving the slots above the backfill target uncovered. A `WithdrawFunds` burn landing in either window could therefore be missed permanently.

Every Yellowstone connection, including the first, now arms the gap gate on its first live block: the checkpoint is held, the missing window below that block is backfilled, and only then is the block forwarded. The source also carries a startup floor representing the highest slot startup has already accounted for: `live_start_slot - 1` when a range was resolved, otherwise the persisted anchor. This floor widens an existing startup gate rather than allowing a lower stream opening to narrow it, and bounds the first fill to only the remaining uncovered window. `CheckpointState` is unchanged.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 17,750 | 19,421 | 91.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33507369370) |
| Indexer | 37,828 | 41,533 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33507369370) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33507369370) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33507369370) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 15,148 | 19,576 | 77.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33507369370) |
| **Total** | **73,672** | **83,928** | **87.8%** | |

> Last updated: 2026-09-01 13:24:09 UTC by E2E Integration