### PR TITLE
fix(core): commit the retention floor in the same transaction as each…

### DIFF
--- a/core/src/accounts/truncate.rs
+++ b/core/src/accounts/truncate.rs
@@ -289,6 +289,20 @@ async fn process_block_batches(
             .await
             .context("Failed to delete old blocks")?;
 
+        // The loop already broke on an empty fetch, so this batch has set the cursor.
+        let batch_max_slot = last_processed_slot.expect("a non-empty batch sets the cursor");
+        // Query on the batch transaction so it sees deletions this batch has not committed yet.
+        // Bound it by the cursor so the scan skips the index entries this run already deleted.
+        let remaining_floor = query_first_available_slot_above(&mut *tx, batch_max_slot)
+            .await?
+            .ok_or_else(|| {
+                // Unreachable: keep_slots is at least 1, so the newest block is never
+                // deleted and always survives above the cursor.
+                anyhow!("No blocks remain above slot {batch_max_slot} after a truncation batch")
+            })?;
+        // Advance the advertised floor in the same transaction as the deletions.
+        upsert_first_available_block(&mut *tx, remaining_floor).await?;
+
         tx.commit()
             .await
             .context("Failed to commit truncation batch transaction")?;
@@ -328,21 +342,31 @@ async fn truncate_account_history_rows(pool: &PgPool, truncate_before_slot: u64)
     Ok(result.rows_affected())
 }
 
