### PR TITLE
fix(indexer): reject unsupported withdrawal mints before the target-chain lookup (issue-219)

### DIFF
--- a/docs/runbooks/_glossary.md
+++ b/docs/runbooks/_glossary.md
@@ -18,7 +18,7 @@ DB type `transaction_status`.
 | `completed` | yes | no | Withdrawal release or deposit mint confirmed on-chain. |
 | `failed` | yes | yes | Terminal failure with no on-chain proof. **Primary alert for deposits** (sender-side failures terminate here since there is no remint path). Rare for withdrawals - those go through `pending_remint`. |
 | `failed_reminted` | yes | yes | **Withdrawal-only.** Original withdrawal failed, remint of burned private channel tokens succeeded. Deposits do not have a remint path. |
-| `manual_review` | yes | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: six triggers (build error → halt, pre-flight bail → no halt, four sender-side ambiguities). Deposits: build error, sender-side post-JIT mint failure, or processor-side allowlist-gate rejection (no halt, no sweep). |
+| `manual_review` | yes | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: seven triggers (build error, which halts; allowlist gate and pre-flight bail, which do not; four sender-side ambiguities). Deposits: build error, sender-side post-JIT mint failure, or processor-side allowlist-gate rejection (no halt, no sweep). |
 
 Webhook receivers should treat `failed`, `failed_reminted`, `manual_review` as
 the alertable set. Source: `indexer/src/operator/db_transaction_writer.rs`,

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -39,6 +39,8 @@ have prefixes.
 | (empty `error_message`, status flipped without a quarantine update) | A.halting (collateral row) | yes | `quarantine_all_active_withdrawals` |
 | `mint paused:` | A.non-halting | no | pre-flight |
 | `insufficient escrow balance:` | A.non-halting | no | pre-flight |
+| `unsupported withdrawal mint:` | A.non-halting | no | allowlist gate |
+| `withdrawal mint absent on target chain:` | A.non-halting | no | pre-flight |
 | `remint failed:` | B - stranded after remint failure | no | `sender/remint.rs` |
 | `finality check failed after` | C - ambiguous (RPC unreachable) | no | `sender/remint.rs` |
 | `no signatures to verify` | C - ambiguous (RPC may have broadcast) | no | `sender/transaction.rs` |
@@ -113,13 +115,21 @@ collateral.
 6. **Confirm recovery** by watching for new `Completed` webhooks for
    the re-armed rows.
 
-## Path A.non-halting - pre-flight bail (paused mint, escrow drain)
+## Path A.non-halting - row-specific bail (allowlist gate, paused mint, escrow drain)
 
-The pre-flight check (`processor.rs::check_withdrawal_preflights`) bailed
-on a row whose mint is paused or whose target ATA does not have enough
-on-chain balance. The processor quarantined **only this row** and
-**continued the loop** - there is no halt and no collateral. Other
-withdrawals are unaffected.
+One of two checks bailed on this row. `processor.rs::check_withdrawal_mint_supported`
+runs first and emits `unsupported withdrawal mint:`;
+`processor.rs::check_withdrawal_preflights` runs after it and emits
+`mint paused:`, `insufficient escrow balance:`, and
+`withdrawal mint absent on target chain:`. Either way the processor parked
+**only this row** and **continued the loop** - there is no halt and no
+collateral. Other withdrawals are unaffected.
+
+Note that parking is not a refund. `WithdrawFunds` burns the user's channel
+tokens before the row exists, and a row parked here never reaches the
+sender, so the compensating remint that normally restores those tokens
+after a permanent release failure never runs. Every disposition below has
+to say explicitly what the user is owed.
 
 1. **Verify on-chain.** Run [`_verify_onchain_release.md`](_verify_onchain_release.md)
    for this row. Expected: `NOT_LANDED` (pre-flight aborted before send).
@@ -133,6 +143,32 @@ withdrawals are unaffected.
    - `insufficient escrow balance:` - check the escrow ATA balance vs.
      the row's amount. A permanent delegate may have drained the ATA. If
      the deficit is permanent, refund out-of-band; do not re-arm.
+   - `unsupported withdrawal mint:` - the escrow never allowlisted this mint,
+     so no escrowed funds back the row. Confirm with
+     `SELECT * FROM mints WHERE mint_address = :mint;` (no row) and compare
+     the checkpoint quoted in the message against
+     `SELECT slot FROM indexer_state WHERE program_type = 'escrow';`. If the
+     checkpoint is current or absent, the mint is genuinely unsupported: do
+     not re-arm, and mark `failed`. No escrowed funds back the row, but the
+     user's channel tokens were burned to create it, so decide and record
+     whether to restore them by an admin mint on the channel. If the
+     escrow indexer is instead behind the slot that allowed the mint, fix the
+     backfill first, then re-arm. If the parked row's `withdrawal_nonce` is a
+     multiple of the tree size, marking it `failed` releases later withdrawals
+     onto a tree generation that was never rotated, so rotate before you
+     terminalize it; this applies to any terminalized boundary row, not just
+     this one. [Escalate](_escalation.md) (Tier 3) either
+     way: a burn of an unsupported mint means one was created or distributed
+     on the channel without a matching `AllowMint`.
+   - `withdrawal mint absent on target chain:` - the mint is allowlisted but
+     has no account on the target chain. Check `solana account <mint> --url
+     <target-rpc>` **and** confirm `rpc_url` points at the cluster the escrow
+     is deployed on; a wrong cluster makes every mint read as absent and is the
+     more common cause. If the cluster is wrong, correct `rpc_url`, restart the
+     operator, and re-arm the parked rows. If the cluster is right and the
+     account is genuinely gone, do not re-arm; refund out-of-band, and note
+     that the channel tokens were burned too. [Escalate](_escalation.md)
+     (Tier 2).
 3. **If the condition has cleared, re-arm just this row:**
    ```sql
    UPDATE transactions

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -143,32 +143,36 @@ to say explicitly what the user is owed.
    - `insufficient escrow balance:` - check the escrow ATA balance vs.
      the row's amount. A permanent delegate may have drained the ATA. If
      the deficit is permanent, refund out-of-band; do not re-arm.
-   - `unsupported withdrawal mint:` - the escrow never allowlisted this mint,
-     so no escrowed funds back the row. Confirm with
-     `SELECT * FROM mints WHERE mint_address = :mint;` (no row) and compare
-     the checkpoint quoted in the message against
-     `SELECT slot FROM indexer_state WHERE program_type = 'escrow';`. If the
-     checkpoint is current or absent, the mint is genuinely unsupported: do
-     not re-arm, and mark `failed`. No escrowed funds back the row, but the
-     user's channel tokens were burned to create it, so decide and record
-     whether to restore them by an admin mint on the channel. If the
-     escrow indexer is instead behind the slot that allowed the mint, fix the
-     backfill first, then re-arm. If the parked row's `withdrawal_nonce` is a
-     multiple of the tree size, marking it `failed` releases later withdrawals
-     onto a tree generation that was never rotated, so rotate before you
-     terminalize it; this applies to any terminalized boundary row, not just
-     this one. [Escalate](_escalation.md) (Tier 3) either
-     way: a burn of an unsupported mint means one was created or distributed
-     on the channel without a matching `AllowMint`.
-   - `withdrawal mint absent on target chain:` - the mint is allowlisted but
-     has no account on the target chain. Check `solana account <mint> --url
-     <target-rpc>` **and** confirm `rpc_url` points at the cluster the escrow
-     is deployed on; a wrong cluster makes every mint read as absent and is the
-     more common cause. If the cluster is wrong, correct `rpc_url`, restart the
-     operator, and re-arm the parked rows. If the cluster is right and the
-     account is genuinely gone, do not re-arm; refund out-of-band, and note
-     that the channel tokens were burned too. [Escalate](_escalation.md)
-     (Tier 2).
+   - `unsupported withdrawal mint:` - the escrow has no `AllowedMint` account for
+     this mint, which is the same account `release_funds` requires, so the release
+     could not have landed. Two causes, and they need opposite responses. Confirm
+     which with `solana account $(allowed-mint-pda <instance> <mint>) --url
+     <target-rpc>`, then:
+     - **Never allowlisted.** No escrowed funds back the row. Do not re-arm; mark
+       `failed`. The user's channel tokens were burned to create the row, so decide
+       and record whether to restore them by an admin mint on the channel.
+       [Escalate](_escalation.md) (Tier 3): a burn of an unsupported mint means one
+       was created or distributed on the channel without a matching `AllowMint`.
+     - **Allowlisted, then blocked.** `BlockMint` closes the account, and escrowed
+       funds are still held. The withdrawal cannot proceed while the mint is blocked,
+       because the escrow program rejects the release. Either re-allow the mint and
+       re-arm the row, or refund out-of-band from the escrow.
+       [Escalate](_escalation.md) (Tier 2).
+
+     Either way, if the parked row's `withdrawal_nonce` is a multiple of the tree
+     size, marking it `failed` releases later withdrawals onto a tree generation
+     that was never rotated, so rotate before you terminalize it. This applies to
+     any terminalized boundary row, not just this one.
+   - `withdrawal mint absent on target chain:` - the mint was allowlisted, so its
+     account existed then, and the node answered from a slot at or past that allow
+     before reporting nothing. A lagging node cannot produce this message; it
+     errors and the operator retries instead. So the account was closed, or
+     `rpc_url` points at a different cluster from the one the escrow is deployed
+     on. Check `solana account <mint> --url <target-rpc>` and confirm the cluster.
+     If the cluster is wrong, correct `rpc_url`, restart the operator, and re-arm
+     the parked rows. If it is right and the account is gone, do not re-arm;
+     refund out-of-band, and note that the channel tokens were burned too.
+     [Escalate](_escalation.md) (Tier 2).
 3. **If the condition has cleared, re-arm just this row:**
    ```sql
    UPDATE transactions

--- a/indexer/src/error/account.rs
+++ b/indexer/src/error/account.rs
@@ -6,6 +6,11 @@ pub enum AccountError {
     #[error("Account {pubkey} not found")]
     AccountNotFound { pubkey: Pubkey },
 
+    /// The node answered and the mint is genuinely absent from the target chain.
+    /// Kept apart from `AccountNotFound`, which a read that may heal also produces.
+    #[error("Mint {pubkey} not found on target chain")]
+    TargetMintMissing { pubkey: Pubkey },
+
     #[error("Instance {instance} not found")]
     InstanceNotFound { instance: Pubkey },
 

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -153,6 +153,21 @@ counter_vec!(
     &["program_type", "reason"]
 );
 
+/// Reason labels for the withdrawal bails that park one row and leave the
+/// pipeline running. Kept here so the emitting code and the pre-registration
+/// below read one list and a label cannot exist in only one of them.
+pub const BAIL_REASON_UNSUPPORTED_MINT: &str = "unsupported_mint";
+pub const BAIL_REASON_TARGET_MINT_MISSING: &str = "target_mint_missing";
+pub const BAIL_REASON_MINT_PAUSED: &str = "mint_paused";
+pub const BAIL_REASON_ESCROW_DRAINED: &str = "escrow_drained";
+
+pub const BAIL_REASONS: [&str; 4] = [
+    BAIL_REASON_UNSUPPORTED_MINT,
+    BAIL_REASON_TARGET_MINT_MISSING,
+    BAIL_REASON_MINT_PAUSED,
+    BAIL_REASON_ESCROW_DRAINED,
+];
+
 // Supervision: a critical task inside the operator exited.  The supervisor
 // aborts the process immediately when this increments; the counter exists
 // so dashboards can alert even if the restart is fast.
@@ -308,9 +323,18 @@ pub fn init_labels(program_type: &str) {
     FEEPAYER_BALANCE_LAMPORTS.with_label_values(&[program_type]);
 
     // Quarantine reasons must match the string constants returned by
-    // `classify_processor_error` in processor.rs — any mismatch is a dead
+    // `classify_processor_error` in processor.rs - any mismatch is a dead
     // label (visible in Prometheus, never incremented).
-    for reason in &["invalid_pubkey", "invalid_builder", "program_error"] {
+    for reason in &[
+        "invalid_pubkey",
+        "invalid_builder",
+        "program_error",
+        "mint_not_allowed",
+    ] {
+        OPERATOR_TRANSACTION_QUARANTINED.with_label_values(&[program_type, reason]);
+    }
+
+    for reason in &BAIL_REASONS {
         OPERATOR_TRANSACTION_QUARANTINED.with_label_values(&[program_type, reason]);
     }
 

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -494,8 +494,18 @@ async fn check_withdrawal_mint_supported(
         .mint_cache
         .rpc_client()
         .ok_or_else(|| OperatorError::RpcError("mint allowlist check requires RPC".to_string()))?;
+
+    // A null only proves "never allowlisted" if the node has caught up. Anchor on the
+    // tip it reports and require the read to answer at or past it, so a lagging backend
+    // errors instead of denying an allowlist entry it simply has not seen yet.
+    let commitment = rpc.rpc_client.commitment();
+    let (ref_slot, _) = rpc
+        .get_latest_blockhash_with_context(commitment)
+        .await
+        .map_err(|e| OperatorError::RpcError(format!("allowlist freshness anchor: {e}")))?;
+
     let response = rpc
-        .get_account_with_context(&allowed_mint_pda, rpc.rpc_client.commitment())
+        .get_account_with_context_min_slot(&allowed_mint_pda, commitment, Some(ref_slot))
         .await
         .map_err(|e| OperatorError::RpcError(format!("get_account({allowed_mint_pda}): {e}")))?;
 
@@ -4556,6 +4566,65 @@ mod tests {
             "an unreadable allowlist must stay transient, got: {outcome:?}"
         );
         assert!(update.is_none(), "no verdict means no park");
+    }
+
+    /// A node behind the anchor slot must not be able to answer the allowlist read at
+    /// all: its null would deny a mint the escrow did allow, parking a burned row.
+    #[tokio::test]
+    async fn process_release_funds_lagging_allowlist_read_is_transient() {
+        let mut server = mockito::Server::new_async().await;
+        // Anchor the gate at slot 500, then refuse to serve there as a lagging node does.
+        let _anchor = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getLatestBlockhash""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":500},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":600}},"id":1}"#,
+            )
+            .create();
+        let _lagging = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""minContextSlot"\s*:\s*500"#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","error":{"code":-32016,"message":"Minimum context slot has not been reached"},"id":1}"#,
+            )
+            .expect_at_least(1)
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::with_rpc(
+                storage.clone(),
+                Arc::new(RpcClientWithRetry::with_retry_config(
+                    server.url(),
+                    crate::operator::utils::rpc_util::RetryConfig {
+                        max_attempts: 1,
+                        base_delay: std::time::Duration::from_millis(1),
+                        max_delay: std::time::Duration::from_millis(2),
+                    },
+                    solana_sdk::commitment_config::CommitmentConfig::confirmed(),
+                )),
+            ),
+        };
+
+        let (outcome, update, _) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&Pubkey::new_unique(), 5)).await;
+
+        assert!(
+            matches!(outcome, Err(OperatorError::RpcError(_))),
+            "a node that cannot answer at the anchor slot must stay transient, got: {outcome:?}"
+        );
+        assert!(
+            update.is_none(),
+            "a lagging node is not a verdict, so no park"
+        );
     }
 
     /// A boundary nonce whose mint is unsupported must not dispatch a rotation,

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -1,6 +1,5 @@
 use crate::channel_utils::send_guaranteed;
 use crate::error::{AccountError, OperatorError, ProgramError};
-use crate::indexer::checkpoint::get_last_checkpoint;
 use crate::metrics;
 use crate::operator::instruction_util::{
     mint_idempotency_memo, MintToBuilder, SourceEventId, TransactionBuilder, WithdrawalRemintInfo,
@@ -466,12 +465,11 @@ pub async fn run_processor(
     }
 }
 
