### PR TITLE
fix(core): budget and offload getAccountInfo account encoding (issue-161)

### DIFF
--- a/core/src/rpc/constants.rs
+++ b/core/src/rpc/constants.rs
@@ -14,5 +14,19 @@ pub const MAX_RESPONSE_SIZE: usize = 10 * 1024 * 1024;
 /// Half the response ceiling, leaving room for logs and inner instructions beside it.
 pub const MAX_SIMULATION_ACCOUNTS_BYTES: usize = MAX_RESPONSE_SIZE / 2;
 
+/// Encoded-byte budget for the account in a `getAccountInfo` reply.
+/// Sized off what the endpoint actually serves: the largest account is the
+/// 134 KB SPL Token precompile, encoding to ~175 KB. The reply holds nothing
+/// else, so there is no logs allowance to leave room for.
+pub const MAX_ACCOUNT_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Allowance per account for its metadata fields and the JSON punctuation.
+pub const PER_ACCOUNT_JSON_OVERHEAD: usize = 256;
+
+/// Estimated JSON bytes one encoded account contributes.
+pub fn estimated_encoded_bytes(data_len: usize) -> usize {
+    data_len.div_ceil(3) * 4 + PER_ACCOUNT_JSON_OVERHEAD
+}
+
 /// Maximum serialized transaction size (matches Solana's PACKET_DATA_SIZE).
 pub const PACKET_DATA_SIZE: usize = 1232;

--- a/core/src/rpc/get_account_info_impl.rs
+++ b/core/src/rpc/get_account_info_impl.rs
@@ -1,19 +1,20 @@
 use crate::{
     accounts::precompiles,
     rpc::{
-        error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+        constants::{estimated_encoded_bytes, MAX_ACCOUNT_RESPONSE_BYTES},
+        error::{custom_error, INVALID_PARAMS_CODE, INVALID_REQUEST_CODE, JSON_RPC_SERVER_ERROR},
         ReadDeps,
     },
 };
 use jsonrpsee::core::RpcResult;
-use solana_account_decoder::encode_ui_account;
+use solana_account_decoder::{encode_ui_account, MAX_BASE58_BYTES};
 use solana_account_decoder_client_types::{UiAccount, UiAccountEncoding};
 use solana_client::{
     rpc_config::RpcAccountInfoConfig,
     rpc_response::{Response, RpcResponseContext},
 };
-use solana_sdk::pubkey::Pubkey;
-use std::str::FromStr;
+use solana_sdk::{account::ReadableAccount, pubkey::Pubkey};
+use std::{cmp::min, str::FromStr};
 use tracing::debug;
 
 pub async fn get_account_info_impl(
@@ -45,8 +46,63 @@ pub async fn get_account_info_impl(
     };
 
     let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base64);
