### PR TITLE
fix(indexer): raise getBlock max transaction version to 1

### DIFF
--- a/docs/runbooks/indexer_block_unavailable.md
+++ b/docs/runbooks/indexer_block_unavailable.md
@@ -93,7 +93,7 @@ Confirm the endpoint really cannot serve it (substitute the slot from the log):
 
 ```sh
 curl -s "$COMMON_RPC_URL" -H 'content-type: application/json' -d \
-  '{"jsonrpc":"2.0","id":1,"method":"getBlock","params":[<N>,{"encoding":"json","transactionDetails":"none","maxSupportedTransactionVersion":0,"rewards":false,"commitment":"finalized"}]}'
+  '{"jsonrpc":"2.0","id":1,"method":"getBlock","params":[<N>,{"encoding":"json","transactionDetails":"none","maxSupportedTransactionVersion":1,"rewards":false,"commitment":"finalized"}]}'
 ```
 
 An error with code `-32004`, `-32007` or `-32009`, or a `null` result, confirms

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -1217,8 +1217,9 @@ mod tests {
     fn v1_transaction_captured_from_devnet_parses_into_a_deposit_row() {
         let amount = 4_242;
         // Escrow program at key index 0; the rest pad the deposit's 12 accounts.
-        let mut account_keys: Vec<String> =
-            (0u8..12).map(|index| test_pubkey(index).to_string()).collect();
+        let mut account_keys: Vec<String> = (0u8..12)
+            .map(|index| test_pubkey(index).to_string())
+            .collect();
         account_keys[0] = PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string();
 
         let response = json!({

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -262,7 +262,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{error::ParserError, test_utils::rpc_blocks::*};
+    use crate::{
+        error::ParserError,
+        test_utils::{
+            escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes},
+            pubkey::test_pubkey,
+            rpc_blocks::*,
+        },
+    };
+    use serde_json::json;
 
     const TEST_PROGRAM_ID: &str = "TestProgram11111111111111111111111111111111";
 
@@ -1187,5 +1195,89 @@ mod tests {
             total,
             "(instruction_index, inner_index) must be unique regardless of CPI depth"
         );
+    }
+
+    /// A v1 transaction survives `RpcBlock` and reaches the parser intact.
+    ///
+    /// The envelope is copied from what a node actually served: devnet slot
+    /// 495752744, `getBlock` with `maxSupportedTransactionVersion: 1`. Its v1
+    /// markers are `version: 1` beside `transaction`, `transactionConfig` nested
+    /// inside `message`, and no `addressTableLookups` at all, because v1 dropped
+    /// lookup tables (SIMD-0385). None of the three are declared on our structs,
+    /// so serde has to drop them; this pins that. Tightening `RpcBlock` with
+    /// `deny_unknown_fields` breaks v1 here rather than in production.
+    ///
+    /// The captured transaction belonged to an unrelated devnet program, so the
+    /// instruction payload and its event CPI are swapped for escrow fixtures to
+    /// give the parser a row to find. The envelope is the real one; the payload
+    /// is version-independent and covered by the deposit tests above.
+    ///
+    /// v1 format: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md
+    #[test]
+    fn v1_transaction_captured_from_devnet_parses_into_a_deposit_row() {
+        let amount = 4_242;
+        // Escrow program at key index 0; the rest pad the deposit's 12 accounts.
+        let mut account_keys: Vec<String> =
+            (0u8..12).map(|index| test_pubkey(index).to_string()).collect();
+        account_keys[0] = PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string();
+
+        let response = json!({
+            "blockhash": "xbRm5shPwQECtyLGoxKKERD7vRqPeNHYqB6vt6hzjMb",
+            "parentSlot": 495_752_743u64,
+            "transactions": [{
+                "version": 1,
+                "transaction": {
+                    "signatures": ["42dtdM7KqUDEuPZPH8ic7KXoe6e14TrLCAKLVefGPKWhQgWBZkmDomRze9zv9KHyDjHMWSHTGWqwLfKevq6wzQDq"],
+                    "message": {
+                        "header": {
+                            "numRequiredSignatures": 1,
+                            "numReadonlySignedAccounts": 0,
+                            "numReadonlyUnsignedAccounts": 1
+                        },
+                        "accountKeys": account_keys,
+                        "recentBlockhash": "Fu11pcSvhJBX3sNaE1FzsXC6jPx5wJPTaWrdsfmMPnos",
+                        "instructions": [{
+                            "programIdIndex": 0,
+                            "accounts": (0u8..12).collect::<Vec<u8>>(),
+                            "data": bs58::encode(deposit_ix_bytes(amount, None)).into_string(),
+                            "stackHeight": 1
+                        }],
+                        "transactionConfig": {
+                            "computeUnitLimit": 1_400_000,
+                            "heapSize": null,
+                            "loadedAccountsDataSizeLimit": 1_048_576,
+                            "priorityFee": null
+                        }
+                    }
+                },
+                "meta": {
+                    "err": null,
+                    "status": { "Ok": null },
+                    "fee": 5000,
+                    "computeUnitsConsumed": 37_638,
+                    "logMessages": [],
+                    "loadedAddresses": { "writable": [], "readonly": [] },
+                    "innerInstructions": [{
+                        "index": 0,
+                        "instructions": [{
+                            "programIdIndex": 0,
+                            "accounts": [],
+                            "data": bs58::encode(deposit_event_bytes(amount)).into_string(),
+                            "stackHeight": 2
+                        }]
+                    }]
+                }
+            }]
+        });
+
+        let block: RpcBlock = serde_json::from_value(response)
+            .expect("a v1 getBlock response must deserialize into RpcBlock");
+
+        let result = parse_block(&block, 495_752_744, ProgramType::Escrow, None);
+
+        assert_eq!(result.len(), 1, "the v1 deposit is indexed");
+        assert_eq!(deposit_amount(&result[0]), amount);
+        assert_eq!(result[0].instruction_index, 0);
+        assert_eq!(result[0].inner_index, None);
     }
 }

--- a/indexer/src/indexer/datasource/rpc_polling/rpc.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/rpc.rs
@@ -58,7 +58,10 @@ impl RpcPoller {
                     {
                         "encoding": self.encoding.to_string(),
                         "transactionDetails": "full",
-                        "maxSupportedTransactionVersion": 0,
+                        // Ceiling, not a request: below it one v1 tx fails the whole
+                        // block with -32015, which wedges the slot instead of skipping it.
+                        // https://solana.com/upgrades/larger-transaction-sizes
+                        "maxSupportedTransactionVersion": 1,
                         "rewards": false,
                         "commitment": self.commitment.to_string(),
                     }

--- a/indexer/src/indexer/datasource/rpc_polling/rpc.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/rpc.rs
@@ -17,6 +17,11 @@ pub(crate) const MAX_IDLE_GAP_SLOTS: u64 = 1_000;
 /// same poller also reads chains whose skipped runs no heartbeat bounds.
 pub(crate) const MAX_LOOKAHEAD_SLOTS: u64 = MAX_IDLE_GAP_SLOTS * 10;
 
+/// Highest transaction version this poller can decode. A ceiling, not a request:
+/// below it one v1 tx fails the whole block with -32015, which wedges the slot
+/// instead of skipping it. https://solana.com/upgrades/larger-transaction-sizes
+const MAX_SUPPORTED_TRANSACTION_VERSION: u8 = 1;
+
 pub struct RpcPoller {
     client: reqwest::Client,
     rpc_url: String,
@@ -58,10 +63,7 @@ impl RpcPoller {
                     {
                         "encoding": self.encoding.to_string(),
                         "transactionDetails": "full",
-                        // Ceiling, not a request: below it one v1 tx fails the whole
-                        // block with -32015, which wedges the slot instead of skipping it.
-                        // https://solana.com/upgrades/larger-transaction-sizes
-                        "maxSupportedTransactionVersion": 1,
+                        "maxSupportedTransactionVersion": MAX_SUPPORTED_TRANSACTION_VERSION,
                         "rewards": false,
                         "commitment": self.commitment.to_string(),
                     }

--- a/indexer/src/indexer/datasource/yellowstone/convert.rs
+++ b/indexer/src/indexer/datasource/yellowstone/convert.rs
@@ -48,6 +48,10 @@ pub(super) fn create_message(message: proto::Message) -> CreateResult<VersionedM
         return Err("failed to parse hash");
     }
 
+    // `versioned` is true for v0 and v1 alike, so v1 lands in the V0 arm. That
+    // only loses `Message.config`, which we never read. v1 has no lookups, so the
+    // vec stays empty. Upstream fixed the same thing in geyser 15.1.1:
+    // https://github.com/rpcpool/yellowstone-grpc/blob/master/CHANGELOG.md
     Ok(if message.versioned {
         let mut address_table_lookups = Vec::with_capacity(message.address_table_lookups.len());
         for table in message.address_table_lookups {


### PR DESCRIPTION
## What

Raises `maxSupportedTransactionVersion` from 0 to 1 on the indexer's `getBlock`. Enough to keep indexing working when [v1 transactions](https://solana.com/upgrades/larger-transaction-sizes) show up on mainnet. It's not v1 support.

## Why

One v1 transaction makes the node reject the whole block with `-32015`. We don't treat that code as skipped-or-missing, so the slot errors, the poller never checkpoints past it, and it retries the same slot forever.

Nothing else breaks. The indexer reads RPC JSON and protobuf, never raw transaction bytes, and the new [v1 fields](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md) are ones our structs don't declare, so serde drops them.

## Decisions

  - **Hardcoded `1` instead of a config option.** The value is a ceiling, not a request for a version, so old nodes and our own channel node both accept it. No deploy ordering to worry about, and no new argument through five call sites.
  - **Left `-32015` out of the skip codes.** It means we don't know what's in the block. Skipping it would trade a visible stall for quiet data loss.
  - **No Yellowstone change.** `versioned` is true for both v0 and v1, so v1 goes down the V0 path and loses only `Message.config`, which we never read. Upstream fixed the same thing in [geyser 15.1.1](https://github.com/rpcpool/yellowstone-grpc/blob/master/CHANGELOG.md).

## Not covered

The channel node still rejects v1 on the way in (1232 byte cap, and sdk 2.3 can't parse `0x81`). No way to count v1 volume on proto `~12.2`.

## Testing

The fixture is a real v1 transaction from devnet slot 495752744. Only the instruction payload is swapped for an escrow deposit, so the shape comes from the node rather than from my reading of the spec. Checked it can fail by adding `deny_unknown_fields`.

No Yellowstone test. On proto `~12.2` a v1 message looks exactly like a v0 one with no lookups, so the test would just be a v0 test with a new name. It needs the 12.6+ bump to test anything real.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 21,831 | 23,680 | 92.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34391890225) |
| Indexer | 38,849 | 43,042 | 90.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34391890225) |
| Gateway | 1,662 | 1,957 | 84.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34391890225) |
| Auth | 1,765 | 1,982 | 89.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34391890225) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | 16,411 | 21,776 | 75.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34391890225) |
| **Total** | **80,518** | **92,437** | **87.1%** | |

> Last updated: 2026-09-09 19:40:44 UTC by E2E Integration