### PR TITLE
fix(core): enforce canonical SPL preconditions on AdminVm InitializeMint targets (issue-140)

### DIFF
--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -71,6 +71,47 @@ impl AdminVm {
         account
     }
 
+    /// Preconditions canonical SPL Token execution would enforce before an
+    /// `InitializeMint` could write the mint: the SVM's account rules
+    /// (writable, non-executable, token-owned) and the processor's own
+    /// (exactly `Mint::LEN` bytes, not already initialized). Synthesizing the
+    /// post-state skips both, so without these the VM would replace any
+    /// account an admin transaction happens to reference.
+    ///
+    /// A missing target stays legal: the private channel allocates and
+    /// initializes in one step so mint addresses mirror mainnet.
+    ///
+    /// Rent exemption is deliberately not checked. Execution is gasless
+    /// (`GaslessRentCollector` reports zero rent) and `create_mint_account`
+    /// holds 1 lamport by design.
+    fn check_initialize_mint_target(
+        existing: Option<&AccountSharedData>,
+        is_writable: bool,
+    ) -> Result<(), InstructionError> {
+        if !is_writable {
+            return Err(InstructionError::ReadonlyDataModified);
+        }
+
+        let Some(existing) = existing else {
+            return Ok(());
+        };
+
+        if existing.executable() {
+            return Err(InstructionError::ExecutableDataModified);
+        }
+        if *existing.owner() != SPL_TOKEN_ID {
+            return Err(InstructionError::ExternalAccountDataModified);
+        }
+        // `unpack_unchecked` rejects any length but `Mint::LEN`, and unlike
+        // `unpack` it still decodes an uninitialized allocation.
+        let mint = Mint::unpack_unchecked(existing.data())
+            .map_err(|_| InstructionError::InvalidAccountData)?;
+        if mint.is_initialized {
+            return Err(InstructionError::AccountAlreadyInitialized);
+        }
+        Ok(())
+    }
+
     /// Creates an ExecutedTransaction result carrying the given status.
     /// On failure (`status.is_err()`), callers pass `vec![]` so nothing persists —
     /// this matches real-SVM atomicity.
