### PR TITLE
fix(core): bound settler buffering by account bytes and upgrade sqlx (issue-235)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,10 +1405,12 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bigdecimal"
-version = "0.3.1"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
+ "autocfg",
+ "libm",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -2201,7 +2203,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3247,7 +3249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3850,10 +3852,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3868,11 +3866,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3904,9 +3902,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -5073,11 +5068,10 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -6832,7 +6826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
  "once_cell",
@@ -6867,7 +6861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -6880,7 +6874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -7703,7 +7697,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8343,6 +8337,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smpl_jwt"
@@ -8377,7 +8374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15749,20 +15746,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -15773,71 +15760,65 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "ahash 0.8.12",
- "atoi",
+ "base64 0.22.1",
  "bigdecimal",
- "byteorder",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 2.5.3",
- "futures-channel",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.15.5",
  "hashlink",
- "hex",
  "indexmap 2.11.4",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding 2.3.2",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls 0.23.39",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
  "url 2.5.7",
  "uuid",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -15849,20 +15830,19 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
- "tempfile",
+ "syn 2.0.106",
  "tokio",
  "url 2.5.7",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.9.4",
  "byteorder",
@@ -15894,7 +15874,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "whoami",
@@ -15902,12 +15882,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.9.4",
  "byteorder",