-/// Reject a withdrawal whose mint the escrow never allowlisted. A `mints` row is
-/// the predicate: only an indexed allow writes one and nothing removes it. Running
-/// before the metadata read keeps the rejection independent of the target chain.
+/// Reject a withdrawal the escrow would not accept a release for. The predicate is
+/// the on-chain `AllowedMint` account, the same one `release_funds` requires, so a
+/// row that fails here could never have landed and a row that passes is not blocked.
 async fn check_withdrawal_mint_supported(
     processor_state: &mut ProcessorState,
-    storage: &Arc<Storage>,
     transaction: &DbTransaction,
 ) -> Result<Option<BailReason>, OperatorError> {
     let mint = Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
@@ -479,29 +477,47 @@ async fn check_withdrawal_mint_supported(
         reason: e.to_string(),
     })?;
 
-    // A hit also warms the cache, so the metadata read that follows is free.
-    if processor_state
-        .mint_cache
-        .get_mint_metadata_from_db(&mint)
-        .await?
-        .is_some()
-    {
+    // A verdict already recorded for this mint stands for the process lifetime, so a
+    // busy mint costs one allowlist read rather than one per withdrawal. An admin
+    // blocking a mint mid-run is caught on the next restart.
+    if processor_state.mint_cache.has_existence_floor(&mint) {
         return Ok(None);
     }
 
-    // The checkpoint only shapes the message. An incomplete backfill and a bogus
-    // mint both leave us without permission to release, so the difference is for
-    // an operator to resolve and must not change what happens here.
-    let indexed = match get_last_checkpoint(storage, ProgramType::Escrow).await {
-        Ok(Some(slot)) => format!("escrow indexed through slot {slot}"),
-        Ok(None) => "escrow allowlist never checkpointed".to_string(),
-        Err(_) => "escrow checkpoint unknown".to_string(),
-    };
+    let allowed_mint_pda = processor_state
+        .release_funds_state
+        .as_mut()
+        .ok_or(OperatorError::MissingBuilder)?
+        .get_allowed_mint_pda(&mint);
 
-    Ok(Some(BailReason::new(
-        metrics::BAIL_REASON_UNSUPPORTED_MINT,
-        format!("unsupported withdrawal mint: {mint} ({indexed})"),
-    )))
+    let rpc = processor_state
+        .mint_cache
+        .rpc_client()
+        .ok_or_else(|| OperatorError::RpcError("mint allowlist check requires RPC".to_string()))?;
+    let response = rpc
+        .get_account_with_context(&allowed_mint_pda, rpc.rpc_client.commitment())
+        .await
+        .map_err(|e| OperatorError::RpcError(format!("get_account({allowed_mint_pda}): {e}")))?;
+
+    // Owned by anything else means the address collides with an unrelated account
+    // rather than carrying the escrow's permission, which release would reject.
+    let allowed = response
+        .value
+        .is_some_and(|account| account.owner == PRIVATE_CHANNEL_ESCROW_PROGRAM_ID);
+    if !allowed {
+        return Ok(Some(BailReason::new(
+            metrics::BAIL_REASON_UNSUPPORTED_MINT,
+            format!("unsupported withdrawal mint: {mint} (no escrow allowlist account)"),
+        )));
+    }
+
+    // Creating that account required the escrow to read the mint, so the mint existed
+    // at or before this slot. Later mint reads bind to it, which is what lets a
+    // missing mint be permanent instead of a node that has not caught up.
+    processor_state
+        .mint_cache
+        .record_existence_floor(&mint, response.context.slot);
+    Ok(None)
 }
 
 /// Build the release_funds TransactionBuilder for a single withdrawal.