-    let value = account_data
-        .map(|account| encode_ui_account(&pubkey, &account, encoding, None, config.data_slice));
+    let data_slice = config.data_slice;
+    let value = match account_data {
+        Some(account) => {
+            // Budgeted before anything encodes, so a refused request compresses
+            // nothing. A dataSlice narrows what gets encoded, so it narrows the
+            // estimate too.
+            let selected = data_slice
+                .map(|slice| {
+                    min(
+                        slice.length,
+                        account.data().len().saturating_sub(slice.offset),
+                    )
+                })
+                .unwrap_or(account.data().len());
+            let estimated = estimated_encoded_bytes(selected);
+            if estimated > MAX_ACCOUNT_RESPONSE_BYTES {
+                return Err(custom_error(
+                    INVALID_PARAMS_CODE,
+                    format!(
+                        "Account encodes to about {estimated} bytes (max: {MAX_ACCOUNT_RESPONSE_BYTES}); request a dataSlice"
+                    ),
+                ));
+            }
+
+            // The bs58 encoder swaps oversized data for an error string inside
+            // an otherwise successful payload. Refuse the request like Agave.
+            if matches!(
+                encoding,
+                UiAccountEncoding::Binary | UiAccountEncoding::Base58
+            ) && selected > MAX_BASE58_BYTES
+            {
+                return Err(custom_error(
+                    INVALID_REQUEST_CODE,
+                    format!(
+                        "Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please use Base64 encoding."
+                    ),
+                ));
+            }
+
+            // Encoding is CPU-bound and the caller picks how expensive: zstd on
+            // a precompile ELF costs ~400us against 55us for plain base64. Off
+            // the async worker so a read cannot stall the ones beside it.
+            Some(
+                tokio::task::spawn_blocking(move || {
+                    encode_ui_account(&pubkey, &account, encoding, None, data_slice)
+                })
+                .await
+                .map_err(|e| {
+                    custom_error(
+                        JSON_RPC_SERVER_ERROR,
+                        format!("Account encoding failed: {e}"),
+                    )
+                })?,
+            )
+        }
+        None => None,
+    };
 
     debug!("get_account_info pubkey={} hit={}", pubkey, value.is_some());
 

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -39,6 +39,9 @@ mod tests {
     use super::*;
     use crate::accounts::{traits::BlockInfo, AccountsDB};
     use crate::test_helpers::{create_test_sanitized_transaction, flush_address_signatures_sync};
+    use solana_account_decoder::MAX_BASE58_BYTES;
+    use solana_account_decoder_client_types::{UiAccountEncoding, UiDataSliceConfig};
+    use solana_client::rpc_config::RpcAccountInfoConfig;
     use solana_rpc_client_types::response::RpcPerfSample;
     use solana_sdk::{
         account::AccountSharedData,
@@ -1226,6 +1229,152 @@ mod tests {
             .await
             .unwrap();
         assert!(resp.value.is_none());
+    }
+
+    // Derived, not hardcoded, so retuning either constant cannot move the boundary silently.
+    const EXACT_ACCOUNT_BUDGET_DATA_LEN: usize =
+        ((constants::MAX_ACCOUNT_RESPONSE_BYTES - constants::PER_ACCOUNT_JSON_OVERHEAD) / 4) * 3;
+
+    /// The budget bounds what one reply encodes to, refusing the account before
+    /// anything compresses it. A precompile ELF is the largest account this
+    /// endpoint serves today, so it has to stay on the served side.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_account_info_response_budget() {
+        let (mut db, _pg) = start_pg().await;
+        seed_db(&mut db).await;
+
+        let at_budget = Pubkey::new_unique();
+        let over_budget = Pubkey::new_unique();
+        let owner = solana_sdk::bpf_loader::id();
+        db.set_account(
+            at_budget,
+            AccountSharedData::new(1, EXACT_ACCOUNT_BUDGET_DATA_LEN, &owner),
+        )
+        .await;
+        db.set_account(
+            over_budget,
+            AccountSharedData::new(1, EXACT_ACCOUNT_BUDGET_DATA_LEN + 3, &owner),
+        )
+        .await;
+        let deps = make_read_deps(db);
+
+        let served =
+            get_account_info_impl::get_account_info_impl(&deps, at_budget.to_string(), None)
+                .await
+                .unwrap();
+        assert!(
+            served.value.is_some(),
+            "a request landing exactly on the budget must be served"
+        );
+
+        let err =
+            get_account_info_impl::get_account_info_impl(&deps, over_budget.to_string(), None)
+                .await
+                .expect_err("an over-budget account must be refused");
+        assert_eq!(err.code(), crate::rpc::error::INVALID_PARAMS_CODE);
+
+        let zstd = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64Zstd),
+            ..Default::default()
+        };
+        let precompile = get_account_info_impl::get_account_info_impl(
+            &deps,
+            spl_token::ID.to_string(),
+            Some(zstd),
+        )
+        .await
+        .unwrap();
+        assert!(
+            precompile.value.is_some(),
+            "the budget must not refuse a precompile read"
+        );
+
+        // A dataSlice narrows what gets encoded, so the same over-budget account
+        // is served when the caller asks for a range that fits.
+        let fitting_slice = RpcAccountInfoConfig {
+            data_slice: Some(UiDataSliceConfig {
+                offset: 0,
+                length: MAX_BASE58_BYTES,
+            }),
+            ..Default::default()
+        };
+        let sliced = get_account_info_impl::get_account_info_impl(
+            &deps,
+            over_budget.to_string(),
+            Some(fitting_slice),
+        )
+        .await
+        .unwrap();
+        assert!(
+            sliced.value.is_some(),
+            "a slice that fits must be served from an over-budget account"
+        );
+
+        // An offset past the end selects nothing, so it cannot be over budget.
+        let past_end = RpcAccountInfoConfig {
+            data_slice: Some(UiDataSliceConfig {
+                offset: EXACT_ACCOUNT_BUDGET_DATA_LEN + 99,
+                length: usize::MAX,
+            }),
+            ..Default::default()
+        };
+        let empty = get_account_info_impl::get_account_info_impl(
+            &deps,
+            over_budget.to_string(),
+            Some(past_end),
+        )
+        .await
+        .unwrap();
+        assert!(
+            empty.value.is_some(),
+            "an offset past the end must clamp to nothing, not overflow the estimate"
+        );
+    }
+
+    /// Upstream's bs58 encoder swaps oversized data for an error string inside a
+    /// success payload. Agave refuses the request instead, and so must this.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_account_info_base58_over_cap_is_refused() {
+        let (mut db, _pg) = start_pg().await;
+        seed_db(&mut db).await;
+        let deps = make_read_deps(db);
+        let precompile = spl_token::ID.to_string();
+
+        for encoding in [UiAccountEncoding::Base58, UiAccountEncoding::Binary] {
+            let config = RpcAccountInfoConfig {
+                encoding: Some(encoding),
+                ..Default::default()
+            };
+            let err = get_account_info_impl::get_account_info_impl(
+                &deps,
+                precompile.clone(),
+                Some(config),
+            )
+            .await
+            .expect_err("a precompile ELF is far past the bs58 cap");
+            assert_eq!(
+                err.code(),
+                crate::rpc::error::INVALID_REQUEST_CODE,
+                "encoding {encoding:?}"
+            );
+        }
+
+        // The same account under a slice inside the cap stays served.
+        let capped = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base58),
+            data_slice: Some(UiDataSliceConfig {
+                offset: 0,
+                length: MAX_BASE58_BYTES,
+            }),
+            ..Default::default()
+        };
+        let served = get_account_info_impl::get_account_info_impl(&deps, precompile, Some(capped))
+            .await
+            .unwrap();
+        assert!(
+            served.value.is_some(),
+            "a slice inside the cap must be served"
+        );
     }
 
     /// An unreadable store is a server fault. Reporting it as INVALID_PARAMS