@@ -15917,7 +15897,6 @@ dependencies = [
  "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -15936,7 +15915,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "whoami",
@@ -15944,9 +15923,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
@@ -15960,10 +15939,11 @@ dependencies = [
  "log",
  "percent-encoding 2.3.2",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
+ "thiserror 2.0.17",
  "tracing",
  "url 2.5.7",
- "urlencoding",
  "uuid",
 ]
 
@@ -16257,7 +16237,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17273,12 +17253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17368,12 +17342,6 @@ dependencies = [
  "percent-encoding 2.3.2",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -17728,7 +17696,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ spl-associated-token-account = "7.0.0"
 spl-memo = "6.0.0"
 spl-token = "8.0.0"
 spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tempfile = "3.14"
 testcontainers = "0.25"
 testcontainers-modules = { version = "0.13", features = ["postgres", "redis"] }

--- a/core/src/stage_metrics.rs
+++ b/core/src/stage_metrics.rs
@@ -43,6 +43,9 @@ pub trait StageMetrics: Send + Sync {
     fn bob_settlement_divergences(&self, count: usize);
 
     // Settler
+    fn executor_results_chunked(&self, chunks: usize);
+    fn settler_buffered_account_bytes(&self, bytes: usize);
+    fn settler_backpressure_engaged(&self);
     fn settler_txs_settled(&self, count: usize);
     fn settler_settle_duration_ms(&self, ms: f64);
     fn settler_db_write_duration_ms(&self, ms: f64);
@@ -141,6 +144,15 @@ impl StageMetrics for NoopMetrics {
     }
     fn bob_settlement_divergences(&self, count: usize) {
         debug!("bob: settlement_divergences={}", count);
+    }
+    fn executor_results_chunked(&self, n: usize) {
+        debug!("executor: results split into {} chunks", n);
+    }
+    fn settler_buffered_account_bytes(&self, bytes: usize) {
+        debug!("settler: buffered_account_bytes={}", bytes);
+    }
+    fn settler_backpressure_engaged(&self) {
+        debug!("settler: backpressure engaged");
     }
     fn settler_txs_settled(&self, n: usize) {
         debug!("settler: settled {}", n);
@@ -275,6 +287,12 @@ counter_vec!(
     &[]
 );
 counter_vec!(
+    EXECUTOR_RESULTS_CHUNKED,
+    "private_channel_executor_results_chunked_total",
+    "Execution results split into byte-bounded chunks before the settler send",
+    &[]
+);
+counter_vec!(
     EXECUTOR_RESULTS_SEND_FAILED,
     "private_channel_executor_results_send_failed_total",
     "Failed to send execution results",
@@ -302,6 +320,12 @@ counter_vec!(
     SETTLER_TXS_SETTLED,
     "private_channel_settler_txs_settled_total",
     "Transactions settled to DB",
+    &[]
+);
+counter_vec!(
+    SETTLER_BACKPRESSURE_ENGAGED,
+    "private_channel_settler_backpressure_engaged_total",
+    "Ticks that flushed a settle buffer already at or over its byte budget",
     &[]
 );
 counter_vec!(
@@ -350,6 +374,12 @@ gauge_vec!(
     BOB_CACHE_BYTES,
     "private_channel_bob_cache_bytes",
     "Approx resident account-data bytes in the BOB cache; refreshed at sweep cadence",
+    &[]
+);
+gauge_vec!(
+    SETTLER_BUFFERED_ACCOUNT_BYTES,
+    "private_channel_settler_buffered_account_bytes",
+    "Settled account-data bytes buffered since the last block, against the byte budget",
     &[]
 );
 
@@ -515,6 +545,21 @@ impl StageMetrics for PrometheusMetrics {
             .with_label_values(&[] as &[&str])
             .inc_by(count as f64);
     }
+    fn executor_results_chunked(&self, n: usize) {
+        EXECUTOR_RESULTS_CHUNKED
+            .with_label_values(&[] as &[&str])
+            .inc_by(n as f64);
+    }
+    fn settler_buffered_account_bytes(&self, bytes: usize) {
+        SETTLER_BUFFERED_ACCOUNT_BYTES
+            .with_label_values(&[] as &[&str])
+            .set(bytes as f64);
+    }
+    fn settler_backpressure_engaged(&self) {
+        SETTLER_BACKPRESSURE_ENGAGED
+            .with_label_values(&[] as &[&str])
+            .inc();
+    }
     fn settler_txs_settled(&self, n: usize) {
         SETTLER_TXS_SETTLED
             .with_label_values(&[] as &[&str])
@@ -596,10 +641,13 @@ pub fn init_prometheus_metrics() {
         EXECUTOR_DROPPED_EXPIRED_BH,
         EXECUTOR_CONSERVATION_REJECTED,
         SETTLER_TXS_SETTLED,
+        SETTLER_BACKPRESSURE_ENGAGED,
+        EXECUTOR_RESULTS_CHUNKED,
         BOB_CACHE_EVICTED,
         BOB_CACHE_ENTRIES,
         BOB_CACHE_DIRTY_ENTRIES,
         BOB_CACHE_BYTES,
+        SETTLER_BUFFERED_ACCOUNT_BYTES,
         // Executor latency histograms
         EXECUTOR_BATCH_DURATION,
         EXECUTOR_PRELOAD_DURATION,

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -8,7 +8,7 @@ use {
         },
         scheduler::ConflictFreeBatch,
         stage_metrics::SharedMetrics,
-        stages::{AccountSettlements, ExecutedBatch},
+        stages::{retained_bytes_of, AccountSettlements, ExecutedBatch},
         transactions::is_admin_instruction,
         vm::{
             admin::AdminVm,
@@ -26,7 +26,7 @@ use {
     },
     solana_svm::{
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_processing_result::ProcessedTransaction,
+        transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
         transaction_processor::{
             LoadAndExecuteSanitizedTransactionsOutput, TransactionBatchProcessor,
             TransactionProcessingConfig, TransactionProcessingEnvironment,
@@ -153,15 +153,24 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                                     // Bounded send applies backpressure; race shutdown so a full
                                     // settler queue never wedges executor exit. Owned values only,
                                     // no lock guard is held across this await.
-                                    tokio::select! {
-                                        send_result = execution_results_tx.send((admin_results, execution_result.admin_transactions, execution_result.admin_generation)) => {
-                                            if let Err(e) = send_result {
-                                                metrics.executor_results_send_failed("admin");
-                                                error!("Failed to send admin results: {:?}", e);
-                                                break;
-                                            }
+                                    match send_results_chunked(
+                                        &execution_results_tx,
+                                        admin_results,
+                                        execution_result.admin_transactions,
+                                        execution_result.admin_generation,
+                                        MAX_SEND_CHUNK_BYTES,
+                                        &shutdown_token,
+                                        &metrics,
+                                    )
+                                    .await
+                                    {
+                                        SendOutcome::Sent => {}
+                                        SendOutcome::ChannelClosed => {
+                                            metrics.executor_results_send_failed("admin");
+                                            error!("Failed to send admin results: channel closed");
+                                            break;
                                         }
-                                        _ = shutdown_token.cancelled() => {
+                                        SendOutcome::ShuttingDown => {
                                             info!("Executor shutdown while sending admin results");
                                             return;
                                         }
@@ -176,15 +185,24 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                             if !execution_result.regular_transactions.is_empty() {
                                 if let Some(regular_results) = execution_result.regular_results {
                                     let len = execution_result.regular_transactions.len();
-                                    tokio::select! {
-                                        send_result = execution_results_tx.send((regular_results, execution_result.regular_transactions, execution_result.regular_generation)) => {
-                                            if let Err(e) = send_result {
-                                                metrics.executor_results_send_failed("regular");
-                                                error!("Failed to send regular results: {:?}", e);
-                                                break;
-                                            }
+                                    match send_results_chunked(
+                                        &execution_results_tx,
+                                        regular_results,
+                                        execution_result.regular_transactions,
+                                        execution_result.regular_generation,
+                                        MAX_SEND_CHUNK_BYTES,
+                                        &shutdown_token,
+                                        &metrics,
+                                    )
+                                    .await
+                                    {
+                                        SendOutcome::Sent => {}
+                                        SendOutcome::ChannelClosed => {
+                                            metrics.executor_results_send_failed("regular");
+                                            error!("Failed to send regular results: channel closed");
+                                            break;
                                         }
-                                        _ = shutdown_token.cancelled() => {
+                                        SendOutcome::ShuttingDown => {
                                             info!("Executor shutdown while sending regular results");
                                             return;
                                         }
@@ -316,6 +334,144 @@ fn merge_svm_outputs(
     }
 
     merged
+}
+
+/// Cap on retained account bytes in one message to the settler.
+/// This bounds a message built from several transactions. One transaction is
+/// never divided, so bounding that case is an admission problem, tracked apart.
+pub(crate) const MAX_SEND_CHUNK_BYTES: usize = 64 * 1024 * 1024;
+
+/// A chunk must never exceed the settler budget it is measured against.
+const _: () = assert!(MAX_SEND_CHUNK_BYTES <= crate::stages::MAX_BUFFERED_SETTLE_BYTES);
+
+/// Outcome of a settler send, mirroring the caller's three existing paths.
+pub(crate) enum SendOutcome {
+    Sent,
+    ChannelClosed,
+    ShuttingDown,
+}
+
+/// Where to split a batch, as end-exclusive index ranges over its transactions.
+/// A chunk closes just before the transaction that would exceed the cap, so an
+/// oversized one travels alone and no transaction is ever split across messages.
+fn chunk_ranges_by_bytes(
+    results: &[TransactionProcessingResult],
+    transactions: &[SanitizedTransaction],
+    cap: usize,
+) -> Vec<std::ops::Range<usize>> {
+    // A length mismatch is the settler's error to report, so send the batch whole.
+    if results.len() != transactions.len() {
+        return Vec::new();
+    }
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut buffered = 0usize;
+    for (index, (result, transaction)) in results.iter().zip(transactions.iter()).enumerate() {
+        let bytes = retained_bytes_of(result, transaction);
+        if index > start && buffered + bytes > cap {
+            ranges.push(start..index);
+            start = index;
+            buffered = 0;
+        }
+        buffered += bytes;
+    }
+    if start < results.len() {
+        ranges.push(start..results.len());
+    }
+    ranges
+}
+
+/// Send one batch, racing the shutdown token exactly as the inline send did.
+async fn send_one(
+    results_tx: &mpsc::Sender<ExecutedBatch>,
+    batch: ExecutedBatch,
+    shutdown_token: &CancellationToken,
+) -> SendOutcome {
+    tokio::select! {
+        send_result = results_tx.send(batch) => {
+            match send_result {
+                Ok(()) => SendOutcome::Sent,
+                Err(_) => SendOutcome::ChannelClosed,
+            }
+        }
+        _ = shutdown_token.cancelled() => SendOutcome::ShuttingDown,
+    }
+}
+
+/// Send results to the settler in byte-bounded messages.
+/// A batch under the cap is sent untouched, so ordinary traffic only pays the byte
+/// sum. When split, the real generation rides the last chunk and earlier ones get zero.
+async fn send_results_chunked(
+    results_tx: &mpsc::Sender<ExecutedBatch>,
+    output: LoadAndExecuteSanitizedTransactionsOutput,
+    transactions: Vec<SanitizedTransaction>,
+    generation: u64,
+    cap: usize,
+    shutdown_token: &CancellationToken,
+    metrics: &SharedMetrics,
+) -> SendOutcome {
+    let ranges = chunk_ranges_by_bytes(&output.processing_results, &transactions, cap);
+    if ranges.len() <= 1 {
+        return send_one(
+            results_tx,
+            (output, transactions, generation),
+            shutdown_token,
+        )
+        .await;
+    }
+
+    metrics.executor_results_chunked(ranges.len());
+
+    let LoadAndExecuteSanitizedTransactionsOutput {
+        mut processing_results,
+        error_metrics,
+        execute_timings,
+        balance_collector,
+    } = output;
+    let mut transactions = transactions;
+    // Batch-wide telemetry has no per-chunk meaning, so it rides the first message.
+    let mut head = Some((error_metrics, execute_timings, balance_collector));
+
+    let last = ranges.len() - 1;
+    let mut sent = 0usize;
+    for (position, range) in ranges.iter().enumerate() {
+        let take = range.end - range.start;
+        let (error_metrics, execute_timings, balance_collector) =
+            head.take().unwrap_or_else(|| {
+                (
+                    TransactionErrorMetrics::default(),
+                    ExecuteTimings::default(),
+                    None,
+                )
+            });
+        let chunk = LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: processing_results.drain(..take).collect(),
+            error_metrics,
+            execute_timings,
+            balance_collector,
+        };
+        let chunk_transactions: Vec<SanitizedTransaction> = transactions.drain(..take).collect();
+        // Zero acknowledges nothing, so a partial drain cannot mark writes durable.
+        let chunk_generation = if position == last { generation } else { 0 };
+        match send_one(
+            results_tx,
+            (chunk, chunk_transactions, chunk_generation),
+            shutdown_token,
+        )
+        .await
+        {
+            SendOutcome::Sent => sent += take,
+            other => {
+                // Report what actually landed; the caller only counts a whole batch.
+                if sent > 0 {
+                    metrics.executor_results_sent(sent);
+                }
+                return other;
+            }
+        }
+    }
+
+    SendOutcome::Sent
 }
 
 /// Execute regular transactions across multiple worker threads.
@@ -801,7 +957,8 @@ pub async fn execute_batch(
 mod tests {
     use super::*;
     use crate::{
-        accounts::bob::BOB, stage_metrics::NoopMetrics, test_helpers::start_test_postgres,
+        accounts::bob::BOB, stage_metrics::NoopMetrics, stages::retained_account_bytes,
+        test_helpers::start_test_postgres,
     };
     use solana_sdk::account::AccountSharedData;
     use solana_sdk::{
@@ -811,7 +968,6 @@ mod tests {
         signature::{Keypair, Signer},
         transaction::Transaction,
     };
-    use solana_svm::transaction_processing_result::TransactionProcessingResult;
     use solana_svm::transaction_processor::LoadAndExecuteSanitizedTransactionsOutput;
     use solana_svm_callback::TransactionProcessingCallback;
     use std::collections::{HashSet, LinkedList};
@@ -954,6 +1110,132 @@ mod tests {
     /// A successful single-tx Executed output carrying `accounts`.
     fn executed_with(accounts: Vec<(Pubkey, AccountSharedData)>) -> TransactionProcessingResult {
         executed_with_status(Ok(()), accounts)
+    }
+
+    /// One transfer per requested size, carrying those bytes on its writable slot.
+    fn sized_batch(
+        sizes: &[usize],
+    ) -> (Vec<TransactionProcessingResult>, Vec<SanitizedTransaction>) {
+        let mut results = Vec::new();
+        let mut txs = Vec::new();
+        for size in sizes {
+            let from = Keypair::new();
+            let to = Pubkey::new_unique();
+            txs.push(transfer(&from, &to, 100));
+            results.push(executed_with(vec![
+                (
+                    from.pubkey(),
+                    AccountSharedData::new(1, *size, &Pubkey::default()),
+                ),
+                (to, AccountSharedData::new(1, 0, &Pubkey::default())),
+            ]));
+        }
+        (results, txs)
+    }
+
+    /// Wrap processing results in the SVM output shape the send helper consumes.
+    fn output_of(
+        processing_results: Vec<TransactionProcessingResult>,
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results,
+            error_metrics: TransactionErrorMetrics::default(),
+            execute_timings: ExecuteTimings::default(),
+            balance_collector: None,
+        }
+    }
+
+    /// A chunk over the cap is no bound at all, and dropping or reordering a
+    /// transaction corrupts the block's signature list. Both are asserted on every
+    /// row, since an unsplit batch can regress just as easily as a split one.
+    #[test]
+    fn chunk_ranges_by_bytes_respects_cap_and_preserves_order() {
+        let cap = 1000usize;
+        let cases: Vec<(&str, Vec<usize>, usize)> = vec![
+            ("all small stays unsplit", vec![10, 10, 10, 10], 1),
+            ("exact fit stays unsplit", vec![500, 500], 1),
+            ("one byte over splits", vec![500, 501], 2),
+            ("single oversized tx sits alone", vec![5000], 1),
+            ("oversized in the middle isolates", vec![10, 5000, 10], 3),
+            ("empty yields no chunks", vec![], 0),
+        ];
+
+        for (name, sizes, expected_chunks) in cases {
+            let (results, txs) = sized_batch(&sizes);
+            let ranges = chunk_ranges_by_bytes(&results, &txs, cap);
+            assert_eq!(ranges.len(), expected_chunks, "chunk count for {}", name);
+
+            let mut next = 0usize;
+            for r in &ranges {
+                assert_eq!(r.start, next, "gap or overlap in {}", name);
+                assert!(r.end > r.start, "empty chunk in {}", name);
+                next = r.end;
+            }
+            assert_eq!(next, sizes.len(), "chunks must cover every tx in {}", name);
+
+            for r in &ranges {
+                if r.end - r.start > 1 {
+                    let bytes = retained_account_bytes(&results[r.clone()], &txs[r.clone()]);
+                    assert!(bytes <= cap, "chunk over cap in {}: {}", name, bytes);
+                }
+            }
+        }
+    }
+
+    /// The one assertion standing between the split and a data-loss bug. If a
+    /// non-final chunk carried the real generation, BOB would treat undrained writes
+    /// as durable and drop them, so only the last chunk may advance the watermark.
+    #[tokio::test]
+    async fn chunked_send_stamps_generation_on_final_chunk_only() {
+        let cap = 1000usize;
+        let shutdown = CancellationToken::new();
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+
+        // Each transaction alone exceeds the cap, so this splits into three.
+        let (results, txs) = sized_batch(&[5000, 5000, 5000]);
+        let (chan_tx, mut rx) = mpsc::channel::<ExecutedBatch>(16);
+        let outcome = send_results_chunked(
+            &chan_tx,
+            output_of(results),
+            txs,
+            42,
+            cap,
+            &shutdown,
+            &metrics,
+        )
+        .await;
+        assert!(matches!(outcome, SendOutcome::Sent));
+
+        let mut gens = Vec::new();
+        while let Ok((_, _, g)) = rx.try_recv() {
+            gens.push(g);
+        }
+        assert_eq!(
+            gens,
+            vec![0, 0, 42],
+            "only the final chunk may carry the generation"
+        );
+
+        // Under the cap the batch goes as one message, still stamped.
+        let (results, txs) = sized_batch(&[10, 10]);
+        let (chan_tx, mut rx) = mpsc::channel::<ExecutedBatch>(16);
+        let outcome = send_results_chunked(
+            &chan_tx,
+            output_of(results),
+            txs,
+            7,
+            cap,
+            &shutdown,
+            &metrics,
+        )
+        .await;
+        assert!(matches!(outcome, SendOutcome::Sent));
+
+        let mut gens = Vec::new();
+        while let Ok((_, _, g)) = rx.try_recv() {
+            gens.push(g);
+        }
+        assert_eq!(gens, vec![7], "an unsplit batch stays one message");
     }
 
     /// A token-like data account (program-owned, non-empty data) with `lamports`.

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -61,6 +61,44 @@ pub struct AccountSettlements {
     pub accounts: Vec<(Pubkey, AccountSettlement)>,
 }
 
+/// Cap on buffered account bytes before the settler stops draining the executor.
+/// Far below Postgres' 1 GB limit for one bytea, and small enough that committing
+/// a full buffer still finishes inside the stage health margin.
+pub(crate) const MAX_BUFFERED_SETTLE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Account bytes a batch keeps in memory once buffered for settlement.
+/// Rolled-back and zero-lamport writes count too, because the buffer still holds
+/// them, so this can never read below what the upsert ends up binding.
+pub(crate) fn retained_account_bytes(
+    results: &[TransactionProcessingResult],
+    transactions: &[SanitizedTransaction],
+) -> usize {
+    results
+        .iter()
+        .zip(transactions.iter())
+        .map(|(result, transaction)| retained_bytes_of(result, transaction))
+        .sum()
+}
+
+/// The same count for a single transaction, so the send-side chunker can size
+/// one at a time instead of re-walking the whole batch.
+pub(crate) fn retained_bytes_of(
+    result: &TransactionProcessingResult,
+    transaction: &SanitizedTransaction,
+) -> usize {
+    let Ok(ProcessedTransaction::Executed(executed)) = result else {
+        return 0;
+    };
+    executed
+        .loaded_transaction
+        .accounts
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| transaction.is_writable(*index))
+        .map(|(_, (_, account))| account.data().len())
+        .sum()
+}
+
 struct SettleResult {
     slot: u64,
     blockhash: Hash,
@@ -314,6 +352,8 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                 _ => None,
             };
             let mut processing_results = Vec::new();
+            // Settled bytes since the last block; gates the recv arm below.
+            let mut buffered_account_bytes = 0usize;
 
             // High-water mark of executor generations buffered so far. It is
             // worker-loop state rather than settle state because it describes
@@ -364,6 +404,9 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                     // whatever has accumulated since the last tick.
                     _ = blocktime_interval.tick() => {
                         let num_results = processing_results.len();
+                        if buffered_account_bytes >= MAX_BUFFERED_SETTLE_BYTES {
+                            metrics.settler_backpressure_engaged();
+                        }
                         match settle_transactions(
                             last_block.clone(),
                             &mut accounts_db,
@@ -389,6 +432,8 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                                     blockhash: settle_result.blockhash,
                                 });
                                 processing_results.clear();
+                                buffered_account_bytes = 0;
+                                metrics.settler_buffered_account_bytes(0);
                                 debug!(
                                     "Settled {} transactions in slot {}, blockhash {}",
                                     num_results,
@@ -436,8 +481,11 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                         }
                     }
 
-                    // Accumulate execution results — never flush here, just buffer.
-                    result = execution_results_rx.recv() => {
+                    // Buffer execution results, never settle them here.
+                    // Over budget, this arm switches off and the queue backs up,
+                    // which parks the executor until the tick below drains us.
+                    result = execution_results_rx.recv(),
+                        if buffered_account_bytes < MAX_BUFFERED_SETTLE_BYTES => {
                         match result {
                             Some((svm_output, transactions, generation)) => {
                                 heartbeat.record_input();
@@ -447,6 +495,12 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                                     break;
                                 }
                                 debug!("Extending {} processing results", svm_output.processing_results.len());
+                                // Measured before the extend consumes both vectors.
+                                buffered_account_bytes += retained_account_bytes(
+                                    &svm_output.processing_results,
+                                    &transactions,
+                                );
+                                metrics.settler_buffered_account_bytes(buffered_account_bytes);
                                 processing_results.extend(svm_output.processing_results.into_iter().zip(transactions.into_iter()));
                                 // Fold only once the batch is buffered, so the watermark can
                                 // never cover a batch that was rejected above and therefore
@@ -504,6 +558,8 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                     }
                 }
                 processing_results.clear();
+                buffered_account_bytes = 0;
+                metrics.settler_buffered_account_bytes(buffered_account_bytes);
             }
 
             info!("Settle worker stopped");
@@ -879,6 +935,7 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use crate::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY as RESULTS_CAP;
+    use crate::stage_metrics::PrometheusMetrics;
 
     /// Settle `results` and capture the accounts published on the broadcast
     /// channel (the path the worker consumes), returning them with the result so
@@ -957,6 +1014,571 @@ mod tests {
 
     fn sig(byte: u8) -> Signature {
         Signature::from([byte; 64])
+    }
+
+    /// One batch whose single writable account carries `bytes` of data.
+    fn sized_settle_batch(
+        bytes: usize,
+    ) -> (
+        LoadAndExecuteSanitizedTransactionsOutput,
+        Vec<SanitizedTransaction>,
+    ) {
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 100);
+        let executed = make_executed(vec![
+            (
+                from.pubkey(),
+                AccountSharedData::new(1, bytes, &Pubkey::default()),
+            ),
+            (to, AccountSharedData::new(1, 0, &Pubkey::default())),
+        ]);
+        (
+            LoadAndExecuteSanitizedTransactionsOutput {
+                processing_results: vec![Ok(executed)],
+                error_metrics: Default::default(),
+                execute_timings: Default::default(),
+                balance_collector: None,
+            },
+            vec![tx],
+        )
+    }
+
+    /// Highest value currently reported by one settler gauge family.
+    fn settler_gauge(name: &str) -> f64 {
+        private_channel_metrics::prometheus::gather()
+            .into_iter()
+            .filter(|mf| mf.name() == name)
+            .flat_map(|mf| mf.get_metric().to_vec())
+            .map(|m| m.get_gauge().value())
+            .fold(0.0, f64::max)
+    }
+
+    /// Sum of one settler counter family, sampled as a delta by the callers.
+    fn settler_metric(name: &str) -> f64 {
+        private_channel_metrics::prometheus::gather()
+            .into_iter()
+            .filter(|mf| mf.name() == name)
+            .flat_map(|mf| mf.get_metric().to_vec())
+            .map(|m| m.get_counter().value())
+            .sum()
+    }
+
+    /// A batch whose writable account carries `bytes` but whose tx rolled back.
+    fn failed_sized_settle_batch(
+        bytes: usize,
+    ) -> (
+        LoadAndExecuteSanitizedTransactionsOutput,
+        Vec<SanitizedTransaction>,
+    ) {
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 100);
+        let executed = make_failed_executed(vec![
+            (
+                from.pubkey(),
+                AccountSharedData::new(1, bytes, &Pubkey::default()),
+            ),
+            (to, AccountSharedData::new(1, 0, &Pubkey::default())),
+        ]);
+        (
+            LoadAndExecuteSanitizedTransactionsOutput {
+                processing_results: vec![Ok(executed)],
+                error_metrics: Default::default(),
+                execute_timings: Default::default(),
+                balance_collector: None,
+            },
+            vec![tx],
+        )
+    }
+
+    /// Unread receivers held alive; dropping the address-index one is fatal.
+    struct SettlerSinks {
+        _blockhashes_rx: mpsc::UnboundedReceiver<Hash>,
+        _address_signatures_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
+    }
+
+    /// Settler on a throwaway Postgres, with the channels the assertions read.
+    #[allow(clippy::type_complexity)]
+    async fn settler_under_test(
+        url: String,
+        blocktime_ms: u64,
+        capacity: usize,
+        metrics: SharedMetrics,
+        shutdown: CancellationToken,
+    ) -> (
+        mpsc::Sender<ExecutedBatch>,
+        mpsc::UnboundedReceiver<AccountSettlements>,
+        WorkerHandle,
+        SettlerSinks,
+    ) {
+        let (exec_tx, exec_rx) = mpsc::channel(capacity);
+        let (settled_accounts_tx, settled_accounts_rx) = mpsc::unbounded_channel();
+        let (settled_blockhashes_tx, blockhashes_rx) = mpsc::unbounded_channel();
+        let (address_signatures_tx, address_signatures_rx) = mpsc::channel(64);
+        let handle = start_settle_worker(SettleArgs {
+            execution_results_rx: exec_rx,
+            settled_accounts_tx,
+            settled_blockhashes_tx,
+            address_signatures_tx,
+            accountsdb_connection_url: url,
+            redis_cache_url: None,
+            blocktime_ms,
+            perf_sample_period_secs: 3600,
+            shutdown_token: shutdown,
+            metrics,
+            heartbeat: crate::health::StageHeartbeat::new(),
+        })
+        .await;
+        (
+            exec_tx,
+            settled_accounts_rx,
+            handle,
+            SettlerSinks {
+                _blockhashes_rx: blockhashes_rx,
+                _address_signatures_rx: address_signatures_rx,
+            },
+        )
+    }
+
+    /// The finding itself: unguarded, the settler drains forever and one tick can
+    /// bind an unbounded array. Guarded, the channel backs up and parks the
+    /// executor instead, so a full channel here means the fix is working.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settler_stops_draining_when_byte_budget_exceeded() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        // A long blocktime means no tick rescues the buffer during the test.
+        let (exec_tx, _rx, _h, _sinks) =
+            settler_under_test(url, 60_000, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
+
+        // An eighth of the budget each, so the guard trips before all of them fit.
+        let batch_bytes = MAX_BUFFERED_SETTLE_BYTES / 8;
+        let mut blocked = false;
+        for _ in 0..64 {
+            let (output, txs) = sized_settle_batch(batch_bytes);
+            match exec_tx.try_send((output, txs, 1)) {
+                Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    blocked = true;
+                    break;
+                }
+                Err(e) => panic!("unexpected send error: {:?}", e),
+            }
+        }
+        assert!(
+            blocked,
+            "settler must stop draining once the byte budget is reached"
+        );
+        shutdown.cancel();
+    }
+
+    /// A guard that never reopens is a wedge; this also proves the counter resets.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settler_resumes_draining_after_tick_flush() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        let (exec_tx, mut settled_rx, _h, _sinks) =
+            settler_under_test(url, 50, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
+
+        let batch_bytes = MAX_BUFFERED_SETTLE_BYTES / 4;
+        let mut delivered = 0;
+        for _ in 0..12 {
+            let (output, txs) = sized_settle_batch(batch_bytes);
+            if tokio::time::timeout(Duration::from_secs(10), exec_tx.send((output, txs, 1)))
+                .await
+                .is_ok()
+            {
+                delivered += 1;
+            }
+        }
+        assert!(
+            delivered >= 8,
+            "ticks must drain the buffer and reopen the guard, delivered {}",
+            delivered
+        );
+
+        let settled = tokio::time::timeout(Duration::from_secs(10), settled_rx.recv()).await;
+        assert!(
+            settled.is_ok(),
+            "settlements must still flow under backpressure"
+        );
+        shutdown.cancel();
+    }
+
+    /// Pins the claimed bound: the budget plus the one message already accepted
+    /// when the guard shut. Only the upper bound is asserted, because the gauge is
+    /// a process-global static another settler may also be writing.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn buffered_bytes_stay_within_budget_plus_one_batch() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        // No tick while sampling, and a one-slot channel blocks sends until a drain.
+        let (exec_tx, _rx, _h, _sinks) = settler_under_test(
+            url,
+            600_000,
+            1,
+            Arc::new(PrometheusMetrics),
+            shutdown.clone(),
+        )
+        .await;
+
+        let batch_bytes = MAX_BUFFERED_SETTLE_BYTES / 4;
+        let feeder = tokio::spawn(async move {
+            for _ in 0..16 {
+                let (output, txs) = sized_settle_batch(batch_bytes);
+                if exec_tx.send((output, txs, 1)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Poll while the settler drains, so the peak is observed rather than raced.
+        let mut peak = 0f64;
+        for _ in 0..100 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            peak = peak.max(settler_gauge(
+                "private_channel_settler_buffered_account_bytes",
+            ));
+            if peak >= MAX_BUFFERED_SETTLE_BYTES as f64 {
+                break;
+            }
+        }
+
+        feeder.abort();
+        assert!(peak > 0.0, "the gauge must be observed moving");
+        assert!(
+            peak <= (MAX_BUFFERED_SETTLE_BYTES + batch_bytes) as f64,
+            "buffer {} exceeded budget {} plus one batch {}",
+            peak,
+            MAX_BUFFERED_SETTLE_BYTES,
+            batch_bytes
+        );
+        shutdown.cancel();
+    }
+
+    /// A rolled-back transaction still pins what it allocated. Metering only
+    /// successful writes would let a caller allocate megabytes, fail the
+    /// transaction, and fill the heap while the guard read zero.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rolled_back_allocations_still_engage_the_guard() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        let (exec_tx, _rx, _h, _sinks) =
+            settler_under_test(url, 600_000, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
+
+        let batch_bytes = MAX_BUFFERED_SETTLE_BYTES / 8;
+        let mut blocked = false;
+        for _ in 0..64 {
+            let (output, txs) = failed_sized_settle_batch(batch_bytes);
+            match exec_tx.try_send((output, txs, 1)) {
+                Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    blocked = true;
+                    break;
+                }
+                Err(e) => panic!("unexpected send error: {:?}", e),
+            }
+        }
+        assert!(
+            blocked,
+            "rolled-back allocations must count toward the byte budget"
+        );
+        shutdown.cancel();
+    }
+
+    /// Ordinary traffic must never trip the guard, catching any units error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn normal_traffic_never_engages_backpressure() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+        let before = settler_metric("private_channel_settler_backpressure_engaged_total");
+
+        let (exec_tx, mut settled_rx, _h, _sinks) = settler_under_test(
+            url,
+            50,
+            RESULTS_CAP,
+            Arc::new(PrometheusMetrics),
+            shutdown.clone(),
+        )
+        .await;
+
+        for _ in 0..20 {
+            let (output, txs) = sized_settle_batch(128);
+            exec_tx.send((output, txs, 1)).await.unwrap();
+        }
+        let settled = tokio::time::timeout(Duration::from_secs(10), settled_rx.recv()).await;
+        assert!(settled.is_ok(), "ordinary traffic must settle");
+
+        let after = settler_metric("private_channel_settler_backpressure_engaged_total");
+        assert_eq!(
+            before, after,
+            "small batches must never engage backpressure"
+        );
+        shutdown.cancel();
+    }
+
+    /// If the watermark acknowledged an undrained batch, BOB would mark a
+    /// non-durable account clean and lose the write. The generation must only ever
+    /// describe what the settler actually committed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn generation_watermark_excludes_undrained_batches() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        let (exec_tx, mut settled_rx, _h, _sinks) =
+            settler_under_test(url, 400, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
+
+        // Generation 1 saturates the buffer on its own.
+        let (output, txs) = sized_settle_batch(MAX_BUFFERED_SETTLE_BYTES + 4096);
+        exec_tx.send((output, txs, 1)).await.unwrap();
+
+        // Generation 2 cannot be drained while the guard is shut.
+        let (output2, txs2) = sized_settle_batch(4096);
+        let _ = exec_tx.try_send((output2, txs2, 2));
+
+        let settlements = tokio::time::timeout(Duration::from_secs(10), settled_rx.recv())
+            .await
+            .expect("a tick must fire")
+            .expect("feedback channel stays open");
+        assert_eq!(
+            settlements.generation, 1,
+            "the watermark must not acknowledge an undrained batch"
+        );
+        shutdown.cancel();
+    }
+
+    /// Backpressure must not read as a stall, or the health valve would restart
+    /// the node under load, which is worse than the bug being fixed. The tick keeps
+    /// recording progress while the guard is shut, so health must hold.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settler_stays_healthy_while_backpressured() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        let (exec_tx, exec_rx) = mpsc::channel(1);
+        let (settled_accounts_tx, mut settled_rx) = mpsc::unbounded_channel();
+        let (settled_blockhashes_tx, _bh_rx) = mpsc::unbounded_channel();
+        let (address_signatures_tx, _as_rx) = mpsc::channel(64);
+        let heartbeat = crate::health::StageHeartbeat::new();
+        let _handle = start_settle_worker(SettleArgs {
+            execution_results_rx: exec_rx,
+            settled_accounts_tx,
+            settled_blockhashes_tx,
+            address_signatures_tx,
+            accountsdb_connection_url: url,
+            redis_cache_url: None,
+            blocktime_ms: 100,
+            perf_sample_period_secs: 3600,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: Arc::clone(&heartbeat),
+        })
+        .await;
+
+        // Half the budget each, fed continuously, so the guard keeps re-engaging.
+        let feeder = tokio::spawn(async move {
+            loop {
+                let (output, txs) = sized_settle_batch(MAX_BUFFERED_SETTLE_BYTES / 2);
+                if exec_tx.send((output, txs, 1)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Progress is only recorded by a completed tick, so wait for the first.
+        let first = tokio::time::timeout(Duration::from_secs(60), settled_rx.recv()).await;
+        assert!(first.is_ok(), "settler must produce a first block");
+
+        for _ in 0..5 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            assert!(
+                heartbeat.is_healthy(),
+                "settler must stay healthy while backpressured"
+            );
+        }
+
+        feeder.abort();
+        shutdown.cancel();
+    }
+
+    /// The final flush must commit a saturated buffer and reset the counter.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_flush_commits_saturated_buffer() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        let (exec_tx, _rx, handle, _sinks) =
+            settler_under_test(url, 60_000, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
+
+        let (output, txs) = sized_settle_batch(MAX_BUFFERED_SETTLE_BYTES + 4096);
+        exec_tx.send((output, txs, 1)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        shutdown.cancel();
+        let exited = tokio::time::timeout(Duration::from_secs(15), handle.handle).await;
+        assert!(exited.is_ok(), "final flush must exit promptly");
+    }
+
+    /// Account holding `len` bytes of data, funded so it is not a tombstone.
+    fn sized_account(len: usize) -> AccountSharedData {
+        AccountSharedData::new(1, len, &Pubkey::default())
+    }
+
+    /// A transfer's account list: 0 and 1 writable, 2 the read-only program slot.
+    fn transfer_accounts(
+        from: Pubkey,
+        to: Pubkey,
+        first: AccountSharedData,
+        second: AccountSharedData,
+        readonly: AccountSharedData,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        vec![
+            (from, first),
+            (to, second),
+            (Pubkey::new_unique(), readonly),
+        ]
+    }
+
+    /// Each row is one way the meter could drift from what the buffer retains.
+    #[test]
+    fn retained_account_bytes_counts_what_the_buffer_holds() {
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 100);
+        let fp = from.pubkey();
+
+        let readonly = sized_account(4096);
+        let empty = sized_account(0);
+
+        let fees_only = ProcessedTransaction::FeesOnly(Box::new(FeesOnlyTransaction {
+            load_error: solana_transaction_error::TransactionError::InsufficientFundsForFee,
+            rollback_accounts: RollbackAccounts::FeePayerOnly {
+                fee_payer_account: AccountSharedData::new(900, 0, &Pubkey::default()),
+            },
+            fee_details: Default::default(),
+        }));
+
+        let cases: Vec<(&str, TransactionProcessingResult, usize)> = vec![
+            (
+                "writable, successful, funded",
+                Ok(make_executed(transfer_accounts(
+                    fp,
+                    to,
+                    sized_account(4096),
+                    empty.clone(),
+                    readonly.clone(),
+                ))),
+                4096,
+            ),
+            (
+                "read-only slot is excluded",
+                Ok(make_executed(transfer_accounts(
+                    fp,
+                    to,
+                    empty.clone(),
+                    empty.clone(),
+                    readonly.clone(),
+                ))),
+                0,
+            ),
+            (
+                "a rolled-back tx still holds what it allocated",
+                Ok(make_failed_executed(transfer_accounts(
+                    fp,
+                    to,
+                    sized_account(4096),
+                    empty.clone(),
+                    readonly.clone(),
+                ))),
+                4096,
+            ),
+            (
+                "a zero-lamport account still occupies its bytes",
+                Ok(make_executed(transfer_accounts(
+                    fp,
+                    to,
+                    AccountSharedData::new(0, 4096, &Pubkey::default()),
+                    empty.clone(),
+                    readonly.clone(),
+                ))),
+                4096,
+            ),
+            ("fees-only writes nothing", Ok(fees_only), 0),
+            (
+                "failed transaction writes nothing",
+                Err(solana_transaction_error::TransactionError::AccountNotFound),
+                0,
+            ),
+            (
+                "both writable slots are summed",
+                Ok(make_executed(transfer_accounts(
+                    fp,
+                    to,
+                    sized_account(4096),
+                    sized_account(8192),
+                    readonly.clone(),
+                ))),
+                12288,
+            ),
+        ];
+
+        for (name, result, expected) in cases {
+            let got =
+                retained_account_bytes(std::slice::from_ref(&result), std::slice::from_ref(&tx));
+            assert_eq!(got, expected, "row: {}", name);
+        }
+    }
+
+    /// The meter sums per batch while the settler dedupes by pubkey, so it may
+    /// over-count but never under-count. Under-counting would let the buffer pass
+    /// the budget unnoticed, which is exactly what the guard exists to stop.
+    #[test]
+    fn meter_never_undercounts_what_the_settler_writes() {
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 100);
+        let fp = from.pubkey();
+
+        // The same pubkey written twice collapses to one entry downstream.
+        let results = vec![
+            Ok(make_executed(transfer_accounts(
+                fp,
+                to,
+                sized_account(4096),
+                sized_account(0),
+                sized_account(4096),
+            ))),
+            Ok(make_executed(transfer_accounts(
+                fp,
+                to,
+                sized_account(4096),
+                sized_account(0),
+                sized_account(4096),
+            ))),
+        ];
+        let txs = vec![tx.clone(), tx.clone()];
+
+        let metered = retained_account_bytes(&results, &txs);
+        let settled_unique = 4096;
+
+        assert_eq!(metered, 8192, "the meter sums per transaction");
+        assert!(
+            metered >= settled_unique,
+            "the meter must never report fewer bytes than the settler writes"
+        );
     }
 
     #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -20,7 +20,7 @@ Reference for configuring, tuning, and operating Solana Private Channels service
 | `--sigverify-queue-size` | `PRIVATE_CHANNEL_SIGVERIFY_QUEUE_SIZE` | `1000` | Bounded queue between dedup and sigverify |
 | `--ingress-queue-capacity` | `PRIVATE_CHANNEL_INGRESS_QUEUE_CAPACITY` | `10000` | Bounded RPC→dedup queue; a full queue sheds (`sendTransaction` returns `-32003`, retryable) and increments `rpc_ingress_shed_total` |
 | `--sequencer-queue-capacity` | `PRIVATE_CHANNEL_SEQUENCER_QUEUE_CAPACITY` | `1000` | Bounded sigverify→sequencer queue; a full queue applies upstream backpressure |
-| `--execution-results-capacity` | `PRIVATE_CHANNEL_EXECUTION_RESULTS_CAPACITY` | `1000` | Bounded executor→settler queue; a full queue applies upstream backpressure |
+| `--execution-results-capacity` | `PRIVATE_CHANNEL_EXECUTION_RESULTS_CAPACITY` | `1000` | Bounded executor→settler queue; a full queue applies upstream backpressure. The settler also stops draining once a tick's buffered account bytes reach an internal budget, so the queue is bounded by bytes as well as depth |
 | `--max-tx-per-batch` | `PRIVATE_CHANNEL_MAX_TX_PER_BATCH` | `64` | Max transactions per sequencer batch |
 | `--max-connections` | `PRIVATE_CHANNEL_MAX_CONNECTIONS` | `100` | Max concurrent RPC connections |
 | `--blocktime-ms` | `PRIVATE_CHANNEL_BLOCKTIME_MS` | `100` | Settlement interval (ms) |

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -136,6 +136,8 @@ Batches execution results every 100ms (configurable) and commits to PostgreSQL, 
 
 The mirror is best-effort and covers only what the cache can serve: point lookups by pubkey, signature and slot, plus the chain tip. Ranges, history and counters are read from PostgreSQL, because a short answer from a partial mirror is indistinguishable from a complete one. A failed cache write drops the keys it would have updated so reads miss and resolve against PostgreSQL, and leaves the cached tip behind, which makes the next batch rebuild the cache.
 
+The settler also caps the settled account bytes it buffers between ticks. Once a tick's buffer reaches that budget it stops draining the executor queue, so the executor's bounded send applies backpressure upstream rather than letting one commit grow without limit. Blocks are still produced only on the tick, never early, and the executor splits an oversized batch into byte-bounded messages so a single already-executed batch cannot overshoot the budget. The commit itself binds each column as one array parameter, so bounding the buffer is what bounds the bind; the driver is held at sqlx 0.8 or later, where an oversized bind fails loudly instead of being truncated by the binary protocol's length prefix.
+
 Finally, the settler notifies the executor's in-memory cache (BOB) of settled accounts, completing the feedback loop.
 
 **Location**: [`core/src/stages/settle.rs`](../core/src/stages/settle.rs)

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -53,7 +53,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 futures = { workspace = true }
 async-trait = "0.1"
-bigdecimal = "0.3"
+bigdecimal = "0.4"
 borsh = { workspace = true }
 const-crypto = { workspace = true }
 private-channel-core = { workspace = true }
@@ -80,7 +80,7 @@ rustls = { workspace = true, optional = true }
 solana-keychain = { version = "0.1.0", features = ["all"] }
 
 [dev-dependencies]
-bigdecimal = "0.3"
+bigdecimal = "0.4"
 figment = { workspace = true, features = ["test"] }
 tokio = { workspace = true, features = ["test-util"] }
 spl-associated-token-account = { workspace = true }

--- a/indexer/src/storage/common/amount.rs
+++ b/indexer/src/storage/common/amount.rs
@@ -85,7 +85,7 @@ impl Type<Postgres> for TokenAmount {
 }
 
 impl Encode<'_, Postgres> for TokenAmount {
-    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         let value = BigDecimal::from(self.0);
         <BigDecimal as Encode<Postgres>>::encode_by_ref(&value, buf)
     }
@@ -123,6 +123,21 @@ mod tests {
         for v in [0u64, 1, i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
             let bd = BigDecimal::from(v);
             assert_eq!(u64_from_big_decimal(&bd).unwrap(), v);
+        }
+    }
+
+    /// sqlx 0.8 made encoding fallible so oversized values error instead of being
+    /// truncated. A u64 amount can never be that large, so encoding must never fail
+    /// here; an Err would be a silent write failure on a money column.
+    #[test]
+    fn encode_never_fails_across_the_u64_range() {
+        for v in [0u64, 1, i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+            let mut buf = PgArgumentBuffer::default();
+            let is_null = TokenAmount(v)
+                .encode_by_ref(&mut buf)
+                .unwrap_or_else(|e| panic!("encoding {v} failed: {e}"));
+            assert!(matches!(is_null, IsNull::No), "amount {v} encoded as NULL");
+            assert!(!buf.is_empty(), "amount {v} encoded to no bytes");
         }
     }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -1199,11 +1199,11 @@ mod tests {
             .unwrap();
         assert_eq!(balances.len(), 2);
         assert!(balances.iter().any(|b| b.mint_address == "usdc"
-            && b.total_deposits == BigDecimal::from(10000u64)
-            && b.total_withdrawals == BigDecimal::from(5000u64)));
+            && b.total_deposits == 10000u64
+            && b.total_withdrawals == 5000u64));
         assert!(balances.iter().any(|b| b.mint_address == "usdt"
-            && b.total_deposits == BigDecimal::from(8000u64)
-            && b.total_withdrawals == BigDecimal::from(3000u64)));
+            && b.total_deposits == 8000u64
+            && b.total_withdrawals == 3000u64));
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Summary

The settler buffered execution results without accounting for their byte size, allowing a single tick's `write_batch` to grow arbitrarily large, bounded only by channel depth and batch size. At around 1 GB, Postgres can reject the `bytea[]` parameter and stop block production; beyond the `i32` length cast, sqlx 0.7.4 is affected by RUSTSEC-2024-0363. In practice, heap exhaustion can happen first because account data is retained multiple times along the settlement path.

This PR adds byte-based backpressure at three points. The settler now tracks retained account bytes, including rolled-back and zero-lamport writes, and stops receiving at 64 MiB so the already-bounded executor queue backpressures upstream. Oversized execution batches are split into byte-bounded messages without splitting individual transactions. Only the final chunk carries the real BOB generation; earlier chunks use zero, which already means "acknowledges nothing," preventing a partial drain from marking undrained writes as durable. sqlx is also upgraded to 0.8, which includes the fix for RUSTSEC-2024-0363.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 16,316 | 17,957 | 90.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326270) |
| Indexer | 36,850 | 40,466 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326270) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326270) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326270) |
| Withdraw Program | 129 | 241 | 53.5% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326423) |
| Escrow Program | 1,195 | 1,982 | 60.3% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326423) |
| DvP Swap Program | 270 | 1,179 | 22.9% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326423) |
| E2E Integration | 14,698 | 18,887 | 77.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/32971326270) |
| **Total** | **72,134** | **82,931** | **87.0%** | |

> Last updated: 2026-08-26 13:41:09 UTC by E2E Integration