@@ -627,8 +643,9 @@ async fn check_withdrawal_preflights(
     processor_state: &mut ProcessorState,
     transaction: &DbTransaction,
 ) -> Result<Option<BailReason>, OperatorError> {
-    // A mint the target chain does not have will never appear by retrying, so it
-    // becomes a bail rather than travelling the transient path and restarting us.
+    // The reads below only report a mint absent once the node has passed the slot that
+    // allowlisted it, so the account was closed rather than merely not yet visible.
+    // That is not fixed by retrying, so it parks the row instead of restarting us.
     match check_withdrawal_preflights_inner(processor_state, transaction).await {
         Err(OperatorError::Account(AccountError::TargetMintMissing { pubkey })) => {
             Ok(Some(BailReason::new(
@@ -725,10 +742,10 @@ pub async fn process_release_funds(
         let mut rotation_dispatched = false;
 
         let outcome: Result<RowOutcome, OperatorError> = async {
-            // Settle whether the mint is supported before anything reads the
-            // target chain, so an unsupported mint is rejected from storage alone.
+            // Settle whether the escrow will accept a release for this mint before
+            // building one, so a mint it would reject costs no further work.
             if let Some(bail) =
-                check_withdrawal_mint_supported(processor_state, &storage, &transaction).await?
+                check_withdrawal_mint_supported(processor_state, &transaction).await?
             {
                 park_row(&storage_tx, pt_label, &transaction, bail).await;
                 return Ok(RowOutcome::ParkedBeforeRotation);
@@ -1418,6 +1435,8 @@ mod tests {
         };
 
         let mint_pubkey = Pubkey::new_unique();
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
         let recipient = Pubkey::new_unique();
         {
             let mock_storage = match storage.as_ref() {
@@ -1492,6 +1511,8 @@ mod tests {
         };
 
         let mint_pubkey = Pubkey::new_unique();
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
         let recipient = Pubkey::new_unique();
         {
             let mock_storage = match storage.as_ref() {
@@ -1594,6 +1615,8 @@ mod tests {
         };
 
         let mint_pubkey = Pubkey::new_unique();
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
         let recipient = Pubkey::new_unique();
         {
             let Storage::Mock(mock_storage) = storage.as_ref() else {
@@ -1771,6 +1794,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -1841,6 +1866,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -2133,6 +2160,8 @@ mod tests {
         };
 
         let mint_pubkey = Pubkey::new_unique();
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
         {
             let mock_storage = match storage.as_ref() {
                 Storage::Mock(m) => m,
@@ -2200,13 +2229,17 @@ mod tests {
             mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
 
+        // The gate is not this test's subject; treat the mint as already proved.
+        let mint_pubkey = Pubkey::new_unique();
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
+
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, _sender_rx) = mpsc::channel(10);
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let txn = make_db_transaction(
             1,
-            &Pubkey::new_unique().to_string(),
+            &mint_pubkey.to_string(),
             &Pubkey::new_unique().to_string(),
             None, // <- the poison: withdrawals should never have a NULL nonce
             crate::storage::common::models::TransactionType::Withdrawal,
@@ -2579,6 +2612,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -2643,6 +2678,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         // Pass 1: the pre-flight cannot reach an RPC, so the row is requeued to Pending.
         let (ftx1, frx1) = mpsc::channel::<DbTransaction>(4);
@@ -2729,6 +2766,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -3045,6 +3084,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
         let (sender_tx, mut sender_rx) = mpsc::channel(16);
@@ -3554,6 +3595,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -3662,6 +3705,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint_pubkey, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -4300,6 +4345,8 @@ mod tests {
             release_funds_state: Some(make_release_funds_state()),
             mint_cache: mint_cache_over_absent_chain(storage.clone()),
         };
+        // The gate is not this test's subject; treat the mint as already proved.
+        ps.mint_cache.record_existence_floor(&mint, 1);
 
         let txn = make_db_transaction(
             77,
@@ -4343,25 +4390,35 @@ mod tests {
         })
     }
 
-    /// Seed the escrow indexer's committed checkpoint.
-    fn seed_escrow_checkpoint(storage: &Arc<Storage>, slot: u64) {
-        let mock_storage = match storage.as_ref() {
-            Storage::Mock(m) => m,
-            _ => unreachable!("test helper expects Storage::Mock"),
-        };
-        mock_storage
-            .committed_checkpoints
-            .lock()
-            .unwrap()
-            .insert("escrow".to_string(), slot);
+    /// Mocked `getAccountInfo` reply for an escrow-owned AllowedMint account.
+    fn allowed_mint_account_response(slot: u64) -> serde_json::Value {
+        serde_json::json!({
+            "context": {"slot": slot},
+            "value": {
+                "owner": PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode([2u8, 255u8]), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        })
     }
 
-    /// A withdrawal processor with no RPC client behind its mint cache.
-    fn processor_state_without_rpc(storage: &Arc<Storage>) -> ProcessorState {
+    /// A withdrawal processor whose target chain answers every account read with
+    /// `response`, which for these tests is the allowlist account the gate reads.
+    fn processor_state_answering(
+        storage: &Arc<Storage>,
+        response: serde_json::Value,
+    ) -> ProcessorState {
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, response);
         ProcessorState {
             admin_pubkey: Pubkey::new_unique(),
             release_funds_state: Some(make_release_funds_state()),
-            mint_cache: crate::operator::MintCache::new(storage.clone()),
+            mint_cache: crate::operator::MintCache::with_rpc(
+                storage.clone(),
+                Arc::new(RpcClientWithRetry::new_mocked(mocks)),
+            ),
         }
     }
 
@@ -4376,54 +4433,25 @@ mod tests {
         )
     }
 
-    /// A mint the indexer has never recorded is parked, and the reason names the
-    /// checkpoint so an operator can tell a bogus mint from an incomplete backfill.
+    /// No escrow allowlist account means the escrow program would reject the
+    /// release, so the row is parked rather than retried forever.
     #[tokio::test]
     async fn process_release_funds_unsupported_mint_routes_to_manual_review() {
         let mint = Pubkey::new_unique();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        seed_escrow_checkpoint(&storage, 500);
-        let mut ps = processor_state_without_rpc(&storage);
+        let mut ps = processor_state_answering(&storage, absent_account_response());
 
         let (outcome, update, builder) =
             run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
 
-        assert!(
-            outcome.is_ok(),
-            "an unsupported mint must not exit the task"
-        );
+        assert!(outcome.is_ok(), "one bad mint must not end the loop");
         let update = update.expect("row must be routed to ManualReview");
         assert_eq!(update.status, TransactionStatus::ManualReview);
-        let msg = update.error_message.expect("error_message must be set");
-        assert!(
-            msg.contains("unsupported withdrawal mint:")
-                && msg.contains(&mint.to_string())
-                && msg.contains("500"),
-            "unexpected error_message: {msg}"
-        );
-        assert!(builder.is_none(), "no builder may be dispatched");
-    }
-
-    /// With no escrow checkpoint at all the row is still parked, and the reason
-    /// says the allowlist has never been indexed rather than implying a slot.
-    #[tokio::test]
-    async fn process_release_funds_unsupported_mint_without_checkpoint_says_so() {
-        let mint = Pubkey::new_unique();
-        let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let mut ps = processor_state_without_rpc(&storage);
-
-        let (outcome, update, _) =
-            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
-
-        assert!(outcome.is_ok());
-        let msg = update
-            .expect("row must be routed to ManualReview")
+        assert!(update
             .error_message
-            .expect("error_message must be set");
-        assert!(
-            msg.contains("unsupported withdrawal mint:") && msg.contains("never checkpointed"),
-            "unexpected error_message: {msg}"
-        );
+            .expect("error_message must be set")
+            .contains("unsupported withdrawal mint:"));
+        assert!(builder.is_none(), "nothing may be dispatched");
     }
 
     /// An allowlisted mint passes the gate untouched.
@@ -4432,8 +4460,7 @@ mod tests {
         let mint = Pubkey::new_unique();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
         insert_mint_row(&storage, &mint);
-        seed_escrow_checkpoint(&storage, 500);
-        let mut ps = processor_state_without_rpc(&storage);
+        let mut ps = processor_state_answering(&storage, allowed_mint_account_response(500));
 
         let (outcome, update, builder) =
             run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
@@ -4446,138 +4473,89 @@ mod tests {
         );
     }
 
-    /// A mint that was allowlisted and later blocked stays withdrawable, or the
-    /// escrowed funds behind it would be stranded.
+    /// Passing the gate records the slot the allowlist account was seen at, which is
+    /// what later lets a missing mint account be permanent rather than node lag.
     #[tokio::test]
-    async fn process_release_funds_blocked_mint_still_withdrawable() {
+    async fn process_release_funds_allowlist_hit_records_the_existence_floor() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        insert_mint_row(&storage, &mint);
+        let mut ps = processor_state_answering(&storage, allowed_mint_account_response(500));
+
+        let (outcome, _, _) = run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok());
+        assert!(
+            ps.mint_cache.has_existence_floor(&mint),
+            "the gate must record what it proved"
+        );
+    }
+
+    /// `BlockMint` closes the allowlist account and `release_funds` requires it, so a
+    /// blocked mint's release can never land. Parking makes that visible instead of
+    /// dispatching a transaction the escrow program is certain to reject.
+    #[tokio::test]
+    async fn process_release_funds_blocked_mint_parks_rather_than_dispatching() {
         let mint = Pubkey::new_unique();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
         insert_mint_row(&storage, &mint);
         seed_mint_status(&storage, &mint, "blocked", 50);
-        seed_escrow_checkpoint(&storage, 500);
-        let mut ps = processor_state_without_rpc(&storage);
+        let mut ps = processor_state_answering(&storage, absent_account_response());
 
         let (outcome, update, builder) =
             run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
 
         assert!(outcome.is_ok());
-        assert!(update.is_none(), "a blocked mint must not be quarantined");
-        assert!(
-            matches!(builder, Some(TransactionBuilder::ReleaseFunds(_))),
-            "a blocked mint must still be releasable"
-        );
-    }
-
-    /// An unreadable allowlist is not a verdict about the mint. The row is left
-    /// alive for a retry rather than terminalized on a database outage.
-    #[tokio::test]
-    async fn process_release_funds_unreadable_allowlist_is_transient() {
-        let mint = Pubkey::new_unique();
-        let mock = MockStorage::new();
-        let txn = seed_processing_withdrawal(
-            &mock,
-            9,
-            5,
-            &mint,
-            &Pubkey::new_unique(),
-            SeededMint::Absent,
-        );
-        mock.set_should_fail("get_mint", true);
-        let storage = Arc::new(Storage::Mock(mock.clone()));
-        let mut ps = processor_state_without_rpc(&storage);
-
-        let (outcome, update, builder) = run_one_withdrawal(&mut ps, storage, txn).await;
-
-        assert!(
-            matches!(outcome, Err(OperatorError::Storage(_))),
-            "a database outage must stay transient, got: {outcome:?}"
-        );
-        assert!(
-            update.is_none(),
-            "an unreadable allowlist must not quarantine"
-        );
-        assert!(builder.is_none());
-        let after = mock.pending_transactions.lock().unwrap();
-        assert_eq!(
-            after[0].status,
-            TransactionStatus::Pending,
-            "row must be requeued for another attempt"
-        );
-    }
-
-    /// An unreadable checkpoint changes the wording of the reason and nothing else.
-    #[tokio::test]
-    async fn process_release_funds_unreadable_checkpoint_still_parks_the_row() {
-        let mint = Pubkey::new_unique();
-        let mock = MockStorage::new();
-        mock.set_should_fail("get_committed_checkpoint", true);
-        let storage = Arc::new(Storage::Mock(mock));
-        let mut ps = processor_state_without_rpc(&storage);
-
-        let (outcome, update, builder) =
-            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
-
-        assert!(outcome.is_ok());
-        let msg = update
-            .expect("row must be routed to ManualReview")
-            .error_message
-            .expect("error_message must be set");
-        assert!(
-            msg.contains("unsupported withdrawal mint:") && msg.contains("checkpoint unknown"),
-            "unexpected error_message: {msg}"
-        );
-        assert!(builder.is_none());
-    }
-
-    /// The gate reaches its verdict from storage alone, so an operator with no
-    /// RPC configured still rejects the row instead of failing on the missing client.
-    #[tokio::test]
-    async fn process_release_funds_unsupported_mint_needs_no_rpc() {
-        let mint = Pubkey::new_unique();
-        let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        seed_escrow_checkpoint(&storage, 7);
-        let mut ps = processor_state_without_rpc(&storage);
-
-        let (outcome, update, _) =
-            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
-
-        assert!(outcome.is_ok(), "the gate must not depend on an RPC client");
         assert_eq!(
             update.expect("row must be parked").status,
             TransactionStatus::ManualReview
         );
+        assert!(
+            builder.is_none(),
+            "a release that cannot land is not dispatched"
+        );
     }
 
-    /// The allowlist is the authority. A mint that exists on the target chain but
-    /// was never allowlisted is still rejected, which is what makes the gate
-    /// independent of whether the chain is reachable.
+    /// An account squatting the allowlist address carries no escrow permission, so
+    /// presence alone must not open the gate.
     #[tokio::test]
-    async fn process_release_funds_unsupported_mint_ignores_live_target_chain() {
+    async fn process_release_funds_foreign_owned_allowlist_account_is_rejected() {
         let mint = Pubkey::new_unique();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        seed_escrow_checkpoint(&storage, 500);
+        insert_mint_row(&storage, &mint);
+        let mut ps = processor_state_answering(&storage, spl_mint_account_response(6));
 
-        let mut mocks = std::collections::HashMap::new();
-        mocks.insert(RpcRequest::GetAccountInfo, spl_mint_account_response(6));
-        let mut ps = ProcessorState {
-            admin_pubkey: Pubkey::new_unique(),
-            release_funds_state: Some(make_release_funds_state()),
-            mint_cache: crate::operator::MintCache::with_rpc(
-                storage.clone(),
-                Arc::new(RpcClientWithRetry::new_mocked(mocks)),
-            ),
-        };
-
-        let (outcome, update, builder) =
+        let (outcome, update, _) =
             run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
 
         assert!(outcome.is_ok());
         assert_eq!(
             update.expect("row must be parked").status,
             TransactionStatus::ManualReview,
-            "a live target-chain account must not override the allowlist"
+            "only an escrow-owned account grants permission"
         );
-        assert!(builder.is_none());
+    }
+
+    /// A node we cannot reach is not a verdict about the mint, so the row must stay
+    /// eligible rather than be parked on an unanswered question.
+    #[tokio::test]
+    async fn process_release_funds_unreadable_allowlist_is_transient() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (outcome, update, _) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(
+            matches!(outcome, Err(OperatorError::RpcError(_))),
+            "an unreadable allowlist must stay transient, got: {outcome:?}"
+        );
+        assert!(update.is_none(), "no verdict means no park");
     }
 
     /// A boundary nonce whose mint is unsupported must not dispatch a rotation,
@@ -4586,8 +4564,7 @@ mod tests {
     async fn process_release_funds_unsupported_boundary_mint_skips_rotation() {
         let mint = Pubkey::new_unique();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        seed_escrow_checkpoint(&storage, 500);
-        let mut ps = processor_state_without_rpc(&storage);
+        let mut ps = processor_state_answering(&storage, absent_account_response());
 
         let (outcome, update, builder) = run_one_withdrawal(
             &mut ps,
@@ -4631,13 +4608,11 @@ mod tests {
             SeededMint::Resolved,
         );
         let storage = Arc::new(Storage::Mock(mock.clone()));
-        seed_escrow_checkpoint(&storage, 500);
 
-        let mut ps = ProcessorState {
-            admin_pubkey: Pubkey::new_unique(),
-            release_funds_state: Some(make_release_funds_state()),
-            mint_cache: crate::operator::MintCache::new(storage.clone()),
-        };
+        // The head's mint has no allowlist account; the sibling's is already proved,
+        // so only the head reaches the gate.
+        let mut ps = processor_state_answering(&storage, absent_account_response());
+        ps.mint_cache.record_existence_floor(&good_mint, 1);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -1,5 +1,6 @@
 use crate::channel_utils::send_guaranteed;
-use crate::error::{OperatorError, ProgramError};
+use crate::error::{AccountError, OperatorError, ProgramError};
+use crate::indexer::checkpoint::get_last_checkpoint;
 use crate::metrics;
 use crate::operator::instruction_util::{
     mint_idempotency_memo, MintToBuilder, SourceEventId, TransactionBuilder, WithdrawalRemintInfo,
@@ -160,6 +161,27 @@ fn classify_processor_error(err: &OperatorError) -> ErrorDisposition {
     }
 }
 
+/// A row-specific reason to park one withdrawal without stopping the pipeline.
+/// `label` is the metric dimension and `message` lands on the row and its alert.
+/// Poison rows take the error classifier instead, which sweeps every active row.
+struct BailReason {
+    label: &'static str,
+    message: String,
+}
+
+/// How far a row got before leaving the loop body, which decides whether the
+/// rows the fetcher already handed us are still safe to dispatch.
+enum RowOutcome {
+    Continue,
+    ParkedBeforeRotation,
+}
+
+impl BailReason {
+    fn new(label: &'static str, message: String) -> Self {
+        Self { label, message }
+    }
+}
+
 /// Emit a `ManualReview` status update for a single row via the shared storage
 /// writer channel.  Reuses `TransactionStatusUpdate` so the existing
 /// DbTransactionWriter path handles both the DB write and the alert webhook.
@@ -190,6 +212,19 @@ async fn quarantine_single(
             "Failed to send quarantine update (storage writer down): {}", e
         );
     }
+}
+
+/// Park one row in `ManualReview` and record why, leaving the pipeline running.
+async fn park_row(
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    pt_label: &str,
+    transaction: &DbTransaction,
+    bail: BailReason,
+) {
+    metrics::OPERATOR_TRANSACTION_QUARANTINED
+        .with_label_values(&[pt_label, bail.label])
+        .inc();
+    quarantine_single(storage_tx, transaction, bail.message).await;
 }
 
 /// Halt the withdrawal pipeline after a poison-pill is detected.
@@ -431,6 +466,44 @@ pub async fn run_processor(
     }
 }
 
+/// Reject a withdrawal whose mint the escrow never allowlisted. A `mints` row is
+/// the predicate: only an indexed allow writes one and nothing removes it. Running
+/// before the metadata read keeps the rejection independent of the target chain.
+async fn check_withdrawal_mint_supported(
+    processor_state: &mut ProcessorState,
+    storage: &Arc<Storage>,
+    transaction: &DbTransaction,
+) -> Result<Option<BailReason>, OperatorError> {
+    let mint = Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
+        pubkey: transaction.mint.clone(),
+        reason: e.to_string(),
+    })?;
+
+    // A hit also warms the cache, so the metadata read that follows is free.
+    if processor_state
+        .mint_cache
+        .get_mint_metadata_from_db(&mint)
+        .await?
+        .is_some()
+    {
+        return Ok(None);
+    }
+
+    // The checkpoint only shapes the message. An incomplete backfill and a bogus
+    // mint both leave us without permission to release, so the difference is for
+    // an operator to resolve and must not change what happens here.
+    let indexed = match get_last_checkpoint(storage, ProgramType::Escrow).await {
+        Ok(Some(slot)) => format!("escrow indexed through slot {slot}"),
+        Ok(None) => "escrow allowlist never checkpointed".to_string(),
+        Err(_) => "escrow checkpoint unknown".to_string(),
+    };
+
+    Ok(Some(BailReason::new(
+        metrics::BAIL_REASON_UNSUPPORTED_MINT,
+        format!("unsupported withdrawal mint: {mint} ({indexed})"),
+    )))
+}
+
 /// Build the release_funds TransactionBuilder for a single withdrawal.
 ///
 /// Kept out of the loop so error handling in the caller is a single
@@ -540,19 +613,40 @@ async fn build_release_funds(
 /// Token-2022 pre-flight for a withdrawal.
 ///
 /// Returns:
-/// - `Ok(None)` — clean: proceed to build + dispatch.
-/// - `Ok(Some(reason))` — row-specific bail: caller routes to ManualReview
-///   via `quarantine_single` and continues the loop. Used for paused mints
-///   and permanent-delegate drains where the row's data is fine but the
-///   on-chain state would cause an immediate release-funds failure.
-/// - `Err(_)` — transient infrastructure issue (RPC failure, malformed
+/// - `Ok(None)` - clean: proceed to build + dispatch.
+/// - `Ok(Some(bail))` - row-specific bail: caller routes to ManualReview
+///   via `quarantine_single` and continues the loop. Used for paused mints,
+///   permanent-delegate drains, and mints the target chain does not have,
+///   where the row's data is fine but the on-chain state would cause an
+///   immediate release-funds failure.
+/// - `Err(_)` - transient infrastructure issue (RPC unreachable, malformed
 ///   mint data). Caller's classifier treats as Transient and restarts the
 ///   task, which is preferable to mass-quarantining rows during an RPC
 ///   blip.
 async fn check_withdrawal_preflights(
     processor_state: &mut ProcessorState,
     transaction: &DbTransaction,
-) -> Result<Option<String>, OperatorError> {
+) -> Result<Option<BailReason>, OperatorError> {
+    // A mint the target chain does not have will never appear by retrying, so it
+    // becomes a bail rather than travelling the transient path and restarting us.
+    match check_withdrawal_preflights_inner(processor_state, transaction).await {
+        Err(OperatorError::Account(AccountError::TargetMintMissing { pubkey })) => {
+            Ok(Some(BailReason::new(
+                metrics::BAIL_REASON_TARGET_MINT_MISSING,
+                format!("withdrawal mint absent on target chain: {pubkey}"),
+            )))
+        }
+        other => other,
+    }
+}
+
+/// The pre-flight checks themselves, wrapped above so one error shape can be
+/// turned into a bail without repeating the conversion at each call that can
+/// produce it.
+async fn check_withdrawal_preflights_inner(
+    processor_state: &mut ProcessorState,
+    transaction: &DbTransaction,
+) -> Result<Option<BailReason>, OperatorError> {
     let mint = Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
         pubkey: transaction.mint.clone(),
         reason: e.to_string(),
@@ -578,7 +672,10 @@ async fn check_withdrawal_preflights(
         .await?;
 
     if is_pausable && processor_state.mint_cache.check_paused(&mint).await? {
-        return Ok(Some(format!("mint paused: {mint}")));
+        return Ok(Some(BailReason::new(
+            metrics::BAIL_REASON_MINT_PAUSED,
+            format!("mint paused: {mint}"),
+        )));
     }
 
     if has_permanent_delegate {
@@ -595,8 +692,9 @@ async fn check_withdrawal_preflights(
             .get_ata_balance(&instance_ata)
             .await?;
         if on_chain < amount {
-            return Ok(Some(format!(
-                "insufficient escrow balance: on_chain={on_chain}, needed={amount}"
+            return Ok(Some(BailReason::new(
+                metrics::BAIL_REASON_ESCROW_DRAINED,
+                format!("insufficient escrow balance: on_chain={on_chain}, needed={amount}"),
             )));
         }
     }
@@ -626,7 +724,16 @@ pub async fn process_release_funds(
         // skip a tree generation. Read after the non-move async block completes.
         let mut rotation_dispatched = false;
 
-        let outcome: Result<(), OperatorError> = async {
+        let outcome: Result<RowOutcome, OperatorError> = async {
+            // Settle whether the mint is supported before anything reads the
+            // target chain, so an unsupported mint is rejected from storage alone.
+            if let Some(bail) =
+                check_withdrawal_mint_supported(processor_state, &storage, &transaction).await?
+            {
+                park_row(&storage_tx, pt_label, &transaction, bail).await;
+                return Ok(RowOutcome::ParkedBeforeRotation);
+            }
+
             // Build the withdrawal first so (a) rotation + withdrawal dispatch
             // are atomic from the sender's perspective, and (b) row-data
             // poison (e.g. NULL nonce, unparseable pubkey) surfaces here as
@@ -652,7 +759,7 @@ pub async fn process_release_funds(
                             nonce,
                             "Lower active withdrawal exists - deferring boundary rotation"
                         );
-                        return Ok(());
+                        return Ok(RowOutcome::Continue);
                     }
                     let target_tree_index = nonce / MAX_TREE_LEAVES as u64;
                     let release_funds_state = processor_state
@@ -712,10 +819,9 @@ pub async fn process_release_funds(
             // It is best-effort: a delegate can still drain between this read and
             // the on-chain CPI, leaving that to the sender retry path. RPC errors
             // bubble up as Transient and restart the task.
-            if let Some(reason) = check_withdrawal_preflights(processor_state, &transaction).await?
-            {
-                quarantine_single(&storage_tx, &transaction, reason).await;
-                return Ok(());
+            if let Some(bail) = check_withdrawal_preflights(processor_state, &transaction).await? {
+                park_row(&storage_tx, pt_label, &transaction, bail).await;
+                return Ok(RowOutcome::Continue);
             }
 
             info!("Processing withdrawal");
@@ -723,65 +829,75 @@ pub async fn process_release_funds(
                 .await
                 .map_err(OperatorError::ChannelSend)?;
 
-            Ok(())
+            Ok(RowOutcome::Continue)
         }
         .instrument(span.clone())
         .await;
+
+        // Parking before the boundary rotation leaves the tree on the old generation,
+        // so buffered siblings go back to Pending rather than dispatch against an
+        // index the chain rejects. The parked row blocks them until it is resolved.
+        let err = match outcome {
+            Ok(RowOutcome::Continue) => continue,
+            Ok(RowOutcome::ParkedBeforeRotation) => {
+                drain_and_requeue_buffered(&storage, &mut fetcher_rx, pt_label).await;
+                continue;
+            }
+            Err(err) => err,
+        };
 
         // A per-row error is classified.  For a deterministic poison-pill
         // we quarantine the row, halt the whole withdrawal pipeline, and
         // return so the supervisor can shut down cleanly.  Transient or
         // fatal errors bubble up directly.
-        if let Err(err) = outcome {
-            match classify_processor_error(&err) {
-                ErrorDisposition::Quarantine(reason) => {
-                    warn!(
-                        txn_id = transaction.id,
-                        trace_id = %transaction.trace_id,
-                        reason,
-                        "Quarantining withdrawal and halting pipeline: {}",
-                        err
-                    );
-                    metrics::OPERATOR_TRANSACTION_QUARANTINED
-                        .with_label_values(&[pt_label, reason])
-                        .inc();
-                    quarantine_single(&storage_tx, &transaction, err.to_string()).await;
-                    halt_withdrawal_pipeline(
+        match classify_processor_error(&err) {
+            ErrorDisposition::Quarantine(reason) => {
+                warn!(
+                    txn_id = transaction.id,
+                    trace_id = %transaction.trace_id,
+                    reason,
+                    "Quarantining withdrawal and halting pipeline: {}",
+                    err
+                );
+                metrics::OPERATOR_TRANSACTION_QUARANTINED
+                    .with_label_values(&[pt_label, reason])
+                    .inc();
+                quarantine_single(&storage_tx, &transaction, err.to_string()).await;
+                halt_withdrawal_pipeline(
+                    &storage,
+                    &storage_tx,
+                    &mut fetcher_rx,
+                    Some(transaction.id),
+                )
+                .await;
+                return Ok(());
+            }
+            ErrorDisposition::Transient => {
+                // The head row is safe to rescue only before its own rotation
+                // dispatch; after that a reprocess could re-fire an unconfirmed
+                // rotation, so leave it for recovery. Buffered siblings never
+                // had a rotation dispatched for them, so drain and requeue them
+                // either way rather than strand them Processing.
+                if !rotation_dispatched {
+                    requeue_or_quarantine_head(
                         &storage,
                         &storage_tx,
-                        &mut fetcher_rx,
-                        Some(transaction.id),
+                        pt_label,
+                        &transaction,
+                        err.to_string(),
                     )
                     .await;
-                    return Ok(());
                 }
-                ErrorDisposition::Transient => {
-                    // The head row is safe to rescue only before its own rotation
-                    // dispatch; after that a reprocess could re-fire an unconfirmed
-                    // rotation, so leave it for recovery. Buffered siblings never
-                    // had a rotation dispatched for them, so drain and requeue them
-                    // either way rather than strand them Processing.
-                    if !rotation_dispatched {
-                        requeue_or_quarantine_head(
-                            &storage,
-                            &storage_tx,
-                            pt_label,
-                            &transaction,
-                            err.to_string(),
-                        )
-                        .await;
-                    }
-                    drain_and_requeue_buffered(&storage, &mut fetcher_rx, pt_label).await;
-                    // Surface the error so the supervisor can restart us cleanly.
-                    return Err(err);
-                }
-                ErrorDisposition::Fatal => {
-                    error!(
-                        txn_id = transaction.id,
-                        "Fatal processor error, exiting task: {}", err
-                    );
-                    return Err(err);
-                }
+                drain_and_requeue_buffered(&storage, &mut fetcher_rx, pt_label).await;
+                // Surface the error so the supervisor can restart us cleanly.
+                return Err(err);
+            }
+            ErrorDisposition::Fatal => {
+                error!(
+                    txn_id = transaction.id,
+                    "Fatal processor error, exiting task: {}", err
+                );
+                return Err(err);
             }
         }
     }
@@ -1109,34 +1225,94 @@ mod tests {
         assert_eq!(state.instance_atas.len(), 2);
     }
 
-    /// Insert a minimal `mints` row AND a slot-0 `allowed` status history
-    /// entry so `assert_mint_allowed_at_slot` accepts the mint at any slot.
-    fn insert_mint_row(storage: &Arc<Storage>, mint: &Pubkey) {
+    /// Insert a `mints` row with the given token program and extension flags,
+    /// plus a slot-0 `allowed` status history entry so
+    /// `assert_mint_allowed_at_slot` accepts the mint at any slot.
+    fn insert_mint_row_with(
+        storage: &Arc<Storage>,
+        mint: &Pubkey,
+        token_program: &Pubkey,
+        flags: Option<(bool, bool)>,
+    ) {
         let mock_storage = match storage.as_ref() {
             Storage::Mock(m) => m,
             _ => unreachable!("test helper expects Storage::Mock"),
+        };
+        let (is_pausable, has_permanent_delegate) = match flags {
+            Some((p, d)) => (Some(p), Some(d)),
+            None => (None, None),
         };
         mock_storage.mints.lock().unwrap().insert(
             mint.to_string(),
             DbMint {
                 mint_address: mint.to_string(),
                 decimals: 6,
-                token_program: spl_token::id().to_string(),
+                token_program: token_program.to_string(),
                 created_at: chrono::Utc::now(),
                 status: "allowed".to_string(),
-                is_pausable: Some(false),
-                has_permanent_delegate: Some(false),
+                is_pausable,
+                has_permanent_delegate,
             },
         );
+        seed_mint_status(storage, mint, "allowed", 0);
+    }
+
+    /// Append a `mint_status_history` transition for a mint.
+    fn seed_mint_status(storage: &Arc<Storage>, mint: &Pubkey, status: &str, slot: i64) {
+        let mock_storage = match storage.as_ref() {
+            Storage::Mock(m) => m,
+            _ => unreachable!("test helper expects Storage::Mock"),
+        };
         mock_storage.mint_status_history.lock().unwrap().push(
             crate::storage::common::models::DbMintStatus {
                 mint_address: mint.to_string(),
-                status: "allowed".to_string(),
-                effective_slot: 0,
-                signature: format!("test-seed-{mint}"),
+                status: status.to_string(),
+                effective_slot: slot,
+                signature: format!("test-seed-{mint}-{status}-{slot}"),
                 created_at: chrono::Utc::now(),
             },
         );
+    }
+
+    /// Insert a minimal legacy-SPL `mints` row with both extension flags resolved.
+    fn insert_mint_row(storage: &Arc<Storage>, mint: &Pubkey) {
+        insert_mint_row_with(storage, mint, &spl_token::id(), Some((false, false)));
+    }
+
+    /// Drive one withdrawal through `process_release_funds` and return whatever
+    /// reached the storage writer and the sender. The loop's own result comes back
+    /// too, since exiting with an error is what restarts the operator.
+    async fn run_one_withdrawal(
+        ps: &mut ProcessorState,
+        storage: Arc<Storage>,
+        txn: DbTransaction,
+    ) -> (
+        Result<(), OperatorError>,
+        Option<TransactionStatusUpdate>,
+        Option<TransactionBuilder>,
+    ) {
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let outcome = process_release_funds(
+            ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+
+        (
+            outcome,
+            storage_rx.try_recv().ok(),
+            sender_rx.try_recv().ok(),
+        )
     }
 
     /// Mocked `getAccountInfo` response for an Instance account carrying the
@@ -2056,29 +2232,46 @@ mod tests {
 
     // ── transient pre-broadcast requeue ─────────────────────────────────
 
-    /// Seed a Processing withdrawal into the mock's pending set. When
-    /// `mint_seeded` is false the mint is left out of `mock.mints`, so the
-    /// no-RPC MintCache surfaces the build-phase transient (RpcError) that the
-    /// fix rescues. Returns the row to feed through the fetcher channel.
+    /// Seed a Processing withdrawal into the mock's pending set, shaping its mint
+    /// row so it either proceeds, hits a transient, or is unsupported.
+    /// How the mint backing a seeded withdrawal is represented in storage.
+    #[derive(Clone, Copy)]
+    enum SeededMint {
+        /// Allowlisted with its extension flags already resolved, so the
+        /// withdrawal runs to completion without needing an RPC.
+        Resolved,
+        /// Allowlisted but with unresolved extension flags, so the pre-flight reaches
+        /// for an RPC client the test does not configure. Manufactures a genuine
+        /// infrastructure failure rather than a verdict about the row.
+        NeedsRpc,
+        /// Never allowlisted.
+        Absent,
+    }
+
     fn seed_processing_withdrawal(
         mock: &MockStorage,
         id: i64,
         nonce: i64,
         mint: &Pubkey,
         recipient: &Pubkey,
-        mint_seeded: bool,
+        seeded_mint: SeededMint,
     ) -> DbTransaction {
-        if mint_seeded {
+        let row = match seeded_mint {
+            SeededMint::Resolved => Some((spl_token::id(), Some(false), Some(false))),
+            SeededMint::NeedsRpc => Some((spl_token_2022::id(), None, None)),
+            SeededMint::Absent => None,
+        };
+        if let Some((token_program, is_pausable, has_permanent_delegate)) = row {
             mock.mints.lock().unwrap().insert(
                 mint.to_string(),
                 DbMint {
                     mint_address: mint.to_string(),
                     decimals: 6,
-                    token_program: spl_token::id().to_string(),
+                    token_program: token_program.to_string(),
                     created_at: chrono::Utc::now(),
                     status: "allowed".to_string(),
-                    is_pausable: Some(false),
-                    has_permanent_delegate: Some(false),
+                    is_pausable,
+                    has_permanent_delegate,
                 },
             );
         }
@@ -2093,15 +2286,16 @@ mod tests {
         txn
     }
 
-    /// Core fix: a build-phase transient (unknown mint, no RPC) requeues the
-    /// current row Processing -> Pending instead of stranding it, and does not
-    /// quarantine it. The error still bubbles so the supervisor restarts.
+    /// Core fix: a pre-flight transient (extension flags unresolved, no RPC)
+    /// requeues the current row Processing -> Pending instead of stranding it, and
+    /// does not quarantine it. The error still bubbles so the supervisor restarts.
     #[tokio::test]
     async fn process_release_funds_transient_requeues_row_to_pending() {
         let mock = MockStorage::new();
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        let txn =
+            seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, SeededMint::NeedsRpc);
         let storage = Arc::new(Storage::Mock(mock.clone()));
 
         let mut ps = ProcessorState {
@@ -2161,7 +2355,8 @@ mod tests {
         let mock = MockStorage::new();
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let mut txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        let mut txn =
+            seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, SeededMint::NeedsRpc);
         // Fetched row already at the cap: the next transient must quarantine.
         txn.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
         let storage = Arc::new(Storage::Mock(mock.clone()));
@@ -2219,9 +2414,12 @@ mod tests {
         let good_mint = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
         // Row 1 triggers the transient; 2 and 3 are valid but buffered behind it.
-        let t1 = seed_processing_withdrawal(&mock, 1, 5, &bad_mint, &recipient, false);
-        let t2 = seed_processing_withdrawal(&mock, 2, 6, &good_mint, &recipient, true);
-        let t3 = seed_processing_withdrawal(&mock, 3, 7, &good_mint, &recipient, true);
+        let t1 =
+            seed_processing_withdrawal(&mock, 1, 5, &bad_mint, &recipient, SeededMint::NeedsRpc);
+        let t2 =
+            seed_processing_withdrawal(&mock, 2, 6, &good_mint, &recipient, SeededMint::Resolved);
+        let t3 =
+            seed_processing_withdrawal(&mock, 3, 7, &good_mint, &recipient, SeededMint::Resolved);
         let storage = Arc::new(Storage::Mock(mock.clone()));
 
         let mut ps = ProcessorState {
@@ -2275,7 +2473,8 @@ mod tests {
         let mock = MockStorage::new();
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        let txn =
+            seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, SeededMint::NeedsRpc);
         mock.set_should_fail("try_requeue_prebroadcast", true);
         let storage = Arc::new(Storage::Mock(mock.clone()));
 
@@ -2315,8 +2514,8 @@ mod tests {
         );
     }
 
-    /// Once a boundary rotation is dispatched, a later transient (here a
-    /// preflight RPC blip) must NOT requeue the head, or the reprocess could
+    /// Once a boundary rotation is dispatched, a later transient (here an
+    /// unreadable escrow balance) must NOT requeue the head, or the reprocess could
     /// re-fire the rotation; it is left Processing for recovery. Buffered siblings
     /// carry post-boundary nonces that cannot re-fire the rotation, so they are
     /// still drained and requeued rather than stranded. The ResetSmtRoot goes out.
@@ -2326,20 +2525,15 @@ mod tests {
         let recipient = Pubkey::new_unique();
 
         let mock = MockStorage::new();
-        // Token-2022 with unresolved extension flags forces the preflight onto
-        // the RPC leg; the mocked getAccountInfo is an Instance account, so the
-        // mint parse fails transiently after the rotation was already sent.
-        mock.mints.lock().unwrap().insert(
-            mint_pubkey.to_string(),
-            DbMint {
-                mint_address: mint_pubkey.to_string(),
-                decimals: 6,
-                token_program: spl_token_2022::id().to_string(),
-                created_at: chrono::Utc::now(),
-                status: "allowed".to_string(),
-                is_pausable: None,
-                has_permanent_delegate: None,
-            },
+        let storage_for_seed = Arc::new(Storage::Mock(mock.clone()));
+        // A permanent-delegate mint sends the preflight to read the escrow balance and
+        // the mocked reply carries an unparseable amount. That is a read failure, not a
+        // verdict about the mint, so it stays transient and surfaces after the rotation.
+        insert_mint_row_with(
+            &storage_for_seed,
+            &mint_pubkey,
+            &spl_token_2022::id(),
+            Some((false, true)),
         );
         let boundary = make_db_transaction(
             1,
@@ -2366,6 +2560,18 @@ mod tests {
         // On-chain tree index 0 < target 1, so the rotation fires first.
         let mut mocks = std::collections::HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, instance_account_response(0));
+        mocks.insert(
+            RpcRequest::GetTokenAccountBalance,
+            serde_json::json!({
+                "context": {"slot": 1},
+                "value": {
+                    "amount": "not-a-number",
+                    "decimals": 6,
+                    "uiAmount": 0.0,
+                    "uiAmountString": "0"
+                }
+            }),
+        );
         let rpc_client = RpcClientWithRetry::new_mocked(mocks);
 
         let mut ps = ProcessorState {
@@ -2420,14 +2626,16 @@ mod tests {
     }
 
     /// Integration: transient-requeue a row to Pending, then heal the transient
-    /// (seed the mint) and feed the same row back Processing; it must now build
-    /// and reach the sender. Proves the rescued row is genuinely re-fetchable.
+    /// (resolve the mint's extension flags) and feed the same row back Processing;
+    /// it must now build and reach the sender. Proves the rescued row is
+    /// genuinely re-fetchable.
     #[tokio::test]
     async fn transient_then_recovery_end_to_end() {
         let mock = MockStorage::new();
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        let txn =
+            seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, SeededMint::NeedsRpc);
         let storage = Arc::new(Storage::Mock(mock.clone()));
 
         let mut ps = ProcessorState {
@@ -2436,7 +2644,7 @@ mod tests {
             mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
 
-        // Pass 1: unknown mint -> transient -> requeue to Pending.
+        // Pass 1: the pre-flight cannot reach an RPC, so the row is requeued to Pending.
         let (ftx1, frx1) = mpsc::channel::<DbTransaction>(4);
         let (stx1, _srx1) = mpsc::channel(10);
         let (gtx1, _grx1) = mpsc::channel(10);
@@ -2459,19 +2667,21 @@ mod tests {
             after[0].clone()
         };
 
-        // Heal the transient: the mint is now known in the DB.
+        // Heal the transient: the extension flags are now resolved in the DB, so
+        // the pre-flight no longer needs an RPC.
         mock.mints.lock().unwrap().insert(
             mint_pubkey.to_string(),
             DbMint {
                 mint_address: mint_pubkey.to_string(),
                 decimals: 6,
-                token_program: spl_token::id().to_string(),
+                token_program: spl_token_2022::id().to_string(),
                 created_at: chrono::Utc::now(),
                 status: "allowed".to_string(),
                 is_pausable: Some(false),
                 has_permanent_delegate: Some(false),
             },
         );
+        ps.mint_cache.clear();
 
         // Pass 2: the fetcher re-locks the row (Processing); it must now be sent.
         let mut relocked = requeued;
@@ -2508,7 +2718,8 @@ mod tests {
         let mock = MockStorage::new();
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, true);
+        let txn =
+            seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, SeededMint::Resolved);
         // One transient blip on get_mint; the backoff rides it out.
         mock.set_fail_times("get_mint", 1);
         let storage = Arc::new(Storage::Mock(mock.clone()));
@@ -4053,6 +4264,414 @@ mod tests {
             mock.pending_transactions.lock().unwrap()[0].status,
             TransactionStatus::Processing,
             "the row stays Processing for the recovery sweep to complete"
+        );
+    }
+
+    /// Mocked `getAccountInfo` reply for an account that does not exist.
+    fn absent_account_response() -> serde_json::Value {
+        serde_json::json!({"context": {"slot": 1}, "value": null})
+    }
+
+    /// A `MintCache` whose RPC reports every account as absent.
+    fn mint_cache_over_absent_chain(storage: Arc<Storage>) -> crate::operator::MintCache {
+        use crate::operator::rpc_util::RpcClientWithRetry;
+        use solana_client::rpc_request::RpcRequest;
+
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, absent_account_response());
+        crate::operator::MintCache::with_rpc(
+            storage,
+            Arc::new(RpcClientWithRetry::new_mocked(mocks)),
+        )
+    }
+
+    /// A Token-2022 mint the indexer knows about, whose account is absent from the
+    /// target chain, must park the one row instead of taking the operator down.
+    #[tokio::test]
+    async fn process_release_funds_target_mint_missing_routes_to_manual_review() {
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        // Flags unresolved, so the pre-flight has to ask the chain about this mint.
+        insert_mint_row_with(&storage, &mint, &spl_token_2022::id(), None);
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: mint_cache_over_absent_chain(storage.clone()),
+        };
+
+        let txn = make_db_transaction(
+            77,
+            &mint.to_string(),
+            &recipient.to_string(),
+            Some(5),
+            TransactionType::Withdrawal,
+        );
+
+        let (outcome, update, builder) = run_one_withdrawal(&mut ps, storage, txn).await;
+
+        assert!(outcome.is_ok(), "a missing mint must not exit the task");
+        let update = update.expect("row must be routed to ManualReview");
+        assert_eq!(update.transaction_id, 77);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let msg = update.error_message.expect("error_message must be set");
+        assert!(
+            msg.contains("withdrawal mint absent on target chain")
+                && msg.contains(&mint.to_string()),
+            "unexpected error_message: {msg}"
+        );
+        assert!(builder.is_none(), "no builder may be dispatched");
+    }
+
+    /// Mocked `getAccountInfo` reply for a well-formed legacy SPL mint.
+    fn spl_mint_account_response(decimals: u8) -> serde_json::Value {
+        // Base SPL mint layout is 82 bytes; decimals sits at offset 44 and the
+        // is_initialized flag at offset 45.
+        let mut data = vec![0u8; 82];
+        data[44] = decimals;
+        data[45] = 1;
+        serde_json::json!({
+            "context": {"slot": 1},
+            "value": {
+                "owner": spl_token::id().to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode(&data), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        })
+    }
+
+    /// Seed the escrow indexer's committed checkpoint.
+    fn seed_escrow_checkpoint(storage: &Arc<Storage>, slot: u64) {
+        let mock_storage = match storage.as_ref() {
+            Storage::Mock(m) => m,
+            _ => unreachable!("test helper expects Storage::Mock"),
+        };
+        mock_storage
+            .committed_checkpoints
+            .lock()
+            .unwrap()
+            .insert("escrow".to_string(), slot);
+    }
+
+    /// A withdrawal processor with no RPC client behind its mint cache.
+    fn processor_state_without_rpc(storage: &Arc<Storage>) -> ProcessorState {
+        ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        }
+    }
+
+    /// A withdrawal row for `mint` at `nonce`.
+    fn withdrawal_for(mint: &Pubkey, nonce: i64) -> DbTransaction {
+        make_db_transaction(
+            9,
+            &mint.to_string(),
+            &Pubkey::new_unique().to_string(),
+            Some(nonce),
+            TransactionType::Withdrawal,
+        )
+    }
+
+    /// A mint the indexer has never recorded is parked, and the reason names the
+    /// checkpoint so an operator can tell a bogus mint from an incomplete backfill.
+    #[tokio::test]
+    async fn process_release_funds_unsupported_mint_routes_to_manual_review() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        seed_escrow_checkpoint(&storage, 500);
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, builder) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(
+            outcome.is_ok(),
+            "an unsupported mint must not exit the task"
+        );
+        let update = update.expect("row must be routed to ManualReview");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let msg = update.error_message.expect("error_message must be set");
+        assert!(
+            msg.contains("unsupported withdrawal mint:")
+                && msg.contains(&mint.to_string())
+                && msg.contains("500"),
+            "unexpected error_message: {msg}"
+        );
+        assert!(builder.is_none(), "no builder may be dispatched");
+    }
+
+    /// With no escrow checkpoint at all the row is still parked, and the reason
+    /// says the allowlist has never been indexed rather than implying a slot.
+    #[tokio::test]
+    async fn process_release_funds_unsupported_mint_without_checkpoint_says_so() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, _) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok());
+        let msg = update
+            .expect("row must be routed to ManualReview")
+            .error_message
+            .expect("error_message must be set");
+        assert!(
+            msg.contains("unsupported withdrawal mint:") && msg.contains("never checkpointed"),
+            "unexpected error_message: {msg}"
+        );
+    }
+
+    /// An allowlisted mint passes the gate untouched.
+    #[tokio::test]
+    async fn process_release_funds_allowlisted_mint_proceeds() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        insert_mint_row(&storage, &mint);
+        seed_escrow_checkpoint(&storage, 500);
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, builder) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok());
+        assert!(update.is_none(), "a supported mint must not be quarantined");
+        assert!(
+            matches!(builder, Some(TransactionBuilder::ReleaseFunds(_))),
+            "the withdrawal must be dispatched"
+        );
+    }
+
+    /// A mint that was allowlisted and later blocked stays withdrawable, or the
+    /// escrowed funds behind it would be stranded.
+    #[tokio::test]
+    async fn process_release_funds_blocked_mint_still_withdrawable() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        insert_mint_row(&storage, &mint);
+        seed_mint_status(&storage, &mint, "blocked", 50);
+        seed_escrow_checkpoint(&storage, 500);
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, builder) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok());
+        assert!(update.is_none(), "a blocked mint must not be quarantined");
+        assert!(
+            matches!(builder, Some(TransactionBuilder::ReleaseFunds(_))),
+            "a blocked mint must still be releasable"
+        );
+    }
+
+    /// An unreadable allowlist is not a verdict about the mint. The row is left
+    /// alive for a retry rather than terminalized on a database outage.
+    #[tokio::test]
+    async fn process_release_funds_unreadable_allowlist_is_transient() {
+        let mint = Pubkey::new_unique();
+        let mock = MockStorage::new();
+        let txn = seed_processing_withdrawal(
+            &mock,
+            9,
+            5,
+            &mint,
+            &Pubkey::new_unique(),
+            SeededMint::Absent,
+        );
+        mock.set_should_fail("get_mint", true);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, builder) = run_one_withdrawal(&mut ps, storage, txn).await;
+
+        assert!(
+            matches!(outcome, Err(OperatorError::Storage(_))),
+            "a database outage must stay transient, got: {outcome:?}"
+        );
+        assert!(
+            update.is_none(),
+            "an unreadable allowlist must not quarantine"
+        );
+        assert!(builder.is_none());
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Pending,
+            "row must be requeued for another attempt"
+        );
+    }
+
+    /// An unreadable checkpoint changes the wording of the reason and nothing else.
+    #[tokio::test]
+    async fn process_release_funds_unreadable_checkpoint_still_parks_the_row() {
+        let mint = Pubkey::new_unique();
+        let mock = MockStorage::new();
+        mock.set_should_fail("get_committed_checkpoint", true);
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, builder) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok());
+        let msg = update
+            .expect("row must be routed to ManualReview")
+            .error_message
+            .expect("error_message must be set");
+        assert!(
+            msg.contains("unsupported withdrawal mint:") && msg.contains("checkpoint unknown"),
+            "unexpected error_message: {msg}"
+        );
+        assert!(builder.is_none());
+    }
+
+    /// The gate reaches its verdict from storage alone, so an operator with no
+    /// RPC configured still rejects the row instead of failing on the missing client.
+    #[tokio::test]
+    async fn process_release_funds_unsupported_mint_needs_no_rpc() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        seed_escrow_checkpoint(&storage, 7);
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, _) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok(), "the gate must not depend on an RPC client");
+        assert_eq!(
+            update.expect("row must be parked").status,
+            TransactionStatus::ManualReview
+        );
+    }
+
+    /// The allowlist is the authority. A mint that exists on the target chain but
+    /// was never allowlisted is still rejected, which is what makes the gate
+    /// independent of whether the chain is reachable.
+    #[tokio::test]
+    async fn process_release_funds_unsupported_mint_ignores_live_target_chain() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        seed_escrow_checkpoint(&storage, 500);
+
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, spl_mint_account_response(6));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::with_rpc(
+                storage.clone(),
+                Arc::new(RpcClientWithRetry::new_mocked(mocks)),
+            ),
+        };
+
+        let (outcome, update, builder) =
+            run_one_withdrawal(&mut ps, storage, withdrawal_for(&mint, 5)).await;
+
+        assert!(outcome.is_ok());
+        assert_eq!(
+            update.expect("row must be parked").status,
+            TransactionStatus::ManualReview,
+            "a live target-chain account must not override the allowlist"
+        );
+        assert!(builder.is_none());
+    }
+
+    /// A boundary nonce whose mint is unsupported must not dispatch a rotation,
+    /// exactly as it did not before the gate existed.
+    #[tokio::test]
+    async fn process_release_funds_unsupported_boundary_mint_skips_rotation() {
+        let mint = Pubkey::new_unique();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        seed_escrow_checkpoint(&storage, 500);
+        let mut ps = processor_state_without_rpc(&storage);
+
+        let (outcome, update, builder) = run_one_withdrawal(
+            &mut ps,
+            storage,
+            withdrawal_for(&mint, MAX_TREE_LEAVES as i64),
+        )
+        .await;
+
+        assert!(outcome.is_ok());
+        assert_eq!(
+            update.expect("row must be parked").status,
+            TransactionStatus::ManualReview
+        );
+        assert!(builder.is_none(), "no rotation may be dispatched");
+    }
+
+    /// Parking a boundary row leaves the tree on the old generation, so buffered
+    /// siblings must go back to Pending. Dispatching one would build it against an
+    /// index the chain rejects, waiting on a rotation this row alone could trigger.
+    #[tokio::test]
+    async fn process_release_funds_parked_boundary_requeues_buffered_siblings() {
+        let mock = MockStorage::new();
+        let unsupported = Pubkey::new_unique();
+        let good_mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let boundary = MAX_TREE_LEAVES as i64;
+        let head = seed_processing_withdrawal(
+            &mock,
+            1,
+            boundary,
+            &unsupported,
+            &recipient,
+            SeededMint::Absent,
+        );
+        let sibling = seed_processing_withdrawal(
+            &mock,
+            2,
+            boundary + 1,
+            &good_mint,
+            &recipient,
+            SeededMint::Resolved,
+        );
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        seed_escrow_checkpoint(&storage, 500);
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(head).await.unwrap();
+        fetcher_tx.send(sibling).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+
+        assert!(result.is_ok(), "parking a row must not end the task");
+        assert_eq!(
+            storage_rx.try_recv().expect("head must be parked").status,
+            TransactionStatus::ManualReview
+        );
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "no rotation and no sibling may be dispatched"
+        );
+
+        let after = mock.pending_transactions.lock().unwrap();
+        let sibling_row = after.iter().find(|t| t.id == 2).unwrap();
+        assert_eq!(
+            sibling_row.status,
+            TransactionStatus::Pending,
+            "buffered sibling must be requeued, not dispatched"
         );
     }
 }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -2706,8 +2706,9 @@ mod tests {
         let mut row = make_withdrawal_row(1, Some(3));
         row.updated_at = Utc::now() - chrono::Duration::minutes(10);
         mock.pending_transactions.lock().unwrap().push(row.clone());
-        // The mint is unknown (a DB-first read), so the build is a transient error,
-        // and the rescue write that would requeue the row fails too.
+        // The allowlist read fails for the whole of its retry budget, which is the
+        // DB outage, and the rescue write that would requeue the row fails too.
+        mock.set_fail_times("get_mint", 3);
         mock.set_fail_times("try_requeue_prebroadcast", 1);
         let storage = Arc::new(Storage::Mock(mock.clone()));
 

--- a/indexer/src/operator/utils/mint_util.rs
+++ b/indexer/src/operator/utils/mint_util.rs
@@ -15,7 +15,7 @@ use spl_token_2022::extension::{
 };
 use spl_token_2022::state::Mint as Token2022MintState;
 use spl_token_2022::ID as TOKEN_2022_PROGRAM_ID;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::warn;
@@ -23,19 +23,28 @@ use tracing::warn;
 const DECIMALS_OFFSET: usize = 44;
 
 /// Reads a mint, telling "absent" apart from "could not read"; `get_account` merges both.
-/// Uses the client's commitment so a new mint is not mistaken for one that never existed.
+///
+/// `existence_floor` is a slot the mint provably existed at. Requiring the node to
+/// answer at or past it means a null cannot be lag: the node has the creation in its
+/// state, so nothing is a permanent verdict without that proof.
 async fn read_target_mint_account(
     rpc: &RpcClientWithRetry,
     mint: &Pubkey,
+    existence_floor: Option<u64>,
 ) -> Result<Account, OperatorError> {
     let response = rpc
-        .get_account_with_context(mint, rpc.rpc_client.commitment())
+        .get_account_with_context_min_slot(mint, rpc.rpc_client.commitment(), existence_floor)
         .await
         .map_err(|e| OperatorError::RpcError(format!("get_account({mint}): {e}")))?;
 
-    response
-        .value
-        .ok_or_else(|| AccountError::TargetMintMissing { pubkey: *mint }.into())
+    match (response.value, existence_floor) {
+        (Some(account), _) => Ok(account),
+        (None, Some(_)) => Err(AccountError::TargetMintMissing { pubkey: *mint }.into()),
+        // Nothing proves this mint ever existed, so absence stays retryable.
+        (None, None) => Err(OperatorError::RpcError(format!(
+            "get_account({mint}): absent, and no allowlist slot proves it ever existed"
+        ))),
+    }
 }
 
 /// `getTokenAccountBalance` returns `RpcResponseError { code: -32602, ... }`
@@ -65,10 +74,9 @@ pub struct MintCache {
     rpc_client: Option<Arc<RpcClientWithRetry>>,
     cache: HashMap<String, MintMetadata>,
     extension_flags_cache: HashMap<String, (bool, bool)>,
-    /// Mints with a real `mints` row, written only by the storage read below.
-    /// The allowlist gate reads this, not `cache`, which the RPC fallback also fills.
-    /// Rows are never deleted, so a stale entry cannot open the gate; a miss re-reads.
-    db_backed: HashSet<String>,
+    /// Per-mint slot the mint provably existed at, recorded by the caller that
+    /// proved it. Absent means unproven, which keeps a missing account retryable.
+    existence_floor: HashMap<String, u64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -84,7 +92,7 @@ impl MintCache {
             rpc_client: None,
             cache: HashMap::new(),
             extension_flags_cache: HashMap::new(),
-            db_backed: HashSet::new(),
+            existence_floor: HashMap::new(),
         }
     }
 
@@ -94,7 +102,7 @@ impl MintCache {
             rpc_client: Some(rpc_client),
             cache: HashMap::new(),
             extension_flags_cache: HashMap::new(),
-            db_backed: HashSet::new(),
+            existence_floor: HashMap::new(),
         }
     }
 
@@ -103,48 +111,19 @@ impl MintCache {
         self.rpc_client.as_deref()
     }
 
-    /// Basic mint metadata from storage only. `Ok(None)` means the indexer has no
-    /// row for this mint, which is an answer rather than a reason to reach across
-    /// chains. A hit warms both caches, so a later read costs no second round trip.
-    pub async fn get_mint_metadata_from_db(
-        &mut self,
-        mint: &Pubkey,
-    ) -> Result<Option<MintMetadata>, OperatorError> {
-        let mint_str = mint.to_string();
+    /// Record that this mint provably existed at `slot`. The caller establishes the
+    /// proof; only then may a missing account be treated as permanent rather than lag.
+    pub fn record_existence_floor(&mut self, mint: &Pubkey, slot: u64) {
+        self.existence_floor.insert(mint.to_string(), slot);
+    }
 
-        if self.db_backed.contains(&mint_str) {
-            if let Some(metadata) = self.cache.get(&mint_str) {
-                return Ok(Some(metadata.clone()));
-            }
-        }
+    /// Whether a caller has already proved this mint exists on the target chain.
+    pub fn has_existence_floor(&self, mint: &Pubkey) -> bool {
+        self.existence_floor.contains_key(&mint.to_string())
+    }
 
-        // Retry a transient DB blip before answering, so a brief outage does not
-        // surface as a missing mint and strand the withdrawal.
-        // transaction_id=-1: no per-call txn context here; retries log by op name.
-        let db_mint = with_storage_backoff("mint metadata read", -1, || {
-            self.storage.get_mint(&mint_str)
-        })
-        .await?;
-
-        let Some(m) = db_mint else {
-            return Ok(None);
-        };
-
-        let token_program =
-            Pubkey::from_str(&m.token_program).map_err(|e| OperatorError::InvalidPubkey {
-                pubkey: m.token_program.clone(),
-                reason: e.to_string(),
-            })?;
-        let metadata = MintMetadata {
-            token_program,
-            decimals: m.decimals as u8,
-        };
-        self.cache.insert(mint_str.clone(), metadata.clone());
-        self.db_backed.insert(mint_str.clone());
-        if let (Some(p), Some(d)) = (m.is_pausable, m.has_permanent_delegate) {
-            self.extension_flags_cache.insert(mint_str, (p, d));
-        }
-        Ok(Some(metadata))
+    fn existence_floor(&self, mint: &Pubkey) -> Option<u64> {
+        self.existence_floor.get(&mint.to_string()).copied()
     }
 
     /// Basic mint metadata (decimals + token program), served from cache, then DB,
@@ -154,18 +133,44 @@ impl MintCache {
         &mut self,
         mint: &Pubkey,
     ) -> Result<MintMetadata, OperatorError> {
-        if let Some(metadata) = self.get_mint_metadata_from_db(mint).await? {
+        let mint_str = mint.to_string();
+
+        if let Some(metadata) = self.cache.get(&mint_str) {
+            return Ok(metadata.clone());
+        }
+
+        // Retry a transient DB blip before falling through to the RPC leg, so a
+        // brief outage does not surface as Transient and strand the withdrawal.
+        // transaction_id=-1: no per-call txn context here; retries log by op name.
+        let db_mint = with_storage_backoff("mint metadata read", -1, || {
+            self.storage.get_mint(&mint_str)
+        })
+        .await?;
+        if let Some(m) = db_mint {
+            let token_program =
+                Pubkey::from_str(&m.token_program).map_err(|e| OperatorError::InvalidPubkey {
+                    pubkey: m.token_program.clone(),
+                    reason: e.to_string(),
+                })?;
+            let metadata = MintMetadata {
+                token_program,
+                decimals: m.decimals as u8,
+            };
+            self.cache.insert(mint_str.clone(), metadata.clone());
+            if let (Some(p), Some(d)) = (m.is_pausable, m.has_permanent_delegate) {
+                self.extension_flags_cache.insert(mint_str, (p, d));
+            }
             return Ok(metadata);
         }
 
-        let mint_str = mint.to_string();
+        let floor = self.existence_floor(mint);
         let rpc = self.rpc_client.as_ref().ok_or_else(|| {
             OperatorError::RpcError(format!(
                 "MintCache needs RPC for unknown mint {mint_str}, but no RPC client is configured",
             ))
         })?;
 
-        let (metadata, flags) = self.fetch_mint_from_rpc(mint, rpc).await?;
+        let (metadata, flags) = self.fetch_mint_from_rpc(mint, rpc, floor).await?;
         self.cache.insert(mint_str.clone(), metadata.clone());
         self.extension_flags_cache.insert(mint_str, flags);
         Ok(metadata)
@@ -196,13 +201,14 @@ impl MintCache {
             }
         }
 
+        let floor = self.existence_floor(mint);
         let rpc = self.rpc_client.as_ref().ok_or_else(|| {
             OperatorError::RpcError(format!(
                 "MintCache needs RPC to resolve extension flags for mint {mint_str}",
             ))
         })?;
 
-        let (_metadata, flags) = self.fetch_mint_from_rpc(mint, rpc).await?;
+        let (_metadata, flags) = self.fetch_mint_from_rpc(mint, rpc, floor).await?;
 
         // Write-back only when the indexer has already landed a row. No row
         // means this is a pre-AllowMint-ingested edge case; we keep the
@@ -234,12 +240,14 @@ impl MintCache {
     /// pre-flight pause check in the operator's ReleaseFunds path: only
     /// call this after `MintMetadata.is_pausable` came back true.
     pub async fn check_paused(&self, mint: &Pubkey) -> Result<bool, OperatorError> {
+        let floor = self.existence_floor(mint);
         let rpc = self.rpc_client.as_ref().ok_or_else(|| {
             OperatorError::RpcError("check_paused requires an RPC client".to_string())
         })?;
 
-        // Same split as the metadata fetch: an absent mint is deterministic, an unreachable node is not.
-        let account = read_target_mint_account(rpc, mint).await?;
+        // Same split as the metadata fetch: a proven-absent mint is deterministic,
+        // an unreachable or unconvinced node is not.
+        let account = read_target_mint_account(rpc, mint, floor).await?;
 
         let state =
             StateWithExtensions::<Token2022MintState>::unpack(&account.data).map_err(|_| {
@@ -294,8 +302,9 @@ impl MintCache {
         &self,
         mint: &Pubkey,
         rpc: &RpcClientWithRetry,
+        existence_floor: Option<u64>,
     ) -> Result<(MintMetadata, (bool, bool)), OperatorError> {
-        let account = read_target_mint_account(rpc, mint).await?;
+        let account = read_target_mint_account(rpc, mint, existence_floor).await?;
 
         let token_program = account.owner;
 
@@ -406,7 +415,6 @@ mod tests {
     impl MintCache {
         pub fn clear(&mut self) {
             self.cache.clear();
-            self.db_backed.clear();
         }
 
         pub fn cache_size(&self) -> usize {
@@ -816,7 +824,7 @@ mod tests {
     #[tokio::test]
     async fn check_paused_errors_without_rpc() {
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let cache = MintCache::new(storage);
+        let mut cache = MintCache::new(storage);
 
         let err = cache
             .check_paused(&create_test_mint())
@@ -940,37 +948,6 @@ mod tests {
         let result = cache.get_mint_metadata(&mint).await;
         assert!(result.is_err());
     }
-
-    /// The allowlist answer must come from storage, never from an entry the RPC
-    /// fallback left behind, or a mint the indexer has no row for would read as
-    /// allowlisted for the rest of the process and open the gate silently.
-    #[tokio::test]
-    async fn metadata_from_db_ignores_an_rpc_resolved_entry() {
-        let mint = Pubkey::new_unique();
-        let mut mocks = std::collections::HashMap::new();
-        mocks.insert(
-            RpcRequest::GetAccountInfo,
-            create_mock_account_response(&TOKEN_PROGRAM_ID, 9),
-        );
-        let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let mut cache =
-            MintCache::with_rpc(storage, Arc::new(RpcClientWithRetry::new_mocked(mocks)));
-
-        cache
-            .get_mint_metadata(&mint)
-            .await
-            .expect("rpc fallback resolves the mint");
-
-        assert!(
-            cache
-                .get_mint_metadata_from_db(&mint)
-                .await
-                .unwrap()
-                .is_none(),
-            "an RPC-resolved mint must not satisfy the allowlist read"
-        );
-    }
-
     /// An RPC that answers successfully but reports the account as absent.
     fn rpc_reporting_absent_account() -> RpcClientWithRetry {
         let mut mocks = std::collections::HashMap::new();
@@ -1001,7 +978,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mint_metadata_rpc_fallback_absent_account_is_target_mint_missing() {
+    async fn mint_metadata_rpc_fallback_absent_account_stays_transient() {
         let mint = create_test_mint();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
         let mut cache = MintCache::with_rpc(storage, Arc::new(rpc_reporting_absent_account()));
@@ -1009,11 +986,8 @@ mod tests {
         let err = cache.get_mint_metadata(&mint).await.unwrap_err();
 
         assert!(
-            matches!(
-                err,
-                OperatorError::Account(AccountError::TargetMintMissing { pubkey }) if pubkey == mint
-            ),
-            "absent mint must be deterministic, got: {err:?}"
+            matches!(err, OperatorError::RpcError(_)),
+            "an unknown mint has no proof of existence, so absence stays retryable, got: {err:?}"
         );
     }
 
@@ -1033,11 +1007,14 @@ mod tests {
         );
     }
 
+    /// The allow slot proves the mint existed, so a node that has passed it and still
+    /// reports nothing is reporting a closed account, not lag.
     #[tokio::test]
-    async fn check_paused_absent_account_is_target_mint_missing() {
+    async fn check_paused_absent_past_the_allow_slot_is_target_mint_missing() {
         let mint = create_test_mint();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let cache = MintCache::with_rpc(storage, Arc::new(rpc_reporting_absent_account()));
+        let mut cache = MintCache::with_rpc(storage, Arc::new(rpc_reporting_absent_account()));
+        cache.record_existence_floor(&mint, 42);
 
         let err = cache.check_paused(&mint).await.unwrap_err();
 
@@ -1050,86 +1027,70 @@ mod tests {
         );
     }
 
+    /// Without an allow slot nothing proves the mint ever existed, so a null could be
+    /// a lagging node. Staying transient keeps a burned withdrawal out of manual review.
     #[tokio::test]
-    async fn metadata_from_db_returns_none_without_touching_rpc() {
+    async fn check_paused_absent_without_an_allow_slot_stays_transient() {
         let mint = create_test_mint();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let mut cache = MintCache::new(storage);
+        let cache = MintCache::with_rpc(storage, Arc::new(rpc_reporting_absent_account()));
 
-        let found = cache
-            .get_mint_metadata_from_db(&mint)
-            .await
-            .expect("a missing row is an answer, not a failure");
-
-        assert!(found.is_none(), "no row means the mint is not allowlisted");
-    }
-
-    /// A miss is never remembered, so a mint allowlisted after the operator started
-    /// is picked up on the next read instead of needing a restart.
-    #[tokio::test]
-    async fn metadata_from_db_sees_a_row_added_after_a_miss() {
-        let mint = create_test_mint();
-        let mock = MockStorage::new();
-        let rows = mock.mints.clone();
-        let mut cache = MintCache::new(Arc::new(Storage::Mock(mock)));
+        let err = cache.check_paused(&mint).await.unwrap_err();
 
         assert!(
-            cache
-                .get_mint_metadata_from_db(&mint)
-                .await
-                .unwrap()
-                .is_none(),
-            "no row yet"
+            matches!(err, OperatorError::RpcError(_)),
+            "an unprovable absence must stay retryable, got: {err:?}"
         );
+    }
 
-        rows.lock().unwrap().insert(
-            mint.to_string(),
-            DbMint {
-                mint_address: mint.to_string(),
-                decimals: 6,
-                token_program: TOKEN_PROGRAM_ID.to_string(),
-                created_at: chrono::Utc::now(),
-                status: "allowed".to_string(),
-                is_pausable: Some(false),
-                has_permanent_delegate: Some(false),
+    /// The proof is only real if the node is actually asked to honour it, so this
+    /// matches on the wire format: a request without `minContextSlot` gets no reply.
+    #[tokio::test]
+    async fn target_mint_read_sends_the_existence_floor_to_the_node() {
+        let mint = create_test_mint();
+        let mut server = mockito::Server::new_async().await;
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "result": create_mock_account_response(&TOKEN_PROGRAM_ID, 9),
+            "id": 1,
+        });
+        let endpoint = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex("\"minContextSlot\":42".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body.to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let rpc = RpcClientWithRetry::with_retry_config(
+            server.url(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(2),
             },
+            CommitmentConfig::confirmed(),
         );
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut cache = MintCache::with_rpc(storage, Arc::new(rpc));
+        cache.record_existence_floor(&mint, 42);
 
-        assert!(
-            cache
-                .get_mint_metadata_from_db(&mint)
-                .await
-                .unwrap()
-                .is_some(),
-            "a later AllowMint must be visible without clearing the cache"
-        );
+        cache
+            .get_mint_metadata(&mint)
+            .await
+            .expect("the node answers when the floor is honoured");
+
+        endpoint.assert_async().await;
     }
-
-    #[tokio::test]
-    async fn metadata_from_db_hit_warms_both_caches() {
-        let mint = create_test_mint();
-        let storage = create_test_storage_with_mint(&mint, &TOKEN_PROGRAM_ID, 6);
-        let mut cache = MintCache::new(storage);
-
-        let found = cache.get_mint_metadata_from_db(&mint).await.unwrap();
-        assert_eq!(found.expect("row is present").decimals, 6);
-        assert_eq!(cache.cache_size(), 1, "metadata cache must be warmed");
-
-        // No RPC client is configured, so these only succeed if the DB read warmed them.
-        cache.get_mint_metadata(&mint).await.unwrap();
-        assert_eq!(
-            cache.get_extension_flags(&mint).await.unwrap(),
-            (false, false)
-        );
-    }
-
     #[tokio::test]
     async fn check_paused_transport_error_is_rpc_error() {
         let mut server = mockito::Server::new_async().await;
         let rpc = rpc_failing_transport(&mut server).await;
         let mint = create_test_mint();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let cache = MintCache::with_rpc(storage, Arc::new(rpc));
+        let mut cache = MintCache::with_rpc(storage, Arc::new(rpc));
 
         let err = cache.check_paused(&mint).await.unwrap_err();
 

--- a/indexer/src/operator/utils/mint_util.rs
+++ b/indexer/src/operator/utils/mint_util.rs
@@ -6,6 +6,7 @@ use crate::storage::Storage;
 use solana_rpc_client_api::client_error;
 use solana_rpc_client_api::client_error::ErrorKind;
 use solana_rpc_client_api::request::RpcError;
+use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
 use spl_token::ID as TOKEN_PROGRAM_ID;
 use spl_token_2022::extension::{
@@ -14,12 +15,28 @@ use spl_token_2022::extension::{
 };
 use spl_token_2022::state::Mint as Token2022MintState;
 use spl_token_2022::ID as TOKEN_2022_PROGRAM_ID;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::warn;
 
 const DECIMALS_OFFSET: usize = 44;
+
+/// Reads a mint, telling "absent" apart from "could not read"; `get_account` merges both.
+/// Uses the client's commitment so a new mint is not mistaken for one that never existed.
+async fn read_target_mint_account(
+    rpc: &RpcClientWithRetry,
+    mint: &Pubkey,
+) -> Result<Account, OperatorError> {
+    let response = rpc
+        .get_account_with_context(mint, rpc.rpc_client.commitment())
+        .await
+        .map_err(|e| OperatorError::RpcError(format!("get_account({mint}): {e}")))?;
+
+    response
+        .value
+        .ok_or_else(|| AccountError::TargetMintMissing { pubkey: *mint }.into())
+}
 
 /// `getTokenAccountBalance` returns `RpcResponseError { code: -32602, ... }`
 /// when the ATA does not exist. The lowercased substring match is a fallback
@@ -48,6 +65,10 @@ pub struct MintCache {
     rpc_client: Option<Arc<RpcClientWithRetry>>,
     cache: HashMap<String, MintMetadata>,
     extension_flags_cache: HashMap<String, (bool, bool)>,
+    /// Mints with a real `mints` row, written only by the storage read below.
+    /// The allowlist gate reads this, not `cache`, which the RPC fallback also fills.
+    /// Rows are never deleted, so a stale entry cannot open the gate; a miss re-reads.
+    db_backed: HashSet<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -63,6 +84,7 @@ impl MintCache {
             rpc_client: None,
             cache: HashMap::new(),
             extension_flags_cache: HashMap::new(),
+            db_backed: HashSet::new(),
         }
     }
 
@@ -72,6 +94,7 @@ impl MintCache {
             rpc_client: Some(rpc_client),
             cache: HashMap::new(),
             extension_flags_cache: HashMap::new(),
+            db_backed: HashSet::new(),
         }
     }
 
@@ -80,50 +103,62 @@ impl MintCache {
         self.rpc_client.as_deref()
     }
 
-    /// Basic mint metadata (decimals + token program). Cache → DB → RPC
-    /// fallback only when no DB row exists.
-    ///
-    /// Opportunistically warms `extension_flags_cache` on both the DB-hit
-    /// and RPC-fallback branches: the DB row already carries the flags if
-    /// they've been resolved before, and the RPC fallback's
-    /// `fetch_mint_from_rpc` returns them as a by-product of parsing the
-    /// mint account. This saves the subsequent `get_extension_flags` call
-    /// on the withdrawal pre-flight a second DB round-trip (or, on the
-    /// RPC-fallback path, a second RPC parse of the same mint).
-    pub async fn get_mint_metadata(
+    /// Basic mint metadata from storage only. `Ok(None)` means the indexer has no
+    /// row for this mint, which is an answer rather than a reason to reach across
+    /// chains. A hit warms both caches, so a later read costs no second round trip.
+    pub async fn get_mint_metadata_from_db(
         &mut self,
         mint: &Pubkey,
-    ) -> Result<MintMetadata, OperatorError> {
+    ) -> Result<Option<MintMetadata>, OperatorError> {
         let mint_str = mint.to_string();
 
-        if let Some(metadata) = self.cache.get(&mint_str) {
-            return Ok(metadata.clone());
+        if self.db_backed.contains(&mint_str) {
+            if let Some(metadata) = self.cache.get(&mint_str) {
+                return Ok(Some(metadata.clone()));
+            }
         }
 
-        // Retry a transient DB blip before falling through to the RPC leg, so a
-        // brief outage does not surface as Transient and strand the withdrawal.
+        // Retry a transient DB blip before answering, so a brief outage does not
+        // surface as a missing mint and strand the withdrawal.
         // transaction_id=-1: no per-call txn context here; retries log by op name.
         let db_mint = with_storage_backoff("mint metadata read", -1, || {
             self.storage.get_mint(&mint_str)
         })
         .await?;
-        if let Some(m) = db_mint {
-            let token_program =
-                Pubkey::from_str(&m.token_program).map_err(|e| OperatorError::InvalidPubkey {
-                    pubkey: m.token_program.clone(),
-                    reason: e.to_string(),
-                })?;
-            let metadata = MintMetadata {
-                token_program,
-                decimals: m.decimals as u8,
-            };
-            self.cache.insert(mint_str.clone(), metadata.clone());
-            if let (Some(p), Some(d)) = (m.is_pausable, m.has_permanent_delegate) {
-                self.extension_flags_cache.insert(mint_str, (p, d));
-            }
+
+        let Some(m) = db_mint else {
+            return Ok(None);
+        };
+
+        let token_program =
+            Pubkey::from_str(&m.token_program).map_err(|e| OperatorError::InvalidPubkey {
+                pubkey: m.token_program.clone(),
+                reason: e.to_string(),
+            })?;
+        let metadata = MintMetadata {
+            token_program,
+            decimals: m.decimals as u8,
+        };
+        self.cache.insert(mint_str.clone(), metadata.clone());
+        self.db_backed.insert(mint_str.clone());
+        if let (Some(p), Some(d)) = (m.is_pausable, m.has_permanent_delegate) {
+            self.extension_flags_cache.insert(mint_str, (p, d));
+        }
+        Ok(Some(metadata))
+    }
+
+    /// Basic mint metadata (decimals + token program), served from cache, then DB,
+    /// then RPC only when no DB row exists. Both the DB and RPC branches warm
+    /// `extension_flags_cache` where they can, sparing the pre-flight a second read.
+    pub async fn get_mint_metadata(
+        &mut self,
+        mint: &Pubkey,
+    ) -> Result<MintMetadata, OperatorError> {
+        if let Some(metadata) = self.get_mint_metadata_from_db(mint).await? {
             return Ok(metadata);
         }
 
+        let mint_str = mint.to_string();
         let rpc = self.rpc_client.as_ref().ok_or_else(|| {
             OperatorError::RpcError(format!(
                 "MintCache needs RPC for unknown mint {mint_str}, but no RPC client is configured",
@@ -203,10 +238,8 @@ impl MintCache {
             OperatorError::RpcError("check_paused requires an RPC client".to_string())
         })?;
 
-        let account = rpc
-            .get_account(mint)
-            .await
-            .map_err(|_| AccountError::AccountNotFound { pubkey: *mint })?;
+        // Same split as the metadata fetch: an absent mint is deterministic, an unreachable node is not.
+        let account = read_target_mint_account(rpc, mint).await?;
 
         let state =
             StateWithExtensions::<Token2022MintState>::unpack(&account.data).map_err(|_| {
@@ -262,10 +295,7 @@ impl MintCache {
         mint: &Pubkey,
         rpc: &RpcClientWithRetry,
     ) -> Result<(MintMetadata, (bool, bool)), OperatorError> {
-        let account = rpc
-            .get_account(mint)
-            .await
-            .map_err(|_| AccountError::AccountNotFound { pubkey: *mint })?;
+        let account = read_target_mint_account(rpc, mint).await?;
 
         let token_program = account.owner;
 
@@ -368,12 +398,15 @@ mod tests {
     use base64::Engine;
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_client::rpc_request::RpcRequest;
+    use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::pubkey::Pubkey;
     use spl_token_2022::ID as TOKEN_2022_PROGRAM_ID;
+    use std::time::Duration;
 
     impl MintCache {
         pub fn clear(&mut self) {
             self.cache.clear();
+            self.db_backed.clear();
         }
 
         pub fn cache_size(&self) -> usize {
@@ -906,5 +939,203 @@ mod tests {
         // Should error on invalid owner
         let result = cache.get_mint_metadata(&mint).await;
         assert!(result.is_err());
+    }
+
+    /// The allowlist answer must come from storage, never from an entry the RPC
+    /// fallback left behind, or a mint the indexer has no row for would read as
+    /// allowlisted for the rest of the process and open the gate silently.
+    #[tokio::test]
+    async fn metadata_from_db_ignores_an_rpc_resolved_entry() {
+        let mint = Pubkey::new_unique();
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(
+            RpcRequest::GetAccountInfo,
+            create_mock_account_response(&TOKEN_PROGRAM_ID, 9),
+        );
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut cache =
+            MintCache::with_rpc(storage, Arc::new(RpcClientWithRetry::new_mocked(mocks)));
+
+        cache
+            .get_mint_metadata(&mint)
+            .await
+            .expect("rpc fallback resolves the mint");
+
+        assert!(
+            cache
+                .get_mint_metadata_from_db(&mint)
+                .await
+                .unwrap()
+                .is_none(),
+            "an RPC-resolved mint must not satisfy the allowlist read"
+        );
+    }
+
+    /// An RPC that answers successfully but reports the account as absent.
+    fn rpc_reporting_absent_account() -> RpcClientWithRetry {
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(
+            RpcRequest::GetAccountInfo,
+            serde_json::json!({"context": {"slot": 1}, "value": null}),
+        );
+        RpcClientWithRetry::new_mocked(mocks)
+    }
+
+    /// An RPC endpoint that fails at the transport layer on every attempt.
+    async fn rpc_failing_transport(server: &mut mockito::ServerGuard) -> RpcClientWithRetry {
+        server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        RpcClientWithRetry::with_retry_config(
+            server.url(),
+            RetryConfig {
+                max_attempts: 2,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(2),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    #[tokio::test]
+    async fn mint_metadata_rpc_fallback_absent_account_is_target_mint_missing() {
+        let mint = create_test_mint();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut cache = MintCache::with_rpc(storage, Arc::new(rpc_reporting_absent_account()));
+
+        let err = cache.get_mint_metadata(&mint).await.unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                OperatorError::Account(AccountError::TargetMintMissing { pubkey }) if pubkey == mint
+            ),
+            "absent mint must be deterministic, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mint_metadata_rpc_fallback_transport_error_is_rpc_error() {
+        let mut server = mockito::Server::new_async().await;
+        let rpc = rpc_failing_transport(&mut server).await;
+        let mint = create_test_mint();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut cache = MintCache::with_rpc(storage, Arc::new(rpc));
+
+        let err = cache.get_mint_metadata(&mint).await.unwrap_err();
+
+        assert!(
+            matches!(err, OperatorError::RpcError(_)),
+            "a reachability failure must stay transient, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_paused_absent_account_is_target_mint_missing() {
+        let mint = create_test_mint();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let cache = MintCache::with_rpc(storage, Arc::new(rpc_reporting_absent_account()));
+
+        let err = cache.check_paused(&mint).await.unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                OperatorError::Account(AccountError::TargetMintMissing { pubkey }) if pubkey == mint
+            ),
+            "absent mint must be deterministic, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_from_db_returns_none_without_touching_rpc() {
+        let mint = create_test_mint();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut cache = MintCache::new(storage);
+
+        let found = cache
+            .get_mint_metadata_from_db(&mint)
+            .await
+            .expect("a missing row is an answer, not a failure");
+
+        assert!(found.is_none(), "no row means the mint is not allowlisted");
+    }
+
+    /// A miss is never remembered, so a mint allowlisted after the operator started
+    /// is picked up on the next read instead of needing a restart.
+    #[tokio::test]
+    async fn metadata_from_db_sees_a_row_added_after_a_miss() {
+        let mint = create_test_mint();
+        let mock = MockStorage::new();
+        let rows = mock.mints.clone();
+        let mut cache = MintCache::new(Arc::new(Storage::Mock(mock)));
+
+        assert!(
+            cache
+                .get_mint_metadata_from_db(&mint)
+                .await
+                .unwrap()
+                .is_none(),
+            "no row yet"
+        );
+
+        rows.lock().unwrap().insert(
+            mint.to_string(),
+            DbMint {
+                mint_address: mint.to_string(),
+                decimals: 6,
+                token_program: TOKEN_PROGRAM_ID.to_string(),
+                created_at: chrono::Utc::now(),
+                status: "allowed".to_string(),
+                is_pausable: Some(false),
+                has_permanent_delegate: Some(false),
+            },
+        );
+
+        assert!(
+            cache
+                .get_mint_metadata_from_db(&mint)
+                .await
+                .unwrap()
+                .is_some(),
+            "a later AllowMint must be visible without clearing the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_from_db_hit_warms_both_caches() {
+        let mint = create_test_mint();
+        let storage = create_test_storage_with_mint(&mint, &TOKEN_PROGRAM_ID, 6);
+        let mut cache = MintCache::new(storage);
+
+        let found = cache.get_mint_metadata_from_db(&mint).await.unwrap();
+        assert_eq!(found.expect("row is present").decimals, 6);
+        assert_eq!(cache.cache_size(), 1, "metadata cache must be warmed");
+
+        // No RPC client is configured, so these only succeed if the DB read warmed them.
+        cache.get_mint_metadata(&mint).await.unwrap();
+        assert_eq!(
+            cache.get_extension_flags(&mint).await.unwrap(),
+            (false, false)
+        );
+    }
+
+    #[tokio::test]
+    async fn check_paused_transport_error_is_rpc_error() {
+        let mut server = mockito::Server::new_async().await;
+        let rpc = rpc_failing_transport(&mut server).await;
+        let mint = create_test_mint();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let cache = MintCache::with_rpc(storage, Arc::new(rpc));
+
+        let err = cache.check_paused(&mint).await.unwrap_err();
+
+        assert!(
+            matches!(err, OperatorError::RpcError(_)),
+            "a reachability failure must stay transient, got: {err:?}"
+        );
     }
 }

--- a/indexer/src/operator/utils/mint_util.rs
+++ b/indexer/src/operator/utils/mint_util.rs
@@ -822,9 +822,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_ata_balance_treats_a_missing_account_as_zero() {
+        let mut server = mockito::Server::new_async().await;
+        // The JSON-RPC code Solana returns for a token account that does not exist.
+        server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"could not find account"},"id":1}"#,
+            )
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let rpc = RpcClientWithRetry::with_retry_config(
+            server.url(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(2),
+            },
+            CommitmentConfig::confirmed(),
+        );
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let cache = MintCache::with_rpc(storage, Arc::new(rpc));
+
+        let balance = cache
+            .get_ata_balance(&Pubkey::new_unique())
+            .await
+            .expect("a missing ATA is a zero balance, not a transient failure");
+        assert_eq!(balance, 0);
+    }
+
+    #[tokio::test]
     async fn check_paused_errors_without_rpc() {
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let mut cache = MintCache::new(storage);
+        let cache = MintCache::new(storage);
 
         let err = cache
             .check_paused(&create_test_mint())
@@ -1090,7 +1125,7 @@ mod tests {
         let rpc = rpc_failing_transport(&mut server).await;
         let mint = create_test_mint();
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let mut cache = MintCache::with_rpc(storage, Arc::new(rpc));
+        let cache = MintCache::with_rpc(storage, Arc::new(rpc));
 
         let err = cache.check_paused(&mint).await.unwrap_err();
 

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -227,6 +227,14 @@ fn drill_1_error_message_contracts_present_in_source() {
             "indexer/src/operator/processor.rs",
         ),
         (
+            "unsupported withdrawal mint:",
+            "indexer/src/operator/processor.rs",
+        ),
+        (
+            "withdrawal mint absent on target chain:",
+            "indexer/src/operator/processor.rs",
+        ),
+        (
             "withdrawal pipeline halted after poison-pill",
             "indexer/src/operator/processor.rs",
         ),

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -40,6 +40,10 @@ name = "reconciliation_e2e_test"
 path = "tests/indexer/reconciliation_e2e.rs"
 
 [[test]]
+name = "unsupported_withdrawal_mint_integration"
+path = "tests/indexer/unsupported_withdrawal_mint.rs"
+
+[[test]]
 name = "pausable_mint_integration"
 path = "tests/indexer/pausable_mint.rs"
 

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -198,28 +198,6 @@ async fn start_operator_with_config(
     })
 }
 
-async fn wait_for_transaction_status(
-    pool: &sqlx::PgPool,
-    signature: &str,
-    expected_status: &str,
-    timeout_secs: u64,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let start = std::time::Instant::now();
-    while start.elapsed().as_secs() < timeout_secs {
-        if let Some(tx) = db::get_transaction(pool, signature).await? {
-            if tx.status == expected_status {
-                return Ok(());
-            }
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-    Err(format!(
-        "Transaction {} did not reach status {} within {}s",
-        signature, expected_status, timeout_secs
-    )
-    .into())
-}
-
 /// Poll until the row reaches one of `expected_statuses`, returning the one it
 /// reached. A permanently-failed withdrawal is resolved by the deferred-remint
 /// gate, which can land on either a completed remint or an escalation, so the
@@ -600,14 +578,13 @@ async fn test_withdrawal_operator_prevents_double_withdrawal(
 }
 
 /// Triggers one preflight-failing mint (wrong-authority `mint_to`) and one bad
-/// withdrawal (mint not whitelisted on the instance).
+/// withdrawal (mint never allowlisted on the escrow).
 ///
-/// Neither is terminalized by the sender on the send error, because both journal
-/// their signature write-ahead: the mint is left Processing for recovery and fires
-/// no alert, and the withdrawal is handed to the deferred-remint gate, which
-/// resolves it once the journaled signature can no longer land. Only that final
-/// withdrawal disposition fires a webhook, so the configured `alert_webhook_url`
-/// receives exactly one POST via `db_transaction_writer::send_webhook_alert`.
+/// Neither terminalizes the operator: the mint journals its signature write-ahead
+/// and is left Processing for recovery with no alert, while the withdrawal is
+/// parked by the mint gate before a release is built. Only that parking fires a
+/// webhook, so the configured `alert_webhook_url` receives exactly one POST via
+/// `db_transaction_writer::send_webhook_alert`.
 ///
 /// Uses a `mockito` HTTP server as the webhook endpoint so no external service
 /// is required.
@@ -762,23 +739,13 @@ async fn test_failed_withdrawal_alerts_and_preflight_mint_defers_to_recovery(
     )
     .await?;
 
-    // The bad withdrawal preflights with `invalid account data for instruction`
-    // from the escrow program (the mint isn't whitelisted on the instance), so the
-    // send fails — but only after the write-ahead journal recorded its signature.
-    // The sender cannot tell a preflight rejection from an ambiguous transport
-    // error, so it hands the row to the deferred-remint gate instead of
-    // terminalizing it as never-broadcast.
-    wait_for_transaction_status(&pool, &withdrawal_sig, "pending_remint", 180).await?;
-
-    // Once the tip passes the journaled signature's blockhash validity the gate
-    // proves it dead and remints the burned tokens; if it exhausts its deferral
-    // budget first it escalates instead. Both are terminal and fire exactly one
-    // webhook, which is what this test asserts. The env-aware timeout keeps
-    // coverage-instrumented runs off the uninstrumented ceiling.
+    // The mint has no on-chain AllowedMint account, so the withdrawal gate parks it
+    // before a release is ever built. No signature is journaled and the deferred-remint
+    // gate never sees it; the row goes straight to ManualReview.
     let disposition = wait_for_any_transaction_status(
         &pool,
         &withdrawal_sig,
-        &["failed_reminted", "manual_review"],
+        &["manual_review"],
         *WAIT_TIMEOUT_SECS,
     )
     .await?;

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -519,19 +519,17 @@ fn set_operator_env_vars() {
     std::env::set_var("OPERATOR_PRIVATE_KEY", &private_key_base58);
 }
 
-/// Defensive coverage for the missing-ATA branch in the withdrawal pre-flight:
-/// when the escrow ATA does not exist on-chain, the operator must treat the
-/// query as on-chain balance = 0 and route the withdrawal to ManualReview.
-/// Mapping the not-found error to a transient RPC failure instead would
-/// restart the operator in a loop on a condition that won't heal.
+/// Coverage for the escrow-balance branch of the withdrawal pre-flight: an
+/// allowlisted permanent-delegate mint whose escrow ATA holds less than the
+/// withdrawal amount must route to ManualReview, not restart the operator.
 ///
-/// We skip `AllowMint` to set up the missing-ATA state — it's the simplest
-/// way to leave the canonical escrow ATA address unfunded. The pre-flight
-/// reads on-chain state at query time and doesn't care how we got there.
+/// `AllowMint` creates the escrow ATA alongside the AllowedMint account, so the
+/// ATA starts empty and every withdrawal reads a zero balance. Skipping AllowMint
+/// would instead park the row at the mint gate before this branch is reached.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_withdrawal_routed_to_manual_review_when_escrow_ata_does_not_exist(
+async fn test_withdrawal_routed_to_manual_review_when_escrow_ata_is_empty(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== Permanent Delegate: Withdrawal → ManualReview When Escrow ATA Missing ===");
+    println!("=== Permanent Delegate: Withdrawal to ManualReview When Escrow ATA Empty ===");
 
     set_operator_env_vars();
 
@@ -579,15 +577,26 @@ async fn test_withdrawal_routed_to_manual_review_when_escrow_ata_does_not_exist(
     )
     .await?;
 
-    // Skip AllowMint so the escrow ATA is never created on-chain.
+    // AllowMint creates the escrow ATA and the AllowedMint account the gate reads.
+    // Nothing funds the ATA afterwards, so the pre-flight sees a zero balance.
+    allow_mint_for_program(
+        &client,
+        &admin,
+        instance_pda,
+        mint_pubkey,
+        TOKEN_2022_PROGRAM_ID,
+    )
+    .await?;
+
     let escrow_ata = get_associated_token_address_with_program_id(
         &instance_pda,
         &mint_pubkey,
         &TOKEN_2022_PROGRAM_ID,
     );
-    assert!(
-        client.get_account(&escrow_ata).await.is_err(),
-        "pre-condition: escrow ATA must not exist on-chain",
+    let escrow_balance = client.get_token_account_balance(&escrow_ata).await?;
+    assert_eq!(
+        escrow_balance.amount, "0",
+        "pre-condition: escrow ATA must exist and be empty",
     );
 
     // Seed DB: mints row with has_permanent_delegate=None, pending withdrawal.
@@ -649,7 +658,7 @@ async fn test_withdrawal_routed_to_manual_review_when_escrow_ata_does_not_exist(
         .expect("withdrawal row should still exist");
     assert_eq!(
         row.status, "manual_review",
-        "missing escrow ATA should route the withdrawal to manual_review, not loop the operator",
+        "an empty escrow ATA should route the withdrawal to manual_review, not loop the operator",
     );
 
     let stored_mint = storage

--- a/integration/tests/indexer/unsupported_withdrawal_mint.rs
+++ b/integration/tests/indexer/unsupported_withdrawal_mint.rs
@@ -8,8 +8,9 @@
 //! operator down so a supervisor would restart it. The row was only parked after
 //! the restart budget ran out, so one unsupported mint cost several restarts.
 //!
-//! This test seeds a withdrawal for a mint that has no `mints` row and asserts the
-//! row is parked deterministically while the operator keeps running:
+//! This test seeds a withdrawal for a mint the escrow never allowlisted, so no
+//! `AllowedMint` account exists for it, and asserts the row is parked
+//! deterministically while the operator keeps running:
 //!   1. Spin up Postgres + Solana test validator
 //!   2. Set up the escrow instance + operator
 //!   3. Insert a withdrawal whose mint was never allowlisted
@@ -176,7 +177,7 @@ async fn unsupported_withdrawal_mint_is_parked_without_stopping_the_operator(
 
     // 2. Instance + operator, with the environment's own mint allowlisted so the
     // gate has something to accept. The withdrawal below names a different mint
-    // that is deliberately left out of `mints`, which is the condition under test.
+    // that is deliberately never allowlisted, which is the condition under test.
     let env = TestEnvironment::setup(&client, &faucet_keypair, 1, 1_000_000, None).await?;
     TestEnvironment::setup_operator(&client, &faucet_keypair, env.instance).await?;
     storage

--- a/integration/tests/indexer/unsupported_withdrawal_mint.rs
+++ b/integration/tests/indexer/unsupported_withdrawal_mint.rs
@@ -1,0 +1,279 @@
+//! Integration test for the withdrawal allowlist gate in the processor's
+//! withdrawal-dispatch path.
+//!
+//! A withdrawal can name any mint that exists on the private channel, but only a
+//! mint the escrow allowlisted has funds behind it on the target chain. Before the
+//! gate, such a row reached a target-chain metadata lookup, came back as a missing
+//! account, was classified as an infrastructure failure, and took the whole
+//! operator down so a supervisor would restart it. The row was only parked after
+//! the restart budget ran out, so one unsupported mint cost several restarts.
+//!
+//! This test seeds a withdrawal for a mint that has no `mints` row and asserts the
+//! row is parked deterministically while the operator keeps running:
+//!   1. Spin up Postgres + Solana test validator
+//!   2. Set up the escrow instance + operator
+//!   3. Insert a withdrawal whose mint was never allowlisted
+//!   4. Start the withdrawal operator
+//!   5. Assert the row reaches `manual_review` within 30 s
+//!   6. Assert the operator task never exited
+//!
+//! Step 6 is the regression: a critical task exit is what ends `operator::run`,
+//! so a finished handle is exactly the symptom the gate removes.
+
+#[path = "helpers/mod.rs"]
+mod helpers;
+
+#[path = "setup.rs"]
+mod setup;
+
+use {
+    chrono::Utc,
+    helpers::db,
+    private_channel_indexer::{
+        config::{OperatorConfig, PrivateChannelIndexerConfig, ProgramType, StorageType},
+        operator,
+        storage::common::amount::TokenAmount,
+        storage::common::models::{DbMint, DbMintStatus, DbTransaction, TransactionStatus},
+        storage::{PostgresDb, Storage, TransactionType},
+        PostgresConfig,
+    },
+    setup::{TestEnvironment, TEST_ADMIN_KEYPAIR},
+    solana_client::nonblocking::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig,
+        pubkey::Pubkey,
+        signature::{Keypair, Signature, Signer},
+    },
+    std::{sync::Arc, time::Duration},
+    test_utils::operator_helper::{same_host_fallback_url, OperatorHandle},
+    test_utils::validator_helper::start_test_validator_no_geyser,
+    testcontainers::runners::AsyncRunner,
+    testcontainers_modules::postgres::Postgres,
+    tokio::task::JoinHandle,
+    uuid::Uuid,
+};
+
+fn default_operator_config() -> OperatorConfig {
+    OperatorConfig {
+        db_poll_interval: Duration::from_millis(500),
+        batch_size: 10,
+        retry_max_attempts: 15,
+        retry_base_delay: Duration::from_millis(500),
+        channel_buffer_size: 100,
+        rpc_commitment: solana_sdk::commitment_config::CommitmentLevel::Confirmed,
+        alert_webhook_url: None,
+        reconciliation_interval: Duration::from_secs(5 * 60),
+        reconciliation_tolerance_bps: 10,
+        reconciliation_webhook_url: None,
+        feepayer_monitor_interval: Duration::from_secs(60),
+        confirmation_poll_interval_ms: 400,
+    }
+}
+
+fn set_operator_env_vars(keypair: &Keypair) {
+    let private_key_base58 = bs58::encode(keypair.to_bytes()).into_string();
+    std::env::set_var("ADMIN_SIGNER", "memory");
+    std::env::set_var("ADMIN_PRIVATE_KEY", &private_key_base58);
+    std::env::set_var("OPERATOR_SIGNER", "memory");
+    std::env::set_var("OPERATOR_PRIVATE_KEY", &private_key_base58);
+}
+
+async fn start_withdraw_operator(
+    rpc_url: String,
+    db_url: String,
+    operator_keypair: Keypair,
+    instance: Pubkey,
+) -> Result<OperatorHandle, Box<dyn std::error::Error>> {
+    let postgres_config = PostgresConfig {
+        database_url: db_url.clone(),
+        max_connections: 10,
+    };
+    let storage = Arc::new(Storage::Postgres(PostgresDb::new(&postgres_config).await?));
+    let common_config = PrivateChannelIndexerConfig {
+        program_type: ProgramType::Withdraw,
+        storage_type: StorageType::Postgres,
+        rpc_url: rpc_url.clone(),
+        // Withdraw operator requires a source chain for remints; single-validator
+        // test, so point it at the same RPC.
+        source_rpc_url: Some(rpc_url.clone()),
+        // The withdraw operator requires an independent, same-cluster fallback.
+        fallback_rpc_url: Some(same_host_fallback_url(&rpc_url)),
+        postgres: postgres_config,
+        escrow_instance_id: Some(instance),
+    };
+    let operator_config = default_operator_config();
+    set_operator_env_vars(&operator_keypair);
+    let task_handle: JoinHandle<()> = tokio::spawn(async move {
+        if let Err(e) = operator::run(storage, common_config, operator_config, None).await {
+            tracing::error!("Operator error: {}", e);
+        }
+    });
+    Ok(OperatorHandle {
+        _handle: task_handle,
+    })
+}
+
+/// Poll the DB for up to `timeout_secs` waiting for a row to reach
+/// `expected_status`. Returns Ok(()) on success; err otherwise.
+async fn wait_for_status(
+    pool: &sqlx::PgPool,
+    signature: &str,
+    expected_status: &str,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    let mut last_seen = String::new();
+    while start.elapsed().as_secs() < timeout_secs {
+        match db::get_transaction(pool, signature).await {
+            Ok(Some(tx)) => {
+                last_seen = tx.status.clone();
+                if tx.status == expected_status {
+                    return Ok(());
+                }
+            }
+            Ok(None) => {}
+            Err(e) => return Err(format!("DB read failed: {e}")),
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+    Err(format!(
+        "Timed out waiting for {signature} to reach {expected_status}; last seen: {last_seen}"
+    ))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unsupported_withdrawal_mint_is_parked_without_stopping_the_operator(
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Withdrawal allowlist gate -> ManualReview ===");
+
+    // 1. Postgres + test validator.
+    let (test_validator, faucet_keypair) = start_test_validator_no_geyser().await;
+    let client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::confirmed());
+
+    let pg_container = Postgres::default()
+        .with_db_name("unsupported_mint_gate")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+    let pg_host = pg_container.get_host().await?;
+    let pg_port = pg_container.get_host_port_ipv4(5432).await?;
+    let db_url = format!(
+        "postgres://postgres:password@{}:{}/unsupported_mint_gate",
+        pg_host, pg_port
+    );
+
+    let pool = db::connect(&db_url).await?;
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url.clone(),
+            max_connections: 10,
+        })
+        .await?,
+    );
+    storage.init_schema().await?;
+
+    // 2. Instance + operator, with the environment's own mint allowlisted so the
+    // gate has something to accept. The withdrawal below names a different mint
+    // that is deliberately left out of `mints`, which is the condition under test.
+    let env = TestEnvironment::setup(&client, &faucet_keypair, 1, 1_000_000, None).await?;
+    TestEnvironment::setup_operator(&client, &faucet_keypair, env.instance).await?;
+    storage
+        .upsert_mints_batch(&[DbMint::new(
+            env.mint.to_string(),
+            6,
+            spl_token::id().to_string(),
+        )])
+        .await?;
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: env.mint.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{}", env.mint),
+            created_at: Utc::now(),
+        }])
+        .await?;
+
+    // 3. A withdrawal naming a mint the escrow never allowlisted. The DB trigger
+    // assigns its nonce on insert, so it holds a real place in the queue.
+    let unsupported_mint = Pubkey::new_unique();
+    let signature = Signature::new_unique().to_string();
+    let recipient = env.users[0].pubkey();
+    let now = Utc::now();
+    let withdrawal = DbTransaction {
+        id: 0,
+        signature: signature.clone(),
+        trace_id: Uuid::new_v4().to_string(),
+        slot: 1,
+        initiator: recipient.to_string(),
+        recipient: recipient.to_string(),
+        mint: unsupported_mint.to_string(),
+        amount: TokenAmount(10_000),
+        memo: None,
+        transaction_type: TransactionType::Withdrawal,
+        withdrawal_nonce: Some(0), // trigger overwrites with NEXTVAL
+        status: TransactionStatus::Pending,
+        created_at: now,
+        updated_at: now,
+        processed_at: None,
+        counterpart_signature: None,
+        remint_signatures: None,
+        remint_last_valid_block_heights: None,
+        pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
+        instruction_index: 0,
+        inner_index: None,
+        landed_remint_signature: None,
+    };
+    storage.insert_db_transaction(&withdrawal).await?;
+
+    // Defensive: the row must be unsupported for the right reason, and the
+    // allowlist must not be empty, or the test would pass for the wrong one.
+    let seeded: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mints WHERE mint_address = $1")
+        .bind(unsupported_mint.to_string())
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(
+        seeded.0, 0,
+        "the withdrawal's mint must have no allowlist row"
+    );
+    let allowed: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM mints WHERE mint_address = $1")
+        .bind(env.mint.to_string())
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(allowed.0, 1, "a different mint must be allowlisted");
+
+    // 4. Start the operator.
+    let operator_keypair = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
+    let operator_handle = start_withdraw_operator(
+        test_validator.rpc_url(),
+        db_url.clone(),
+        operator_keypair,
+        env.instance,
+    )
+    .await?;
+
+    // 5. The row is parked rather than retried forever.
+    wait_for_status(&pool, &signature, "manual_review", 30)
+        .await
+        .expect("unsupported-mint row must be quarantined to manual_review");
+
+    // 6. The operator is still running. Before the gate, the same row ended the
+    // processor task, which ends `operator::run` and finishes this handle.
+    assert!(
+        !operator_handle._handle.is_finished(),
+        "the operator must survive an unsupported withdrawal mint"
+    );
+
+    // The reason recorded on the row is the one the runbook dispatches on.
+    let row = db::get_transaction(&pool, &signature)
+        .await?
+        .expect("row must still exist");
+    assert_eq!(row.status, "manual_review");
+
+    operator_handle.shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
## Description

`build_release_funds` read a withdrawal's mint metadata from the target chain before checking whether the mint was supported. When the mint was missing from the local cache, `MintCache` fell back to RPC, but `fetch_mint_from_rpc` treated an absent account and an unreachable node as the same `AccountNotFound` error. The processor classified that error as transient, exited, and caused the supervisor to restart the entire operator. An unsupported mint could therefore trigger several restarts before the row exhausted its requeue budget and was parked. The same ambiguity existed in `check_paused` for Token-2022 mints with unresolved extension flags.

The operator now checks for a `mints` row before making any cross-chain read. Only an indexed allow instruction creates that row and nothing removes it, so its presence answers whether the mint was ever allowlisted without comparing slots across chains or stranding a mint that became blocked after funds were escrowed. Both RPC paths now use `get_account_with_context`, separating an absent account from a read failure: an absent account parks the row, while an unreachable node remains transient. Both cases follow the existing per-row error path and cannot trigger the classifier branch that sweeps every active withdrawal. 

The PR adds 15 unit tests, one integration test, and two runbook triage entries with their corresponding drill contracts.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 17,751 | 19,421 | 91.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33496394978) |
| Indexer | 38,271 | 41,961 | 91.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33496394978) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33496394978) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33496394978) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 15,089 | 19,643 | 76.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33496394978) |
| **Total** | **74,057** | **84,423** | **87.7%** | |

> Last updated: 2026-09-01 10:54:40 UTC by E2E Integration