+/// Write the advertised ledger floor, the oldest slot this node still retains.
+/// Takes any executor so a batch can write it on its own open transaction.
+async fn upsert_first_available_block<'e, E>(executor: E, slot: u64) -> Result<()>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    sqlx::query(
+        "INSERT INTO metadata (key, value) VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+    )
+    .bind(FIRST_AVAILABLE_BLOCK_KEY)
+    .bind(slot.to_le_bytes().to_vec())
+    .execute(executor)
+    .await
+    .context("Failed to update first_available_block metadata")?;
+    Ok(())
+}
+
 async fn set_first_available_block_metadata(
     pool: &PgPool,
     slot: Option<u64>,
 ) -> Result<Option<u64>> {
     match slot {
         Some(slot) => {
-            sqlx::query(
-                "INSERT INTO metadata (key, value) VALUES ($1, $2)
-                 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
-            )
-            .bind(FIRST_AVAILABLE_BLOCK_KEY)
-            .bind(slot.to_le_bytes().to_vec())
-            .execute(pool)
-            .await
-            .context("Failed to update first_available_block metadata")?;
+            upsert_first_available_block(pool, slot).await?;
             Ok(Some(slot))
         }
         None => {
@@ -517,6 +541,24 @@ async fn query_latest_slot(pool: &PgPool) -> Result<Option<u64>> {
     Ok(latest_slot.map(|slot| slot as u64))
 }
 
+/// Oldest retained slot strictly above `slot`.
+///
+/// Deletion walks slots in ascending order, so once a batch has removed
+/// everything up to its highest slot, nothing live remains at or below it and
+/// this equals `MIN(slot)` over the whole table.
+async fn query_first_available_slot_above<'e, E>(executor: E, slot: i64) -> Result<Option<u64>>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    let first_available_slot =
+        sqlx::query_scalar::<_, Option<i64>>("SELECT MIN(slot) FROM blocks WHERE slot > $1")
+            .bind(slot)
+            .fetch_one(executor)
+            .await
+            .context("Failed to query remaining first available slot")?;
+    Ok(first_available_slot.map(|slot| slot as u64))
+}
+
 async fn query_first_available_slot(pool: &PgPool) -> Result<Option<u64>> {
     let first_available_slot = sqlx::query_scalar::<_, Option<i64>>("SELECT MIN(slot) FROM blocks")
         .fetch_one(pool)
@@ -658,7 +700,7 @@ mod tests {
 
     // --- Integration tests requiring Postgres ---
 
-    use crate::test_helpers::start_test_postgres_raw;
+    use crate::test_helpers::{start_test_postgres_raw, start_test_postgres_with_url};
 
     async fn store_test_blocks(db: &PostgresAccountsDB, slots: &[u64]) {
         let pool = db.pool.clone();
@@ -693,6 +735,212 @@ mod tests {
                 .unwrap();
             }
         }
+    }
+
+    /// Read the advertised ledger floor exactly as the RPC read path decodes it.
+    async fn read_floor_metadata(pool: &PgPool) -> Option<u64> {
+        sqlx::query_scalar::<_, Option<Vec<u8>>>(
+            "SELECT value FROM metadata WHERE key = 'first_available_block'",
+        )
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+        .flatten()
+        .map(|value| {
+            let bytes: [u8; 8] = value.as_slice().try_into().expect("floor is 8 bytes");
+            u64::from_le_bytes(bytes)
+        })
+    }
+
+    /// Ground truth for the oldest retained block, independent of the metadata key.
+    async fn min_block_slot(pool: &PgPool) -> Option<u64> {
+        sqlx::query_scalar::<_, Option<i64>>("SELECT MIN(slot) FROM blocks")
+            .fetch_one(pool)
+            .await
+            .unwrap()
+            .map(|slot| slot as u64)
+    }
+
+    /// Make one block undeserializable so the batch loop aborts at a known slot.
+    async fn corrupt_block_data(pool: &PgPool, slot: u64) {
+        let updated = sqlx::query("UPDATE blocks SET data = $2 WHERE slot = $1")
+            .bind(slot as i64)
+            .bind(b"not-a-block".to_vec())
+            .execute(pool)
+            .await
+            .unwrap()
+            .rows_affected();
+        assert_eq!(updated, 1, "expected to corrupt exactly one block");
+    }
+
+    /// Run one truncation against a pool of its own, close it, and wait until the
+    /// server has actually dropped the truncation advisory lock.
+    ///
+    /// `truncate_slots` takes that lock on whichever pooled connection serves the
+    /// acquire statement and releases it on whichever connection serves the
+    /// release statement. Those are not guaranteed to be the same connection, so
+    /// a second run against a still-open pool can find the lock held by an idle
+    /// one. Closing the pool ends those sessions, but the backends exit
+    /// asynchronously, so the wait below is what makes multi-run tests
+    /// deterministic. This is test scaffolding only; the lock's connection
+    /// affinity is not part of this change.
+    async fn truncate_on_fresh_pool(
+        url: &str,
+        options: &TruncateOptions,
+        observer: &PgPool,
+    ) -> Result<TruncateReport> {
+        let db = PostgresAccountsDB::new(url, false)
+            .await
+            .expect("test pool connects");
+        let report = truncate_slots(&db, options).await;
+        db.pool.close().await;
+        await_advisory_locks_released(observer).await;
+        report
+    }
+
+    /// Block until no advisory lock is held anywhere on the test database. Each
+    /// test owns its container, so the truncation lock is the only one possible.
+    async fn await_advisory_locks_released(pool: &PgPool) {
+        for _ in 0..600 {
+            let held = sqlx::query_scalar::<_, i64>(
+                "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'",
+            )
+            .fetch_one(pool)
+            .await
+            .expect("pg_locks is readable");
+            if held == 0 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("truncation advisory lock still held after its pool was closed");
+    }
+
+    fn apply_opts(keep_slots: u64, batch_size: usize, backup: &Path) -> TruncateOptions {
+        TruncateOptions {
+            keep_slots,
+            max_backup_age: Duration::from_secs(3600),
+            pg_dump_path: Some(backup.to_path_buf()),
+            batch_size,
+            dry_run: false,
+        }
+    }
+
+    /// Drop every block, transaction and floor entry so one container can serve
+    /// several independent truncation scenarios.
+    async fn reset_ledger(pool: &PgPool) {
+        for sql in [
+            "DELETE FROM blocks",
+            "DELETE FROM transactions",
+            "DELETE FROM metadata WHERE key = 'first_available_block'",
+        ] {
+            sqlx::query(sql).execute(pool).await.unwrap();
+        }
+    }
+
+    /// U1: the advertised floor must equal the retained minimum at every batching
+    /// granularity, including single-row batches and runs that fit in one batch.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn truncate_floor_matches_min_slot_across_batch_sizes() {
+        let (db, _pg, url) = start_test_postgres_with_url().await;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+
+        for batch_size in [1_usize, 3, 1000] {
+            reset_ledger(&db.pool).await;
+            store_test_blocks(&db, &(0..20).collect::<Vec<_>>()).await;
+
+            let report =
+                truncate_on_fresh_pool(&url, &apply_opts(5, batch_size, tmp.path()), &db.pool)
+                    .await
+                    .unwrap();
+
+            let floor = read_floor_metadata(&db.pool).await;
+            let min_slot = min_block_slot(&db.pool).await;
+            assert_eq!(
+                floor, min_slot,
+                "batch_size {batch_size}: advertised floor must equal the retained minimum"
+            );
+            assert_eq!(
+                report.first_available_block, min_slot,
+                "batch_size {batch_size}: report must carry the same floor"
+            );
+            assert_eq!(min_slot, Some(15), "batch_size {batch_size}: keep window");
+        }
+    }
+
+    /// U2: regression test. A run that aborts after committing batches must leave
+    /// the advertised floor at the retained minimum, never at the pre-run value,
+    /// because an absence-based finality verdict treats that floor as proof the
+    /// endpoint still holds the slot range it is being asked about.
+    ///
+    /// Slots 16 to 19 are deliberately absent. The batch that ends at slot 15 is
+    /// therefore followed by slot 20, so a floor derived from the batch cursor
+    /// instead of the surviving rows would claim slots that were never stored.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn aborted_run_leaves_floor_at_retained_minimum() {
+        let (db, _pg, url) = start_test_postgres_with_url().await;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let seeded: Vec<u64> = (0..=15).chain(20..=30).collect();
+        store_test_blocks(&db, &seeded).await;
+
+        // First run establishes the metadata key; without it the reader falls back
+        // to MIN(slot) and the stale-floor window cannot be observed at all.
+        let first = truncate_on_fresh_pool(&url, &apply_opts(21, 100, tmp.path()), &db.pool)
+            .await
+            .unwrap();
+        assert_eq!(first.truncate_before_slot, Some(10));
+        assert_eq!(read_floor_metadata(&db.pool).await, Some(10));
+
+        corrupt_block_data(&db.pool, 20).await;
+
+        // Batches of 3 delete slots 10-12 and 13-15, then abort on slot 20.
+        let aborted = truncate_on_fresh_pool(&url, &apply_opts(5, 3, tmp.path()), &db.pool).await;
+        assert!(aborted.is_err(), "run must abort on the corrupt block");
+        assert!(aborted
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to deserialize block at slot 20"));
+
+        assert_eq!(min_block_slot(&db.pool).await, Some(20));
+        assert_eq!(
+            read_floor_metadata(&db.pool).await,
+            Some(20),
+            "floor must not advertise slots the aborted run already deleted"
+        );
+
+        let accounts_db = crate::accounts::AccountsDB::Postgres(db.clone());
+        assert_eq!(accounts_db.get_first_available_block().await.unwrap(), 20);
+    }
+
+    /// U3: the floor write sits inside the batch loop, one `continue` away from the
+    /// dry-run path, so a dry run must not overwrite an existing floor either.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dry_run_never_writes_floor_even_when_key_exists() {
+        let (db, _pg, url) = start_test_postgres_with_url().await;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        store_test_blocks(&db, &(0..20).collect::<Vec<_>>()).await;
+
+        truncate_on_fresh_pool(&url, &apply_opts(10, 3, tmp.path()), &db.pool)
+            .await
+            .unwrap();
+        let floor_before = read_floor_metadata(&db.pool).await;
+        let blocks_before = min_block_slot(&db.pool).await;
+        assert_eq!(floor_before, Some(10));
+
+        let mut dry = apply_opts(2, 3, tmp.path());
+        dry.dry_run = true;
+        let report = truncate_on_fresh_pool(&url, &dry, &db.pool).await.unwrap();
+        assert!(
+            report.blocks_deleted > 0,
+            "dry run should report work to do"
+        );
+
+        assert_eq!(
+            read_floor_metadata(&db.pool).await,
+            floor_before,
+            "dry run must not move the advertised floor"
+        );
+        assert_eq!(min_block_slot(&db.pool).await, blocks_before);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -67,6 +67,18 @@ pub(crate) async fn start_test_postgres_raw() -> (
     crate::accounts::PostgresAccountsDB,
     testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
 ) {
+    let (db, container, _url) = start_test_postgres_with_url().await;
+    (db, container)
+}
+
+/// Same as `start_test_postgres_raw`, but also hands back the connection URL so a
+/// test can open further independent pools against the same database.
+#[cfg(test)]
+pub(crate) async fn start_test_postgres_with_url() -> (
+    crate::accounts::PostgresAccountsDB,
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+    String,
+) {
     use testcontainers::runners::AsyncRunner;
     use testcontainers_modules::postgres::Postgres;
 
@@ -83,7 +95,7 @@ pub(crate) async fn start_test_postgres_raw() -> (
     let db = crate::accounts::PostgresAccountsDB::new(&url, false)
         .await
         .unwrap();
-    (db, container)
+    (db, container, url)
 }
 
 /// Synchronously insert `address_signatures` rows that `write_batch` would

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -146,6 +146,10 @@ private-channel-admin truncate --keep-slots 100000
 private-channel-admin truncate --keep-slots 100000 --dry-run
 ```
 
+Truncation deletes in batches, and each batch commits the new retention floor
+(`getFirstAvailableBlock`) in the same transaction as its deletions. A partial or
+aborted run therefore never advertises history it has already removed.
+
 ### Makefile Targets
 
 **Source**: [`Makefile`](../Makefile)

--- a/integration/tests/private-channel/test_truncate_floor_atomicity.rs
+++ b/integration/tests/private-channel/test_truncate_floor_atomicity.rs
@@ -1,0 +1,292 @@
+//! Target file: `core/src/accounts/truncate.rs`
+//! Binary: `truncate_integration` (existing).
+//! Fixture: one testcontainers Postgres, plus a second small pool used only to
+//! hold a row lock.
+//!
+//! The advertised ledger floor (`metadata['first_available_block']`, served as
+//! `getFirstAvailableBlock`) is the retention proof an absence-based finality
+//! verdict relies on: a floor at or below the attempt's slot range is read as
+//! "this node still holds that range and the signature is not in it". If the
+//! floor can ever name slots whose rows are already deleted, that proof is
+//! false and a landed-but-pruned transaction reads as never landed.
+//!
+//! The sibling unit test proves the floor is written once per deletion batch.
+//! This test proves the stronger property that the write is in the SAME
+//! transaction as the deletions, which is what closes the mid-run window. It
+//! does that without any production test hook: a separate connection holds the
+//! `FOR UPDATE` row lock the batch upsert needs, so the batch parks with its
+//! deletions issued but uncommitted, and a third connection then checks that
+//! the deletions are invisible for exactly as long as the floor is unchanged.
+//!
+//! Helpers are reused from the parent module rather than duplicated, so a
+//! change to the shared fixture shape is picked up here too.
+
+use {
+    anyhow::{Context, Result},
+    private_channel_core::accounts::{
+        truncate::{truncate_slots, TruncateOptions, TruncateReport},
+        PostgresAccountsDB,
+    },
+    solana_sdk::{hash::Hash, signature::Signature},
+    sqlx::{postgres::PgPoolOptions, PgPool},
+    std::time::Duration,
+};
+
+/// Slots seeded by this test. The first run prunes below `FIRST_FLOOR`, the
+/// second run is the one whose batches are observed mid-flight.
+const SEEDED_SLOTS: u64 = 60;
+const FIRST_KEEP_SLOTS: u64 = 41;
+const FIRST_FLOOR: u64 = 20;
+const SECOND_KEEP_SLOTS: u64 = 5;
+const SECOND_FLOOR: u64 = 56;
+
+fn opts(keep_slots: u64, batch_size: usize, backup: &std::path::Path) -> TruncateOptions {
+    TruncateOptions {
+        keep_slots,
+        max_backup_age: Duration::from_secs(60 * 60),
+        pg_dump_path: Some(backup.to_path_buf()),
+        batch_size,
+        dry_run: false,
+    }
+}
+
+/// Run one truncation against a pool of its own, close it, and wait until the
+/// server has actually dropped the truncation advisory lock.
+///
+/// `truncate_slots` takes that lock on whichever pooled connection serves the
+/// acquire statement and releases it on whichever connection serves the release
+/// statement. Those are not guaranteed to be the same connection, so a second
+/// run against a still-open pool can find the lock held by an idle one. Closing
+/// the pool ends those sessions, but the backends exit asynchronously, so the
+/// wait below is what makes a two-run test deterministic. This is test
+/// scaffolding only; the lock's connection affinity is not part of this change.
+async fn truncate_on_fresh_pool(
+    url: &str,
+    options: &TruncateOptions,
+    observer: &PgPool,
+) -> Result<TruncateReport> {
+    let db = PostgresAccountsDB::new(url, false)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open truncation pool: {e}"))?;
+    let report = truncate_slots(&db, options).await;
+    db.pool.close().await;
+    await_advisory_locks_released(observer).await?;
+    report
+}
+
+/// Block until no advisory lock is held anywhere on the test database. This test
+/// owns its container, so the truncation lock is the only one possible.
+async fn await_advisory_locks_released(pool: &PgPool) -> Result<()> {
+    for _ in 0..600 {
+        let held = sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'",
+        )
+        .fetch_one(pool)
+        .await
+        .context("Failed to poll advisory locks")?;
+        if held == 0 {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    anyhow::bail!("truncation advisory lock still held after its pool was closed")
+}
+
+async fn seed_blocks(pool: &PgPool, count: u64) -> Result<()> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS account_history (
+            id BIGSERIAL PRIMARY KEY,
+            slot BIGINT NOT NULL,
+            data BYTEA NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await
+    .context("Failed to create account_history fixture table")?;
+
+    let mut previous_blockhash = Hash::default();
+    for slot in 1..=count {
+        let signature = Signature::new_unique();
+        let block = super::build_block(slot, previous_blockhash, signature);
+        previous_blockhash = block.blockhash;
+        let data = bincode::serialize(&block).context("Failed to serialize fixture block")?;
+
+        sqlx::query("INSERT INTO blocks (slot, data) VALUES ($1, $2)")
+            .bind(slot as i64)
+            .bind(data)
+            .execute(pool)
+            .await
+            .with_context(|| format!("Failed to insert fixture block at slot {}", slot))?;
+        sqlx::query("INSERT INTO transactions (signature, data) VALUES ($1, $2)")
+            .bind(signature.as_ref().to_vec())
+            .bind(vec![slot as u8])
+            .execute(pool)
+            .await
+            .with_context(|| format!("Failed to insert fixture transaction at slot {}", slot))?;
+        sqlx::query("INSERT INTO account_history (slot, data) VALUES ($1, $2)")
+            .bind(slot as i64)
+            .bind(vec![slot as u8])
+            .execute(pool)
+            .await
+            .with_context(|| format!("Failed to insert account_history row at slot {}", slot))?;
+    }
+    Ok(())
+}
+
+/// Read the floor and the true retained minimum inside one snapshot, so the two
+/// values can never come from different points in time.
+async fn snapshot_floor_and_min(pool: &PgPool) -> Result<(Option<u64>, Option<u64>)> {
+    let mut tx = pool
+        .begin()
+        .await
+        .context("Failed to open observer transaction")?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        .execute(&mut *tx)
+        .await
+        .context("Failed to set observer isolation level")?;
+
+    let floor = sqlx::query_scalar::<_, Option<Vec<u8>>>(
+        "SELECT value FROM metadata WHERE key = 'first_available_block'",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .context("Failed to read first_available_block")?
+    .flatten()
+    .map(|value| {
+        let bytes: [u8; 8] = value.as_slice().try_into().expect("floor is 8 bytes");
+        u64::from_le_bytes(bytes)
+    });
+
+    let min_slot = sqlx::query_scalar::<_, Option<i64>>("SELECT MIN(slot) FROM blocks")
+        .fetch_one(&mut *tx)
+        .await
+        .context("Failed to read MIN(slot)")?
+        .map(|slot| slot as u64);
+
+    tx.rollback().await.ok();
+    Ok((floor, min_slot))
+}
+
+/// Wait until a backend is blocked specifically by `blocker_pid`, the connection
+/// holding the floor row lock.
+///
+/// Matching any ungranted lock in the cluster would let an unrelated waiter
+/// satisfy the poll before the truncation batch had issued its deletions, and
+/// the assertions that follow would then pass for the wrong reason. Naming the
+/// blocker means only the metadata row lock can end this wait.
+async fn await_blocked_by(pool: &PgPool, blocker_pid: i32) -> Result<()> {
+    for _ in 0..600 {
+        let waiting = sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM pg_stat_activity WHERE $1 = ANY(pg_blocking_pids(pid))",
+        )
+        .bind(blocker_pid)
+        .fetch_one(pool)
+        .await
+        .context("Failed to poll for blocked backends")?;
+        if waiting > 0 {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    anyhow::bail!("timed out waiting for the truncation batch to block on the metadata row lock")
+}
+
+/// The deletions and the new floor must become visible together. While a batch
+/// is parked on the floor row lock, an outside reader must still see both the
+/// old floor and the old set of blocks.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_floor_and_deletions_commit_together() -> Result<()> {
+    let (db, container) = super::start_postgres("truncate_floor_atomicity").await?;
+    seed_blocks(&db.pool, SEEDED_SLOTS).await?;
+    let backup_path = super::create_backup_artifact("floor_atomicity")?;
+
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let url = format!(
+        "postgres://postgres:password@{}:{}/truncate_floor_atomicity",
+        host, port
+    );
+
+    // First run creates the metadata key. Without it the read path falls back to
+    // MIN(slot), which is always truthful, and the window cannot be observed.
+    let first =
+        truncate_on_fresh_pool(&url, &opts(FIRST_KEEP_SLOTS, 100, &backup_path), &db.pool).await?;
+    assert_eq!(first.first_available_block, Some(FIRST_FLOOR));
+    assert_eq!(
+        snapshot_floor_and_min(&db.pool).await?,
+        (Some(FIRST_FLOOR), Some(FIRST_FLOOR))
+    );
+
+    // A dedicated pool so holding the lock cannot consume the truncation's
+    // connections, and so the lock is released exactly when this test says.
+    let holder_pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .context("Failed to open the lock-holder pool")?;
+
+    let mut holder = holder_pool
+        .begin()
+        .await
+        .context("Failed to begin the lock-holder transaction")?;
+    let locked = sqlx::query_scalar::<_, i32>(
+        "SELECT 1 FROM metadata WHERE key = 'first_available_block' FOR UPDATE",
+    )
+    .fetch_optional(&mut *holder)
+    .await
+    .context("Failed to take the floor row lock")?;
+    assert_eq!(
+        locked,
+        Some(1),
+        "the floor row must exist before locking it"
+    );
+    let holder_pid = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+        .fetch_one(&mut *holder)
+        .await
+        .context("Failed to read the lock holder's backend pid")?;
+
+    let second_url = url.clone();
+    let second_opts = opts(SECOND_KEEP_SLOTS, 3, &backup_path);
+    let observer = db.pool.clone();
+    let task =
+        tokio::spawn(
+            async move { truncate_on_fresh_pool(&second_url, &second_opts, &observer).await },
+        );
+
+    await_blocked_by(&db.pool, holder_pid).await?;
+
+    // The parked batch has issued its deletions but not committed them, so an
+    // outside reader must see the pre-run floor and the pre-run blocks.
+    let (floor, min_slot) = snapshot_floor_and_min(&db.pool).await?;
+    assert_eq!(
+        floor,
+        Some(FIRST_FLOOR),
+        "floor moved while a batch was still uncommitted"
+    );
+    assert_eq!(
+        min_slot,
+        Some(FIRST_FLOOR),
+        "deletions became visible while the floor still advertised slot {FIRST_FLOOR}"
+    );
+
+    holder
+        .commit()
+        .await
+        .context("Failed to release the floor row lock")?;
+
+    let report = tokio::time::timeout(Duration::from_secs(120), task)
+        .await
+        .context("truncation task timed out")?
+        .context("truncation task panicked")??;
+
+    assert_eq!(report.first_available_block, Some(SECOND_FLOOR));
+    assert_eq!(
+        snapshot_floor_and_min(&db.pool).await?,
+        (Some(SECOND_FLOOR), Some(SECOND_FLOOR)),
+        "after the run the floor must equal the retained minimum"
+    );
+
+    holder_pool.close().await;
+    super::cleanup_backup_artifact(&backup_path);
+    Ok(())
+}

--- a/integration/tests/private-channel/truncate.rs
+++ b/integration/tests/private-channel/truncate.rs
@@ -15,6 +15,8 @@
 // this same test binary so they share compile state.
 #[path = "test_truncate_backup_failure.rs"]
 mod backup_failure;
+#[path = "test_truncate_floor_atomicity.rs"]
+mod floor_atomicity;
 #[path = "test_truncate_lock_contention.rs"]
 mod lock_contention;
 


### PR DESCRIPTION
## Description

`getFirstAvailableBlock` provides the retention proof for absence-based finality. `coverage_verdict` treats a null signature status as `Dead` only when the node's retention floor is at or below the slot range where the transaction could have landed. That floor comes from `metadata['first_available_block']`, which the read path prefers over `MIN(slot) FROM blocks`. Truncation, however, committed block deletions one batch at a time but updated the metadata only after the entire run completed. If a batch committed and the run later failed or crashed, the deleted rows and stored floor could disagree. A transaction that landed and was subsequently pruned could then appear absent while the stale floor incorrectly proved coverage, allowing a remint to execute twice.

Each deletion batch now computes the surviving floor and updates it in the same transaction as the deletions, so readers cannot observe the new state without the corresponding floor. This gives the true surviving minimum while avoiding scans over rows already deleted by the current run. If the floor is ever wrong, it can only overstate pruning, causing the finality check to return `Uncertain` rather than incorrectly proving `Dead`. A missing floor is now an error instead of silently committing deletions behind stale metadata. 

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 15,788 | 17,444 | 90.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32873430379) |
| Indexer | 36,841 | 40,456 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32873430379) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32873430379) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32873430379) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,621 | 18,768 | 77.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32873430379) |
| **Total** | **70,196** | **80,066** | **87.7%** | |

> Last updated: 2026-08-25 17:36:17 UTC by E2E Integration