--- a/core/src/rpc/simulate_transaction_impl.rs
+++ b/core/src/rpc/simulate_transaction_impl.rs
@@ -1,7 +1,7 @@
 use crate::{
     accounts::utils::encode_transaction_data,
     rpc::{
-        constants::MAX_SIMULATION_ACCOUNTS_BYTES,
+        constants::{estimated_encoded_bytes, MAX_SIMULATION_ACCOUNTS_BYTES},
         error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
         ReadDeps,
     },
@@ -63,14 +63,6 @@ fn validate_accounts_config(
     }
 
     Ok(())
-}
-
-/// Allowance per account for its metadata fields and the JSON punctuation.
-const PER_ACCOUNT_JSON_OVERHEAD: usize = 256;
-
-/// Estimated JSON bytes one encoded account contributes.
-fn estimated_encoded_bytes(data_len: usize) -> usize {
-    data_len.div_ceil(3) * 4 + PER_ACCOUNT_JSON_OVERHEAD
 }
 
 /// Resolves every requested address, then encodes only if the whole reply fits.
@@ -375,6 +367,7 @@ pub async fn simulate_transaction(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rpc::constants::PER_ACCOUNT_JSON_OVERHEAD;
     use solana_account_decoder_client_types::UiAccountData;
     use solana_sdk::account::AccountSharedData;
     use solana_svm_callback::InvokeContextCallback;


### PR DESCRIPTION
## Finding 161: getAccountInfo compresses account data inline

`getAccountInfo` passed the caller's chosen encoding straight into `encode_ui_account` with no cost check. With `base64+zstd` and no `dataSlice`, the node compressed the whole account synchronously inside the async RPC task, so enough concurrent requests could slow down other reads.

### Fix

1. **Size guard before encoding.** New `MAX_ACCOUNT_RESPONSE_BYTES` (1 MiB encoded). The estimate uses the `dataSlice`-selected range, so a slice narrows it. Over budget returns an error and nothing gets encoded.
  2. **Encoding moved off the async workers** via `spawn_blocking`, matching Agave.
  3. **Base58 over 128 bytes now errors** like Agave. Before, the decoder quietly put the string `error: data too large for bs58 encoding` into the `data` field of a successful response.

Measured cost, which is what the 1 MiB budget is sized against: `base64+zstd` on the 134 KB SPL Token precompile takes 412us versus 55us for plain base64. On a 165 byte token account it is 10us versus 0.1us, so most of the cost is fixed per-call setup rather than data size.

### Two corrections to the finding

  - **10 MiB accounts are not reachable here.** `core/src/transactions.rs:41` restricts the System program to `Transfer`, so no caller can `Allocate` or `CreateAccount`. The largest account this endpoint can serve is the 134 KB precompile ELF.
  - **"Unauthenticated clients" only applies if core's RPC is exposed directly.**  `getAccountInfo` requires a JWT at the gateway (`gateway/src/auth.rs:72`), and User-role callers can only read their own accounts.

  ### Recommendations not implemented

  - **Reject `base64+zstd` above a small threshold.**  Refusing a standard encoding also breaks normal clients.
  - **Require `dataSlice` for large accounts.** Not part of the Solana JSON-RPC spec, and would break clients.
  - **Config-driven budget.** Nothing needs per-deployment tuning for a limit set well above everything that can exist.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 19,713 | 21,396 | 92.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33766174712) |
| Indexer | 38,763 | 42,485 | 91.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33766174712) |
| Gateway | 1,648 | 1,907 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33766174712) |
| Auth | 1,312 | 1,506 | 87.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33766174712) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 15,458 | 20,094 | 76.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/33766174712) |
| **Total** | **76,894** | **87,388** | **88.0%** | |

> Last updated: 2026-09-03 15:15:41 UTC by E2E Integration