@@ -106,6 +147,10 @@ impl AdminVm {
     /// - InitializeMint empty accounts          -> InvalidAccountData
     /// - freeze authority tag=1, <32 trailing   -> InvalidAccountData
     /// - mint index out of `account_keys`       -> NotEnoughAccountKeys
+    /// - mint read-only in the message          -> ReadonlyDataModified
+    /// - existing target executable             -> ExecutableDataModified
+    /// - existing target not SPL-Token-owned    -> ExternalAccountDataModified
+    /// - existing target not `Mint::LEN` bytes  -> InvalidAccountData
     /// - mint already initialized               -> AccountAlreadyInitialized
     pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
         &self,
@@ -242,21 +287,15 @@ impl AdminVm {
             return Err(InstructionError::NotEnoughAccountKeys);
         };
 
-        // Refuse re-init on a live mint: if an account already exists at
-        // `mint_pubkey` and unpacks as an initialized Mint, a second
-        // InitializeMint would silently overwrite supply / decimals / authority.
-        // Zero-initialized allocations (is_initialized = false) still proceed.
-        if let Some(existing) = callbacks.get_account_shared_data(&mint_pubkey) {
-            if Mint::unpack(existing.data())
-                .map(|m| m.is_initialized)
-                .unwrap_or(false)
-            {
-                debug!(
-                    "[admin-vm] InitializeMint: {} already initialized",
-                    mint_pubkey
-                );
-                return Err(InstructionError::AccountAlreadyInitialized);
-            }
+        let existing = callbacks.get_account_shared_data(&mint_pubkey);
+        if let Err(err) =
+            Self::check_initialize_mint_target(existing.as_ref(), tx.is_writable(mint_index))
+        {
+            debug!(
+                "[admin-vm] InitializeMint: target {} rejected: {:?}",
+                mint_pubkey, err
+            );
+            return Err(err);
         }
 
         let decimals = instruction.data[1];
@@ -269,9 +308,14 @@ impl AdminVm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::account::ReadableAccount;
+    use solana_sdk::account::{Account, ReadableAccount, WritableAccount};
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+    use solana_sdk::message::Message;
+    use solana_sdk::signature::{Keypair, Signer};
+    use solana_sdk::transaction::{SanitizedTransaction, Transaction};
     use spl_token::solana_program::program_pack::Pack;
     use spl_token::state::Mint;
+    use std::collections::HashSet;
 
     /// `create_mint_account` packs a Mint with the given decimals + authority
     /// and no freeze authority; the packed bytes round-trip through
@@ -353,10 +397,7 @@ mod tests {
     impl solana_svm_callback::TransactionProcessingCallback for StubCbWithUninitialized {
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             if *pubkey == self.mint {
-                // Zeroed data of Mint::LEN → is_initialized = false
-                let mut acct = AccountSharedData::new(0, Mint::LEN, &spl_token::id());
-                acct.set_data_from_slice(&[0u8; Mint::LEN]);
-                Some(acct)
+                Some(mint_allocation())
             } else {
                 None
             }
@@ -423,14 +464,6 @@ mod tests {
         program_id: Pubkey,
         data: Vec<u8>,
     ) -> (solana_sdk::transaction::SanitizedTransaction, Pubkey) {
-        use solana_sdk::{
-            instruction::{AccountMeta, Instruction},
-            message::Message,
-            signature::{Keypair, Signer},
-            transaction::Transaction,
-        };
-        use std::collections::HashSet;
-
         let payer = Keypair::new();
         let mint = Pubkey::new_unique();
         // Mint first — SPL Token InitializeMint semantics: accounts[0] is the mint.
@@ -476,14 +509,6 @@ mod tests {
         ix1_data: Vec<u8>,
         ix2_data: Vec<u8>,
     ) -> solana_sdk::transaction::SanitizedTransaction {
-        use solana_sdk::{
-            instruction::{AccountMeta, Instruction},
-            message::Message,
-            signature::{Keypair, Signer},
-            transaction::Transaction,
-        };
-        use std::collections::HashSet;
-
         let payer = Keypair::new();
         let mint_a = Pubkey::new_unique();
         let mint_b = Pubkey::new_unique();
@@ -529,6 +554,37 @@ mod tests {
         let mint = Mint::unpack(account.data()).unwrap();
         assert_eq!(mint.decimals, 9);
         assert_eq!(mint.mint_authority, COption::Some(authority));
+    }
+
+    /// The operator's JIT mint path, built exactly as
+    /// `InitializeMintBuilder::instruction` does: no account at the target yet,
+    /// admin as fee payer. Pins that flow against the target preconditions.
+    #[test]
+    fn test_operator_built_initialize_mint_for_missing_target_succeeds() {
+        let admin = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let decimals = 6;
+        let ix = spl_token::instruction::initialize_mint(
+            &spl_token::id(),
+            &mint,
+            &admin.pubkey(),
+            Some(&admin.pubkey()),
+            decimals,
+        )
+        .unwrap();
+        let msg = Message::new(&[ix], Some(&admin.pubkey()));
+        let tx = Transaction::new(&[&admin], msg, solana_sdk::hash::Hash::default());
+        let sanitized =
+            SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new()).unwrap();
+
+        let executed = assert_executed_with_status(run_admin_vm(&[sanitized]), Ok(()));
+
+        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
+        let (pubkey, account) = &executed.loaded_transaction.accounts[0];
+        assert_eq!(*pubkey, mint, "the mint meta must resolve to the mint key");
+        let mint_state = Mint::unpack(account.data()).unwrap();
+        assert_eq!(mint_state.decimals, decimals);
+        assert_eq!(mint_state.mint_authority, COption::Some(admin.pubkey()));
     }
 
     // ─── Failure paths ──────────────────────────────────────────────────────
@@ -615,6 +671,33 @@ mod tests {
             Err(TransactionError::InstructionError(
                 0,
                 InstructionError::AccountAlreadyInitialized,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    /// A read-only mint meta is rejected even with no account at the target.
+    /// BOB gates on the account's position in the returned vec, not the mint's
+    /// message index, so this has to be the VM's own check.
+    #[test]
+    fn test_readonly_mint_meta_returns_readonly_data_modified() {
+        let payer = Keypair::new();
+        let target = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![AccountMeta::new_readonly(target, false)],
+            data: valid_init_mint_data(6, Pubkey::new_unique()),
+        };
+        let msg = Message::new(&[ix], Some(&payer.pubkey()));
+        let tx = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
+        let sanitized =
+            SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new()).unwrap();
+
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[sanitized]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::ReadonlyDataModified,
             )),
         );
         assert!(executed.loaded_transaction.accounts.is_empty());
@@ -713,14 +796,6 @@ mod tests {
         data[2..34].copy_from_slice(&Pubkey::new_unique().to_bytes());
         data[34] = 0; // COption::None for freeze authority
 
-        use solana_sdk::{
-            instruction::{AccountMeta, Instruction},
-            message::Message,
-            signature::{Keypair, Signer},
-            transaction::Transaction,
-        };
-        use std::collections::HashSet;
-
         let payer = Keypair::new();
         let ix = Instruction {
             program_id: spl_token::id(),
@@ -739,5 +814,81 @@ mod tests {
         // targeting the payer pubkey as the mint → VM succeeds.
         let output = run_admin_vm(&[sanitized]);
         assert_eq!(output.processing_results.len(), 1);
+    }
+
+    // ─── Target preconditions ───────────────────────────────────────────────
+
+    /// Token-owned, Mint::LEN, zeroed: the only pre-existing state
+    /// InitializeMint may write over.
+    fn mint_allocation() -> AccountSharedData {
+        AccountSharedData::from(Account {
+            lamports: 1,
+            data: vec![0u8; Mint::LEN],
+            owner: spl_token::id(),
+            executable: false,
+            rent_epoch: 0,
+        })
+    }
+
+    /// No account at the target is legal: the private channel allocates and
+    /// initializes in one step, which the operator's JIT path relies on.
+    #[test]
+    fn test_check_target_missing_is_allowed() {
+        assert_eq!(AdminVm::check_initialize_mint_target(None, true), Ok(()));
+    }
+
+    #[test]
+    fn test_check_target_uninitialized_allocation_is_allowed() {
+        assert_eq!(
+            AdminVm::check_initialize_mint_target(Some(&mint_allocation()), true),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn test_check_target_not_writable_rejected() {
+        assert_eq!(
+            AdminVm::check_initialize_mint_target(Some(&mint_allocation()), false),
+            Err(InstructionError::ReadonlyDataModified)
+        );
+    }
+
+    #[test]
+    fn test_check_target_executable_rejected() {
+        let mut account = mint_allocation();
+        account.set_executable(true);
+        assert_eq!(
+            AdminVm::check_initialize_mint_target(Some(&account), true),
+            Err(InstructionError::ExecutableDataModified)
+        );
+    }
+
+    #[test]
+    fn test_check_target_foreign_owner_rejected() {
+        let mut account = mint_allocation();
+        account.set_owner(solana_sdk::system_program::id());
+        assert_eq!(
+            AdminVm::check_initialize_mint_target(Some(&account), true),
+            Err(InstructionError::ExternalAccountDataModified)
+        );
+    }
+
+    /// A token-owned account of the wrong size, e.g. an SPL token account.
+    #[test]
+    fn test_check_target_wrong_size_rejected() {
+        let account = AccountSharedData::new(1, spl_token::state::Account::LEN, &spl_token::id());
+        assert_eq!(
+            AdminVm::check_initialize_mint_target(Some(&account), true),
+            Err(InstructionError::InvalidAccountData)
+        );
+    }
+
+    #[test]
+    fn test_check_target_live_mint_rejected() {
+        let account = AdminVm::create_mint_account(6, &Pubkey::new_unique().to_bytes(), None);
+        assert_eq!(
+            AdminVm::check_initialize_mint_target(Some(&account), true),
+            Err(InstructionError::AccountAlreadyInitialized)
+        );
     }
 }


### PR DESCRIPTION
fix(core): enforce canonical SPL preconditions on AdminVm InitializeMint targets

AdminVm synthesizes the post-state of InitializeMint rather than running the SPL Token processor, so none of the SVM's account rules apply to the write.

Before: the only guard was "do the existing bytes unpack as an initialized mint". That failed closed on exactly one state and fell through on every other one — system-owned accounts, token accounts (wrong length), accounts owned by another program, executable program accounts, and read-only mint metas. Each of those was replaced by a freshly synthesized mint, and BOB and the settler persisted the result. A misbuilt admin transaction could overwrite unrelated channel state.

After: check_initialize_mint_target reproduces what canonical execution would enforce, in order — writable at its message index, and when an account already exists: non-executable, owned by SPL Token, exactly Mint::LEN bytes, and not yet initialized. The writability check has to live here because bob.rs:292 and settle.rs:775 gate on the account's position in the returned vec, not on the mint's message index, so a read-only mint meta was previously persisted anyway.

The operator flow is unchanged: InitializeMintBuilder builds through spl_token::instruction::initialize_mint (mint meta always writable), and the only pre-existing state it legitimately meets is what the JIT pre-check already classifies as Uninitialized, which is the arm the fix still permits. Pinned by test_operator_built_initialize_mint_for_missing_target_succeeds.

Not closed / accepted risk

  - A target with no account yet is still allowed, because that is the feature: the private channel allocates and initializes in one step so mint addresses mirror mainnet. A misbuilt admin transaction can therefore still create a mint at an unoccupied address and deny it to its intended use.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 17,712 | 19,382 | 91.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33390692920) |
| Indexer | 37,606 | 41,281 | 91.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33390692920) |
| Gateway | 1,634 | 1,892 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33390692920) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33390692920) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 15,102 | 19,514 | 77.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33390692920) |
| **Total** | **73,366** | **83,575** | **87.8%** | |

> Last updated: 2026-08-31 13:19:05 UTC by E2E Integration