### PR TITLE
test(auth): assert JWT role claim is lowercase (issue-96)

### DIFF
--- a/auth/src/jwt.rs
+++ b/auth/src/jwt.rs
@@ -107,6 +107,28 @@ mod tests {
         assert_eq!(claims.role, Role::Operator);
     }
 
+    /// Decodes the raw JWT payload and asserts the role claim is exactly
+    /// "user" or "operator", the spelling the gateway accepts. Reading it as
+    /// plain JSON instead of into `Role` is the point: a round trip through
+    /// our own enum passes even if it writes "User".
+    #[test]
+    fn role_claim_is_lowercase_in_the_payload() {
+        for (role, expected_claim) in [(Role::User, "user"), (Role::Operator, "operator")] {
+            let token = config().sign(Uuid::new_v4(), role).unwrap();
+            let mut validation = Validation::default();
+            validation.set_issuer(&[JWT_ISSUER]);
+            validation.set_audience(&[JWT_AUDIENCE]);
+            let payload = decode::<serde_json::Value>(
+                &token,
+                &DecodingKey::from_secret(SECRET.as_bytes()),
+                &validation,
+            )
+            .unwrap()
+            .claims;
+            assert_eq!(payload["role"], expected_claim);
+        }
+    }
+
     #[test]
     fn wrong_secret_is_rejected() {
         let token = config().sign(Uuid::new_v4(), Role::User).unwrap();


### PR DESCRIPTION
## Issue 96: JWT role claim casing

The fix itself already landed in PR #169 : `auth::models::Role` carries `#[serde(rename_all = "lowercase")]`, so tokens serialize `"role":"user"` / `"role":"operator"`, which is what the gateway's `Role` accepts.

Missing was the test the finding asked for. Added `role_claim_is_lowercase_in_the_payload` in `auth/src/jwt.rs`: it signs a token per role, decodes the payload as raw JSON instead of into `Role`, and asserts the claim is exactly `"user"` / `"operator"`. The existing round-trip tests pass either way since they sign and verify through the same enum; this one fails without the rename (`String("User") != "user"`).

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 21,344 | 23,184 | 92.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34137627459) |
| Indexer | 39,086 | 42,803 | 91.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34137627459) |
| Gateway | 1,648 | 1,907 | 86.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34137627459) |
| Auth | 1,719 | 1,938 | 88.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34137627459) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **63,797** | **69,832** | **91.4%** | |

> Last updated: 2026-09-07 15:35:08 UTC by Auth