### PR TITLE
fix(core): add cache_mirror_cooldown to two SettleArgs test constructors

### DIFF
--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -1384,6 +1384,7 @@ mod tests {
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown,
             metrics,
+            cache_mirror_cooldown: CACHE_MIRROR_COOLDOWN,
             heartbeat: crate::health::StageHeartbeat::new(),
         })
         .await;
@@ -1640,6 +1641,7 @@ mod tests {
             perf_sample_period_secs: 3600,
             shutdown_token: shutdown.clone(),
             metrics: Arc::new(NoopMetrics),
+            cache_mirror_cooldown: CACHE_MIRROR_COOLDOWN,
             heartbeat: Arc::clone(&heartbeat),
         })
         .await;


### PR DESCRIPTION
The merge into main (PR 268) was textually clean but semantically broken: SettleArgs gained cache_mirror_cooldown while the merged branch added two new test constructors, so neither side conflicted and both tests lost the field. Both are redis_cache_url: None tests, so the value never fires; using the CACHE_MIRROR_COOLDOWN default matches the other 15 construction sites.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 17,603 | 19,279 | 91.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33379009342) |
| Indexer | 37,606 | 41,281 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33379009342) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33379009342) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33379009342) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 15,093 | 19,494 | 77.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33379009342) |
| **Total** | **73,248** | **83,452** | **87.8%** | |

> Last updated: 2026-08-31 10:31:02 UTC by E2E Integration