### PR TITLE
fix(core): bound the post-execution queues by retained bytes and rows (issue-175)

### DIFF
--- a/core/src/stages/address_index_writer.rs
+++ b/core/src/stages/address_index_writer.rs
@@ -10,7 +10,10 @@ use {
     },
     sqlx::{postgres::PgPoolOptions, PgPool},
     std::{sync::Arc, time::Duration},
-    tokio::{sync::mpsc, time::Instant},
+    tokio::{
+        sync::{mpsc, OwnedSemaphorePermit},
+        time::Instant,
+    },
     tracing::{debug, error, info, warn},
 };
 
@@ -25,8 +28,20 @@ const WRITER_POOL_SIZE: u32 = 2;
 /// than tearing the node down on a transient blip.
 const FLUSH_RETRY_BACKOFF_MS: [u64; 4] = [250, 1000, 3000, 5000];
 
+/// Cap on rows queued to this writer but not yet folded into a flush. About
+/// 100 MB of rows, and at high load roughly the writer's own retry budget, so a
+/// writer further behind than this is one the node is about to exit on anyway.
+pub(crate) const MAX_QUEUED_ADDRESS_ROWS: usize = 512_000;
+
+/// One block's address-index rows, carrying the queue budget they occupy.
+pub struct AddressSignatureBatch {
+    pub rows: Vec<AddressSignatureRow>,
+    /// Returns the rows' share of the budget to the settler when dropped.
+    pub permit: OwnedSemaphorePermit,
+}
+
 pub struct AddressIndexWriterArgs {
-    pub rows_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
+    pub rows_rx: mpsc::Receiver<AddressSignatureBatch>,
     pub accountsdb_connection_url: String,
     pub flush_chunk_size: usize,
     pub metrics: SharedMetrics,
@@ -63,7 +78,7 @@ pub async fn start_address_index_writer(args: AddressIndexWriterArgs) -> WorkerH
         };
 
         // Buffer accumulates whatever recv_many delivers per tick.
-        let mut buf: Vec<Vec<AddressSignatureRow>> = Vec::with_capacity(64);
+        let mut buf: Vec<AddressSignatureBatch> = Vec::with_capacity(64);
         let mut flat: Vec<AddressSignatureRow> = Vec::with_capacity(flush_chunk_size * 2);
 
         loop {
@@ -83,8 +98,11 @@ pub async fn start_address_index_writer(args: AddressIndexWriterArgs) -> WorkerH
             let depth = rows_rx.max_capacity().saturating_sub(rows_rx.capacity());
             metrics.address_signatures_queue_depth(depth);
 
-            for batch in buf.drain(..) {
-                flat.extend(batch);
+            for AddressSignatureBatch { rows, permit } in buf.drain(..) {
+                flat.extend(rows);
+                // The rows are ours now, so hand their budget back before the
+                // flush rather than holding the settler off across a COMMIT.
+                drop(permit);
                 // Flush in chunk-sized COMMITs so a single tick worth
                 // of work never produces an oversized transaction.
                 while flat.len() >= flush_chunk_size {
@@ -109,7 +127,7 @@ pub async fn start_address_index_writer(args: AddressIndexWriterArgs) -> WorkerH
 
         // Drain anything still buffered after shutdown / channel close.
         while let Ok(batch) = rows_rx.try_recv() {
-            flat.extend(batch);
+            flat.extend(batch.rows);
         }
         if !flat.is_empty() {
             if let Err(e) = flush_and_record(&pool, &flat, &[], &metrics, &heartbeat).await {
@@ -227,6 +245,15 @@ mod tests {
     };
     use std::time::Duration;
 
+    /// Wrap rows in the queued message shape, with a permit from a throwaway
+    /// budget so tests that are not about the budget do not have to build one.
+    fn rows_msg(rows: Vec<AddressSignatureRow>) -> AddressSignatureBatch {
+        AddressSignatureBatch {
+            rows,
+            permit: crate::stages::test_permit(),
+        }
+    }
+
     fn make_row(addr_byte: u8, slot: i64, sig_byte: u8) -> AddressSignatureRow {
         AddressSignatureRow {
             address: vec![addr_byte; 32],
@@ -273,9 +300,13 @@ mod tests {
         .await;
 
         for slot in 0..5i64 {
-            tx.send(vec![make_row(slot as u8 + 1, slot, slot as u8 + 1)])
-                .await
-                .unwrap();
+            tx.send(rows_msg(vec![make_row(
+                slot as u8 + 1,
+                slot,
+                slot as u8 + 1,
+            )]))
+            .await
+            .unwrap();
         }
         // Closing the sender should let the writer exit on its own.
         drop(tx);
@@ -313,7 +344,7 @@ mod tests {
                 signature: (i as u32).to_le_bytes().repeat(16),
             })
             .collect();
-        tx.send(big).await.unwrap();
+        tx.send(rows_msg(big)).await.unwrap();
         drop(tx);
 
         let join = tokio::time::timeout(Duration::from_secs(15), handle.handle).await;
@@ -374,12 +405,12 @@ mod tests {
         })
         .await;
 
-        tx.send(vec![make_row(1, 0, 1)]).await.unwrap();
+        tx.send(rows_msg(vec![make_row(1, 0, 1)])).await.unwrap();
 
         let join = tokio::time::timeout(Duration::from_secs(15), handle.handle).await;
         assert!(join.is_ok(), "writer should exit after retries exhaust");
 
-        let send_after = tx.send(vec![make_row(2, 1, 2)]).await;
+        let send_after = tx.send(rows_msg(vec![make_row(2, 1, 2)])).await;
         assert!(send_after.is_err(), "writer receiver should be closed");
     }
 
@@ -401,9 +432,13 @@ mod tests {
         // Queue several batches, then close: the writer is the last stage in the
         // drain, so it must land all of them rather than a racy subset.
         for slot in 0..10i64 {
-            tx.send(vec![make_row(slot as u8 + 10, slot, slot as u8 + 10)])
-                .await
-                .unwrap();
+            tx.send(rows_msg(vec![make_row(
+                slot as u8 + 10,
+                slot,
+                slot as u8 + 10,
+            )]))
+            .await
+            .unwrap();
         }
         drop(tx);
 
@@ -412,6 +447,53 @@ mod tests {
 
         let n = count_rows(&url).await;
         assert_eq!(n, 10, "every queued row must be flushed before exit");
+    }
+
+    /// The writer holds a batch against the settler's row budget only until it
+    /// folds it into the flush buffer, so a flush never blocks the settler on
+    /// rows the writer has already taken.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn writer_returns_row_permits_as_it_folds_batches() {
+        let (_db, pg) = start_test_postgres().await;
+        let url = postgres_container_url(&pg, "test_db").await;
+
+        let budget = crate::stages::WeightBudget::new(10);
+        let (tx, rx) = mpsc::channel(8);
+        let handle = start_address_index_writer(AddressIndexWriterArgs {
+            rows_rx: rx,
+            accountsdb_connection_url: url.clone(),
+            flush_chunk_size: 100,
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: StageHeartbeat::new(),
+        })
+        .await;
+
+        for slot in 0..3i64 {
+            let rows: Vec<AddressSignatureRow> = (0..3)
+                .map(|i| {
+                    let byte = (slot * 3 + i + 1) as u8;
+                    make_row(byte, slot, byte)
+                })
+                .collect();
+            let permit = budget
+                .acquire(rows.len(), &tx)
+                .await
+                .expect("the budget has room for three rows");
+            tx.send(AddressSignatureBatch { rows, permit })
+                .await
+                .unwrap();
+        }
+        drop(tx);
+
+        let join = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
+        assert!(join.is_ok(), "writer should exit after channel close");
+
+        assert_eq!(count_rows(&url).await, 9, "every row must land");
+        assert_eq!(
+            budget.available(),
+            10,
+            "every folded batch returned its rows"
+        );
     }
 
     /// Watermark = max flushed slot when buffer drains.
@@ -431,10 +513,10 @@ mod tests {
         .await;
 
         for slot in 10i64..=12 {
-            tx.send(vec![
+            tx.send(rows_msg(vec![
                 make_row(slot as u8, slot, slot as u8),
                 make_row((slot + 100) as u8, slot, (slot + 1) as u8),
-            ])
+            ]))
             .await
             .unwrap();
         }

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -8,7 +8,7 @@ use {
         },
         scheduler::ConflictFreeBatch,
         stage_metrics::SharedMetrics,
-        stages::{retained_bytes_of, AccountSettlements, ExecutedBatch},
+        stages::{retained_bytes_of, AccountSettlements, ExecutedBatch, WeightBudget},
         transactions::is_admin_instruction,
         vm::{
             admin::AdminVm,
@@ -123,6 +123,9 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
         )
         .await;
 
+        // Stage-private: nothing outside the executor takes from this budget.
+        let results_budget = WeightBudget::new(MAX_IN_FLIGHT_RESULT_BYTES);
+
         let mut total_transactions_executed = 0u64;
         let mut total_batches_processed = 0u64;
 
@@ -161,6 +164,7 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                                 execution_result.admin_transactions,
                                 execution_result.admin_generation,
                                 MAX_SEND_CHUNK_BYTES,
+                                &results_budget,
                                 &metrics,
                             )
                             .await
@@ -188,6 +192,7 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                                 execution_result.regular_transactions,
                                 execution_result.regular_generation,
                                 MAX_SEND_CHUNK_BYTES,
+                                &results_budget,
                                 &metrics,
                             )
                             .await
@@ -329,12 +334,28 @@ pub(crate) const MAX_SEND_CHUNK_BYTES: usize = 64 * 1024 * 1024;
 /// A chunk must never exceed the settler budget it is measured against.
 const _: () = assert!(MAX_SEND_CHUNK_BYTES <= crate::stages::MAX_BUFFERED_SETTLE_BYTES);
 
+/// Cap on retained account bytes sent to the settler but not yet received.
+/// Two whole chunks, so the executor can hand one over while the settler still
+/// holds the previous one and ordinary traffic never waits on the budget.
+pub(crate) const MAX_IN_FLIGHT_RESULT_BYTES: usize = 2 * MAX_SEND_CHUNK_BYTES;
+
+/// A chunk that could not fit the budget would wait for room that never comes.
+const _: () = assert!(MAX_SEND_CHUNK_BYTES <= MAX_IN_FLIGHT_RESULT_BYTES);
+
 /// Outcome of a settler send. There is no shutdown variant: abandoning a send
 /// would discard a batch that has already executed and already mutated the
 /// in-memory accounts, and the settler is still draining when this stage exits.
 pub(crate) enum SendOutcome {
     Sent,
     ChannelClosed,
+}
+
+/// One chunk of a batch: where it starts and ends, and the account bytes it
+/// retains. Carrying the byte sum out means the send path can take its share of
+/// the in-flight budget without walking every account a second time.
+struct ChunkRange {
+    range: std::ops::Range<usize>,
+    bytes: usize,
 }
 
 /// Where to split a batch, as end-exclusive index ranges over its transactions.
@@ -344,7 +365,7 @@ fn chunk_ranges_by_bytes(
     results: &[TransactionProcessingResult],
     transactions: &[SanitizedTransaction],
     cap: usize,
-) -> Vec<std::ops::Range<usize>> {
+) -> Vec<ChunkRange> {
     // A length mismatch is the settler's error to report, so send the batch whole.
     if results.len() != transactions.len() {
         return Vec::new();
@@ -355,14 +376,20 @@ fn chunk_ranges_by_bytes(
     for (index, (result, transaction)) in results.iter().zip(transactions.iter()).enumerate() {
         let bytes = retained_bytes_of(result, transaction);
         if index > start && buffered + bytes > cap {
-            ranges.push(start..index);
+            ranges.push(ChunkRange {
+                range: start..index,
+                bytes: buffered,
+            });
             start = index;
             buffered = 0;
         }
         buffered += bytes;
     }
     if start < results.len() {
-        ranges.push(start..results.len());
+        ranges.push(ChunkRange {
+            range: start..results.len(),
+            bytes: buffered,
+        });
     }
     ranges
 }
@@ -404,14 +431,32 @@ async fn send_results_chunked(
     transactions: Vec<SanitizedTransaction>,
     generation: u64,
     cap: usize,
+    budget: &WeightBudget,
     metrics: &SharedMetrics,
 ) -> SendOutcome {
     let ranges = chunk_ranges_by_bytes(&output.processing_results, &transactions, cap);
     if ranges.len() <= 1 {
-        return match send_one(results_tx, (output, transactions, generation)).await {
+        // Empty only when the batch is empty or its lengths disagree, and the
+        // settler rejects the latter on arrival, so nothing is left unweighed.
+        let weight = ranges.first().map_or(0, |chunk| chunk.bytes);
+        let Some(permit) = budget.acquire(weight, results_tx).await else {
+            record_unsent(&transactions, &[], metrics);
+            return SendOutcome::ChannelClosed;
+        };
+        return match send_one(
+            results_tx,
+            ExecutedBatch {
+                output,
+                transactions,
+                generation,
+                permit,
+            },
+        )
+        .await
+        {
             Ok(()) => SendOutcome::Sent,
-            Err((_, transactions, _)) => {
-                record_unsent(&transactions, &[], metrics);
+            Err(batch) => {
+                record_unsent(&batch.transactions, &[], metrics);
                 SendOutcome::ChannelClosed
             }
         };
@@ -431,8 +476,8 @@ async fn send_results_chunked(
 
     let last = ranges.len() - 1;
     let mut sent = 0usize;
-    for (position, range) in ranges.iter().enumerate() {
-        let take = range.end - range.start;
+    for (position, chunk_range) in ranges.iter().enumerate() {
+        let take = chunk_range.range.end - chunk_range.range.start;
         let (error_metrics, execute_timings, balance_collector) =
             head.take().unwrap_or_else(|| {
                 (
@@ -450,16 +495,33 @@ async fn send_results_chunked(
         let chunk_transactions: Vec<SanitizedTransaction> = transactions.drain(..take).collect();
         // Zero acknowledges nothing, so a partial drain cannot mark writes durable.
         let chunk_generation = if position == last { generation } else { 0 };
-        match send_one(results_tx, (chunk, chunk_transactions, chunk_generation)).await {
+        let Some(permit) = budget.acquire(chunk_range.bytes, results_tx).await else {
+            if sent > 0 {
+                metrics.executor_results_sent(sent);
+            }
+            record_unsent(&chunk_transactions, &transactions, metrics);
+            return SendOutcome::ChannelClosed;
+        };
+        match send_one(
+            results_tx,
+            ExecutedBatch {
+                output: chunk,
+                transactions: chunk_transactions,
+                generation: chunk_generation,
+                permit,
+            },
+        )
+        .await
+        {
             Ok(()) => sent += take,
-            Err((_, chunk_transactions, _)) => {
+            Err(batch) => {
                 // Report what actually landed; the caller only counts a whole batch.
                 if sent > 0 {
                     metrics.executor_results_sent(sent);
                 }
                 // The chunks still undrained never left either, so they belong
                 // in the same record as the one that just failed.
-                record_unsent(&chunk_transactions, &transactions, metrics);
+                record_unsent(&batch.transactions, &transactions, metrics);
                 return SendOutcome::ChannelClosed;
             }
         }
@@ -1177,16 +1239,28 @@ mod tests {
             assert_eq!(ranges.len(), expected_chunks, "chunk count for {}", name);
 
             let mut next = 0usize;
-            for r in &ranges {
-                assert_eq!(r.start, next, "gap or overlap in {}", name);
-                assert!(r.end > r.start, "empty chunk in {}", name);
-                next = r.end;
+            for chunk in &ranges {
+                assert_eq!(chunk.range.start, next, "gap or overlap in {}", name);
+                assert!(
+                    chunk.range.end > chunk.range.start,
+                    "empty chunk in {}",
+                    name
+                );
+                next = chunk.range.end;
             }
             assert_eq!(next, sizes.len(), "chunks must cover every tx in {}", name);
 
-            for r in &ranges {
-                if r.end - r.start > 1 {
-                    let bytes = retained_account_bytes(&results[r.clone()], &txs[r.clone()]);
+            for chunk in &ranges {
+                let range = chunk.range.clone();
+                // The sender takes its budget from this sum instead of walking
+                // the accounts again, so it has to match what that walk finds.
+                let bytes = retained_account_bytes(&results[range.clone()], &txs[range]);
+                assert_eq!(
+                    chunk.bytes, bytes,
+                    "reported bytes disagree with the batch in {}",
+                    name
+                );
+                if chunk.range.end - chunk.range.start > 1 {
                     assert!(bytes <= cap, "chunk over cap in {}: {}", name, bytes);
                 }
             }
@@ -1205,13 +1279,22 @@ mod tests {
         // Each transaction alone exceeds the cap, so this splits into three.
         let (results, txs) = sized_batch(&[5000, 5000, 5000]);
         let (chan_tx, mut rx) = mpsc::channel::<ExecutedBatch>(16);
-        let outcome =
-            send_results_chunked(&chan_tx, output_of(results), txs, 42, cap, &metrics).await;
+        let budget = WeightBudget::new(MAX_IN_FLIGHT_RESULT_BYTES);
+        let outcome = send_results_chunked(
+            &chan_tx,
+            output_of(results),
+            txs,
+            42,
+            cap,
+            &budget,
+            &metrics,
+        )
+        .await;
         assert!(matches!(outcome, SendOutcome::Sent));
 
         let mut gens = Vec::new();
-        while let Ok((_, _, g)) = rx.try_recv() {
-            gens.push(g);
+        while let Ok(batch) = rx.try_recv() {
+            gens.push(batch.generation);
         }
         assert_eq!(
             gens,
@@ -1223,12 +1306,13 @@ mod tests {
         let (results, txs) = sized_batch(&[10, 10]);
         let (chan_tx, mut rx) = mpsc::channel::<ExecutedBatch>(16);
         let outcome =
-            send_results_chunked(&chan_tx, output_of(results), txs, 7, cap, &metrics).await;
+            send_results_chunked(&chan_tx, output_of(results), txs, 7, cap, &budget, &metrics)
+                .await;
         assert!(matches!(outcome, SendOutcome::Sent));
 
         let mut gens = Vec::new();
-        while let Ok((_, _, g)) = rx.try_recv() {
-            gens.push(g);
+        while let Ok(batch) = rx.try_recv() {
+            gens.push(batch.generation);
         }
         assert_eq!(gens, vec![7], "an unsplit batch stays one message");
     }
@@ -1267,6 +1351,7 @@ mod tests {
             txs,
             1,
             MAX_SEND_CHUNK_BYTES,
+            &WeightBudget::new(MAX_IN_FLIGHT_RESULT_BYTES),
             &metrics,
         )
         .await;
@@ -1279,32 +1364,129 @@ mod tests {
     }
 
     /// A split batch fails partway. The chunks that never went are just as
-    /// executed and just as uncommitted as the one whose send failed.
-    #[tokio::test]
+    /// executed and just as uncommitted as the one whose send failed, whichever
+    /// of the two limits the executor happened to be parked on.
+    #[tokio::test(flavor = "multi_thread")]
     async fn a_closed_channel_mid_chunk_records_the_remainder() {
         let _guard = DISCARD_METRIC_LOCK.lock().await;
         let metrics: SharedMetrics = Arc::new(PrometheusMetrics);
-        let before = discarded_total();
 
-        // One transaction per chunk, and room for only the first.
-        let (results, txs) = sized_batch(&[5000, 5000, 5000]);
-        let (chan_tx, rx) = mpsc::channel::<ExecutedBatch>(1);
-        // The receiver never drains, so the second chunk parks. Closing it then
-        // is what the settler does when it gives up mid-handover.
-        let closer = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            drop(rx);
+        // Every row splits into three chunks with room for only the first: on
+        // the first the depth is what fills, on the second the byte budget.
+        let cases: [(&str, usize, usize, usize); 2] = [
+            ("parked on queue depth", 1, MAX_IN_FLIGHT_RESULT_BYTES, 5000),
+            ("parked on the byte budget", 16, 1000, 900),
+        ];
+
+        for (name, capacity, total, bytes) in cases {
+            let before = discarded_total();
+            let (results, txs) = sized_batch(&[bytes; 3]);
+            let (chan_tx, rx) = mpsc::channel::<ExecutedBatch>(capacity);
+            let budget = WeightBudget::new(total);
+            // The receiver never drains, so the second chunk parks. Closing it
+            // then is what the settler does when it gives up mid-handover.
+            let closer = tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                drop(rx);
+            });
+            let outcome = send_results_chunked(
+                &chan_tx,
+                output_of(results),
+                txs,
+                9,
+                1000,
+                &budget,
+                &metrics,
+            )
+            .await;
+
+            assert!(matches!(outcome, SendOutcome::ChannelClosed), "{}", name);
+            assert_eq!(
+                discarded_total() - before,
+                2.0,
+                "the failed chunk and the undrained remainder must both be recorded, {}",
+                name
+            );
+            let _ = closer.await;
+        }
+    }
+
+    /// Bytes, not messages, are what park the executor: a 16-slot channel has
+    /// room for both chunks and the second still waits. The settler returns the
+    /// weight by receiving, without touching the permit itself.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_chunk_parks_on_bytes_and_the_receive_returns_them() {
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+        let (results, txs) = sized_batch(&[600, 600]);
+        let (chan_tx, mut rx) = mpsc::channel::<ExecutedBatch>(16);
+        let budget = Arc::new(WeightBudget::new(1000));
+
+        let sender = tokio::spawn({
+            let budget = Arc::clone(&budget);
+            async move {
+                send_results_chunked(
+                    &chan_tx,
+                    output_of(results),
+                    txs,
+                    3,
+                    1000,
+                    &budget,
+                    &metrics,
+                )
+                .await
+            }
         });
-        let outcome =
-            send_results_chunked(&chan_tx, output_of(results), txs, 9, 1000, &metrics).await;
 
-        assert!(matches!(outcome, SendOutcome::ChannelClosed));
-        assert_eq!(
-            discarded_total() - before,
-            2.0,
-            "the failed chunk and the undrained remainder must both be recorded"
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(rx.len(), 1, "only the first chunk got through");
+        assert!(
+            !sender.is_finished(),
+            "the second chunk waits on bytes: the 16 slots are not the limit"
         );
-        let _ = closer.await;
+
+        drop(rx.recv().await.expect("first chunk"));
+        let second = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("the freed bytes must unpark the second chunk")
+            .expect("second chunk");
+        drop(second);
+
+        assert!(matches!(sender.await.unwrap(), SendOutcome::Sent));
+        assert_eq!(
+            budget.available(),
+            1000,
+            "every permit comes back with its message"
+        );
+    }
+
+    /// The weight is the retained account bytes of what is being sent, so one
+    /// unsplit message can take far more of the budget than one slot's worth.
+    #[tokio::test]
+    async fn an_unsplit_batch_takes_its_retained_bytes() {
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+        let (results, txs) = sized_batch(&[300, 400]);
+        let (chan_tx, mut rx) = mpsc::channel::<ExecutedBatch>(16);
+        let budget = WeightBudget::new(1000);
+
+        let outcome = send_results_chunked(
+            &chan_tx,
+            output_of(results),
+            txs,
+            1,
+            1000,
+            &budget,
+            &metrics,
+        )
+        .await;
+        assert!(matches!(outcome, SendOutcome::Sent));
+        assert_eq!(
+            budget.available(),
+            300,
+            "the queued message holds all 700 of its retained bytes"
+        );
+
+        drop(rx.recv().await.expect("the one message"));
+        assert_eq!(budget.available(), 1000);
     }
 
     /// A token-like data account (program-owned, non-empty data) with `lamports`.

--- a/core/src/stages/mod.rs
+++ b/core/src/stages/mod.rs
@@ -12,6 +12,68 @@ pub use sequencer::*;
 pub use settle::*;
 pub use sigverify::*;
 
+use {
+    std::sync::Arc,
+    tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore},
+};
+
+/// How much of a queue's memory its messages may hold, in bytes or rows. The
+/// permit rides inside the message, so every way a message can end returns its
+/// weight without the consumer accounting for it.
+pub(crate) struct WeightBudget {
+    semaphore: Arc<Semaphore>,
+    /// Kept because a semaphore reports what is available, not what it started with.
+    total: usize,
+}
+
+impl WeightBudget {
+    pub(crate) fn new(total: usize) -> Self {
+        // Permits are counted in a u32, and a total that wrapped to zero would
+        // be a budget that silently never blocks.
+        assert!(
+            total <= u32::MAX as usize,
+            "a weight budget must fit the u32 permit count"
+        );
+        Self {
+            semaphore: Arc::new(Semaphore::new(total)),
+            total,
+        }
+    }
+
+    /// Take `weight`, clamped to the whole budget so an oversized message goes
+    /// alone rather than waiting for room that cannot exist. `None` once `tx`
+    /// has lost its receiver, so a parked producer cannot outlive its consumer.
+    pub(crate) async fn acquire<T>(
+        &self,
+        weight: usize,
+        tx: &mpsc::Sender<T>,
+    ) -> Option<OwnedSemaphorePermit> {
+        let wanted = weight.min(self.total) as u32;
+        tokio::select! {
+            // Checked first so a dead consumer always wins over free permits.
+            biased;
+            _ = tx.closed() => None,
+            // Never closed, so the only failure this can report is impossible.
+            permit = Arc::clone(&self.semaphore).acquire_many_owned(wanted) => permit.ok(),
+        }
+    }
+
+    /// Only the tests read the budget back; production just parks on it.
+    #[cfg(test)]
+    pub(crate) fn available(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+}
+
+/// One permit off a throwaway budget, so a test can build a queued message
+/// without standing up the budget the production path uses.
+#[cfg(test)]
+pub(crate) fn test_permit() -> OwnedSemaphorePermit {
+    Arc::new(Semaphore::new(1))
+        .try_acquire_owned()
+        .expect("a fresh semaphore has its permit")
+}
+
 /// Signatures named per log line, so one discard cannot emit a single
 /// unreadable record while still naming every transaction it dropped.
 const DISCARD_SIGNATURES_PER_LINE: usize = 100;
@@ -48,3 +110,117 @@ pub(crate) fn record_discarded(
 
 #[cfg(test)]
 mod sponsor_replay_test;
+
+#[cfg(test)]
+mod weight_budget_tests {
+    use {super::WeightBudget, std::time::Duration, tokio::sync::mpsc};
+
+    /// The two hazards the budget exists for, plus the shapes that must never
+    /// wait: a zero weight, a weight that fits, and one larger than the budget.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn acquire_clamps_parks_and_gives_up_on_a_dead_consumer() {
+        struct Case {
+            name: &'static str,
+            total: usize,
+            prior: usize,
+            weight: usize,
+            parks: bool,
+            close_receiver: bool,
+            expect_permit: bool,
+            available_after: usize,
+        }
+
+        let cases = [
+            Case {
+                name: "zero weight resolves at once",
+                total: 10,
+                prior: 0,
+                weight: 0,
+                parks: false,
+                close_receiver: false,
+                expect_permit: true,
+                available_after: 10,
+            },
+            Case {
+                name: "a weight that fits takes exactly that",
+                total: 10,
+                prior: 0,
+                weight: 4,
+                parks: false,
+                close_receiver: false,
+                expect_permit: true,
+                available_after: 6,
+            },
+            Case {
+                name: "an oversized weight clamps to the whole budget",
+                total: 10,
+                prior: 0,
+                weight: 25,
+                parks: false,
+                close_receiver: false,
+                expect_permit: true,
+                available_after: 0,
+            },
+            Case {
+                name: "a spent budget parks until a prior permit drops",
+                total: 10,
+                prior: 10,
+                weight: 4,
+                parks: true,
+                close_receiver: false,
+                expect_permit: true,
+                available_after: 6,
+            },
+            Case {
+                name: "a parked acquire gives up on a dropped receiver",
+                total: 10,
+                prior: 10,
+                weight: 4,
+                parks: true,
+                close_receiver: true,
+                expect_permit: false,
+                available_after: 0,
+            },
+        ];
+
+        for case in cases {
+            let budget = WeightBudget::new(case.total);
+            let (tx, rx) = mpsc::channel::<()>(1);
+            let prior = budget.acquire(case.prior, &tx).await;
+            assert!(prior.is_some(), "prior acquire for {}", case.name);
+
+            let acquire = budget.acquire(case.weight, &tx);
+            tokio::pin!(acquire);
+            if case.parks {
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(200), &mut acquire)
+                        .await
+                        .is_err(),
+                    "{} must park",
+                    case.name
+                );
+                if case.close_receiver {
+                    drop(rx);
+                } else {
+                    drop(prior);
+                }
+            }
+
+            let permit = tokio::time::timeout(Duration::from_secs(5), &mut acquire)
+                .await
+                .unwrap_or_else(|_| panic!("{} must resolve", case.name));
+            assert_eq!(
+                permit.is_some(),
+                case.expect_permit,
+                "permit for {}",
+                case.name
+            );
+            assert_eq!(
+                budget.available(),
+                case.available_after,
+                "available after {}",
+                case.name
+            );
+        }
+    }
+}

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -6,11 +6,11 @@ use {
             redis::{RedisAccountsDB, CACHE_FAILURE_LIMIT},
             redis_coherence,
             traits::BlockInfo,
-            write_batch::AddressSignatureRow,
             AccountsDB,
         },
         nodes::node::WorkerHandle,
         stage_metrics::SharedMetrics,
+        stages::{AddressSignatureBatch, WeightBudget, MAX_QUEUED_ADDRESS_ROWS},
     },
     anyhow::{anyhow, Context, Result},
     redis::AsyncCommands,
@@ -32,7 +32,10 @@ use {
         sync::Arc,
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
-    tokio::{sync::mpsc, time::Instant},
+    tokio::{
+        sync::{mpsc, OwnedSemaphorePermit},
+        time::Instant,
+    },
     tokio_util::sync::CancellationToken,
     tracing::{debug, error, info, warn},
 };
@@ -146,13 +149,16 @@ pub struct AccountSettlement {
     pub deleted: bool,
 }
 
-/// One executed batch on its way from the executor to the settler. The third
-/// element is the executor's generation for the account writes in this batch.
-pub type ExecutedBatch = (
-    LoadAndExecuteSanitizedTransactionsOutput,
-    Vec<SanitizedTransaction>,
-    u64,
-);
+/// One executed batch on its way from the executor to the settler.
+pub struct ExecutedBatch {
+    pub output: LoadAndExecuteSanitizedTransactionsOutput,
+    pub transactions: Vec<SanitizedTransaction>,
+    /// The executor's generation for the account writes in this batch.
+    pub generation: u64,
+    /// The executor's in-flight byte budget for this batch. Nothing reads it:
+    /// dropping it wherever this message ends is what returns the bytes.
+    pub permit: OwnedSemaphorePermit,
+}
 
 /// Settlement acknowledgement sent back to BOB after a commit.
 ///
@@ -219,9 +225,13 @@ struct BlockPublishers<'a> {
     /// Advances the dedup window. Until dedup holds the hash, transactions
     /// built on it are dropped.
     blockhashes: &'a mpsc::UnboundedSender<Hash>,
-    /// Acks the commit to BOB, which unpins the settled accounts.
+    /// Acks the commit to BOB, which unpins the settled accounts. Unbounded on
+    /// purpose: BOB drains only while the executor runs and the executor runs
+    /// only while the settler drains, so a blocking send here would deadlock.
     accounts: &'a mpsc::UnboundedSender<AccountSettlements>,
-    address_signatures: &'a mpsc::Sender<Vec<AddressSignatureRow>>,
+    address_signatures: &'a mpsc::Sender<AddressSignatureBatch>,
+    /// Rows queued to the writer but not yet folded into a flush.
+    rows_budget: &'a WeightBudget,
 }
 
 #[derive(Debug)]
@@ -335,7 +345,7 @@ pub struct SettleArgs {
     pub settled_accounts_tx: mpsc::UnboundedSender<AccountSettlements>,
     pub settled_blockhashes_tx: mpsc::UnboundedSender<Hash>,
     /// Bounded channel to the background `address_index_writer`.
-    pub address_signatures_tx: mpsc::Sender<Vec<AddressSignatureRow>>,
+    pub address_signatures_tx: mpsc::Sender<AddressSignatureBatch>,
     pub accountsdb_connection_url: String,
     /// The cache the read path also attaches to. One knob for both, so a writer
     /// cannot stop mirroring a cache that readers still trust.
@@ -375,7 +385,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
             mut execution_results_rx: mpsc::Receiver<ExecutedBatch>,
             settled_accounts_tx: mpsc::UnboundedSender<AccountSettlements>,
             settled_blockhashes_tx: mpsc::UnboundedSender<Hash>,
-            address_signatures_tx: mpsc::Sender<Vec<AddressSignatureRow>>,
+            address_signatures_tx: mpsc::Sender<AddressSignatureBatch>,
             accountsdb_connection_url: String,
             redis_cache_url: Option<String>,
             redis_block_ttl_secs: u64,
@@ -387,6 +397,9 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
             heartbeat: Arc<crate::health::StageHeartbeat>,
         ) -> anyhow::Result<()> {
             info!("Settle worker started");
+
+            // Stage-private: nothing outside the settler takes from this budget.
+            let rows_budget = WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS);
 
             let mut accounts_db = AccountsDB::new(&accountsdb_connection_url, false)
                 .await
@@ -631,6 +644,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                                 blockhashes: &settled_blockhashes_tx,
                                 accounts: &settled_accounts_tx,
                                 address_signatures: &address_signatures_tx,
+                                rows_budget: &rows_budget,
                             }),
                             highest_generation,
                             &heartbeat,
@@ -747,7 +761,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                     result = execution_results_rx.recv(),
                         if buffered_account_bytes < MAX_BUFFERED_SETTLE_BYTES => {
                         match result {
-                            Some((svm_output, transactions, generation)) => {
+                            Some(ExecutedBatch { output: svm_output, transactions, generation, .. }) => {
                                 heartbeat.record_input();
                                 debug!("Settle worker received output with {} transactions", transactions.len());
                                 if svm_output.processing_results.len() != transactions.len() {
@@ -793,6 +807,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                         blockhashes: &settled_blockhashes_tx,
                         accounts: &settled_accounts_tx,
                         address_signatures: &address_signatures_tx,
+                        rows_budget: &rows_budget,
                     }),
                     highest_generation,
                     &heartbeat,
@@ -895,12 +910,13 @@ fn discard_buffer(
     // so a snapshot lets a batch land behind the record and die with the
     // receiver. Closing refuses it instead, and the executor records its own.
     execution_results_rx.close();
-    while let Ok((svm_output, transactions, _generation)) = execution_results_rx.try_recv() {
+    while let Ok(batch) = execution_results_rx.try_recv() {
         processing_results.extend(
-            svm_output
+            batch
+                .output
                 .processing_results
                 .into_iter()
-                .zip(transactions.into_iter()),
+                .zip(batch.transactions),
         );
     }
 
@@ -1230,10 +1246,22 @@ async fn settle_transactions(
             publisher_gone = true;
         }
 
-        // Closed channel = writer gone; escalate to exit.
+        // Closed channel = writer gone; escalate to exit. The budget wait is
+        // inside the timing window so a park on rows reads like a park on depth.
         if !addr_sig_rows.is_empty() {
             let send_t0 = tokio::time::Instant::now();
-            match publishers.address_signatures.send(addr_sig_rows).await {
+            let Some(permit) = publishers
+                .rows_budget
+                .acquire(addr_sig_rows.len(), publishers.address_signatures)
+                .await
+            else {
+                return Err(SettleError::AddressIndexWriterGone);
+            };
+            let batch = AddressSignatureBatch {
+                rows: addr_sig_rows,
+                permit,
+            };
+            match publishers.address_signatures.send(batch).await {
                 Ok(()) => {
                     metrics.address_signatures_send_blocked_ms(
                         send_t0.elapsed().as_secs_f64() * 1000.0,
@@ -1517,6 +1545,7 @@ mod tests {
     use super::*;
 
     use crate::{
+        accounts::write_batch::AddressSignatureRow,
         stage_metrics::{NoopMetrics, SharedMetrics},
         test_helpers::{
             create_test_sanitized_transaction, postgres_container_url, start_test_postgres,
@@ -1567,6 +1596,7 @@ mod tests {
                 blockhashes: &blockhashes_tx,
                 accounts: &accounts_tx,
                 address_signatures: &address_signatures_tx,
+                rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
             }),
             0,
             settle_now(),
@@ -1629,6 +1659,29 @@ mod tests {
 
     fn sig(byte: u8) -> Signature {
         Signature::from([byte; 64])
+    }
+
+    /// Wrap an executor output in the queued message shape, with a permit from
+    /// a throwaway budget so tests not about the budget need not build one.
+    fn batch_of(
+        output: LoadAndExecuteSanitizedTransactionsOutput,
+        transactions: Vec<SanitizedTransaction>,
+        generation: u64,
+    ) -> ExecutedBatch {
+        ExecutedBatch {
+            output,
+            transactions,
+            generation,
+            permit: crate::stages::test_permit(),
+        }
+    }
+
+    /// The same for a block's address-index rows.
+    fn rows_msg(rows: Vec<AddressSignatureRow>) -> AddressSignatureBatch {
+        AddressSignatureBatch {
+            rows,
+            permit: crate::stages::test_permit(),
+        }
     }
 
     /// One batch whose single writable account carries `bytes` of data.
@@ -1714,7 +1767,7 @@ mod tests {
     /// Unread receivers held alive; dropping the address-index one is fatal.
     struct SettlerSinks {
         _blockhashes_rx: mpsc::UnboundedReceiver<Hash>,
-        _address_signatures_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
+        _address_signatures_rx: mpsc::Receiver<AddressSignatureBatch>,
     }
 
     /// Settler on a throwaway Postgres, with the channels the assertions read.
@@ -1835,6 +1888,55 @@ mod tests {
         false
     }
 
+    /// The premise the in-flight budget rests on: the settler never holds a
+    /// permit outside the queue, so receiving a batch is what returns its bytes
+    /// to the executor, whatever the settler goes on to do with the batch.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_settler_returns_the_in_flight_budget_on_receive() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+        let shutdown = CancellationToken::new();
+
+        let (exec_tx, mut settled_rx, _h, _sinks, _hb) =
+            settler_under_test(url, 50, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
+
+        let budget = WeightBudget::new(1);
+        let permit = budget
+            .acquire(1, &exec_tx)
+            .await
+            .expect("a fresh budget hands out its only permit");
+        let (output, transactions) = sized_settle_batch(1024);
+        exec_tx
+            .send(ExecutedBatch {
+                output,
+                transactions,
+                generation: 1,
+                permit,
+            })
+            .await
+            .unwrap();
+
+        // Idle ticks also broadcast, so wait for the one carrying our accounts:
+        // that settlement is proof the batch was received and not merely queued.
+        let settled = tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                let settlement = settled_rx.recv().await.expect("settler still running");
+                if !settlement.accounts.is_empty() {
+                    return settlement;
+                }
+            }
+        })
+        .await
+        .expect("the sent batch must settle");
+        assert_eq!(settled.accounts.len(), 2, "both writable accounts settled");
+        assert_eq!(
+            budget.available(),
+            1,
+            "the received batch returned its weight"
+        );
+        shutdown.cancel();
+    }
+
     /// The finding itself: unguarded, the settler drains forever and one tick can
     /// bind an unbounded array. Guarded, the channel backs up and parks the
     /// executor instead, so a full channel here means the fix is working.
@@ -1853,7 +1955,7 @@ mod tests {
         let mut blocked = false;
         for _ in 0..64 {
             let (output, txs) = sized_settle_batch(batch_bytes);
-            match exec_tx.try_send((output, txs, 1)) {
+            match exec_tx.try_send(batch_of(output, txs, 1)) {
                 Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     blocked = true;
@@ -1883,9 +1985,12 @@ mod tests {
         let mut delivered = 0;
         for _ in 0..12 {
             let (output, txs) = sized_settle_batch(batch_bytes);
-            if tokio::time::timeout(Duration::from_secs(10), exec_tx.send((output, txs, 1)))
-                .await
-                .is_ok()
+            if tokio::time::timeout(
+                Duration::from_secs(10),
+                exec_tx.send(batch_of(output, txs, 1)),
+            )
+            .await
+            .is_ok()
             {
                 delivered += 1;
             }
@@ -1927,7 +2032,7 @@ mod tests {
         let feeder = tokio::spawn(async move {
             for _ in 0..16 {
                 let (output, txs) = sized_settle_batch(batch_bytes);
-                if exec_tx.send((output, txs, 1)).await.is_err() {
+                if exec_tx.send(batch_of(output, txs, 1)).await.is_err() {
                     break;
                 }
             }
@@ -1973,7 +2078,7 @@ mod tests {
         let mut blocked = false;
         for _ in 0..64 {
             let (output, txs) = failed_sized_settle_batch(batch_bytes);
-            match exec_tx.try_send((output, txs, 1)) {
+            match exec_tx.try_send(batch_of(output, txs, 1)) {
                 Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     blocked = true;
@@ -2008,7 +2113,7 @@ mod tests {
 
         for _ in 0..20 {
             let (output, txs) = sized_settle_batch(128);
-            exec_tx.send((output, txs, 1)).await.unwrap();
+            exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         }
         let settled = tokio::time::timeout(Duration::from_secs(10), settled_rx.recv()).await;
         assert!(settled.is_ok(), "ordinary traffic must settle");
@@ -2035,11 +2140,11 @@ mod tests {
 
         // Generation 1 saturates the buffer on its own.
         let (output, txs) = sized_settle_batch(MAX_BUFFERED_SETTLE_BYTES + 4096);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         // Generation 2 cannot be drained while the guard is shut.
         let (output2, txs2) = sized_settle_batch(4096);
-        let _ = exec_tx.try_send((output2, txs2, 2));
+        let _ = exec_tx.try_send(batch_of(output2, txs2, 2));
 
         let settlements = tokio::time::timeout(Duration::from_secs(10), settled_rx.recv())
             .await
@@ -2087,7 +2192,7 @@ mod tests {
         let feeder = tokio::spawn(async move {
             loop {
                 let (output, txs) = sized_settle_batch(MAX_BUFFERED_SETTLE_BYTES / 2);
-                if exec_tx.send((output, txs, 1)).await.is_err() {
+                if exec_tx.send(batch_of(output, txs, 1)).await.is_err() {
                     break;
                 }
             }
@@ -2120,7 +2225,7 @@ mod tests {
             settler_under_test(url, 60_000, 1, Arc::new(NoopMetrics), shutdown.clone()).await;
 
         let (output, txs) = sized_settle_batch(MAX_BUFFERED_SETTLE_BYTES + 4096);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         tokio::time::sleep(Duration::from_millis(300)).await;
 
         drop(exec_tx);
@@ -2147,7 +2252,7 @@ mod tests {
         let tip = block_slots_above_tip(&pool).await;
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(600)).await;
         unblock_slots(&pool).await;
@@ -2178,7 +2283,7 @@ mod tests {
         let tip = block_slots_above_tip(&pool).await;
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         // Held long enough that a timestamp sampled at the winning attempt
         // would be several seconds later than one pinned at the first.
@@ -2263,7 +2368,7 @@ mod tests {
         block_slots_above_tip(&pool).await;
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         // Past the stage progress margin, so a frozen verdict would still read healthy.
         tokio::time::sleep(Duration::from_secs(8)).await;
@@ -2292,7 +2397,7 @@ mod tests {
         block_slots_above_tip(&pool).await;
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         tokio::time::sleep(Duration::from_millis(400)).await;
 
         let t0 = tokio::time::Instant::now();
@@ -2332,7 +2437,7 @@ mod tests {
             .expect("lock blocks");
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         let t0 = tokio::time::Instant::now();
         let exited = tokio::time::timeout(Duration::from_secs(60), handle.handle).await;
@@ -2368,7 +2473,7 @@ mod tests {
         let tip = block_slots_above_tip(&pool).await;
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         tokio::time::sleep(Duration::from_millis(400)).await;
 
         // Cancel while it is retrying, then let the failure clear well inside
@@ -2412,7 +2517,7 @@ mod tests {
         block_slots_above_tip(&pool).await;
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         tokio::time::sleep(Duration::from_millis(400)).await;
 
         let t0 = tokio::time::Instant::now();
@@ -2449,7 +2554,7 @@ mod tests {
             .expect("lock blocks");
 
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         // Long enough that an attempt is in flight, short enough that its own
         // timeout has not fired.
         tokio::time::sleep(Duration::from_millis(300)).await;
@@ -2478,12 +2583,12 @@ mod tests {
         // Capacity one, so the second sender parks exactly as the executor does.
         let (tx, mut rx) = mpsc::channel::<ExecutedBatch>(1);
         let (output, txs) = sized_settle_batch(1024);
-        tx.send((output, txs, 1)).await.unwrap();
+        tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         let parked_tx = tx.clone();
         let parked = tokio::spawn(async move {
             let (output, txs) = sized_settle_batch(1024);
-            parked_tx.send((output, txs, 2)).await.is_ok()
+            parked_tx.send(batch_of(output, txs, 2)).await.is_ok()
         });
         tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -2501,7 +2606,7 @@ mod tests {
 
         let (output, txs) = sized_settle_batch(1024);
         assert!(
-            tx.send((output, txs, 3)).await.is_err(),
+            tx.send(batch_of(output, txs, 3)).await.is_err(),
             "the queue must be closed once the buffer is discarded, not merely emptied"
         );
     }
@@ -2528,12 +2633,12 @@ mod tests {
 
         // Buffered before the tick that fails.
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
 
         // Queued while the settler is retrying and therefore not draining.
         tokio::time::sleep(Duration::from_millis(500)).await;
         let (output, txs) = sized_settle_batch(1024);
-        exec_tx.send((output, txs, 2)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 2)).await.unwrap();
 
         let exited = tokio::time::timeout(Duration::from_secs(40), handle.handle).await;
         assert!(
@@ -2593,7 +2698,7 @@ mod tests {
         assert!(await_block(&pool, 0, Duration::from_secs(10)).await);
         for _ in 0..4 {
             let (output, txs) = sized_settle_batch(1024);
-            exec_tx.send((output, txs, 1)).await.unwrap();
+            exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
             tokio::time::sleep(Duration::from_millis(150)).await;
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -3591,7 +3696,7 @@ mod tests {
         // commit it rather than the stage exiting on the signal and dropping it.
         let (output, txs) = sized_settle_batch(1024);
         let landed = *txs[0].signature();
-        exec_tx.send((output, txs, 1)).await.unwrap();
+        exec_tx.send(batch_of(output, txs, 1)).await.unwrap();
         drop(exec_tx);
 
         let result = tokio::time::timeout(Duration::from_secs(15), handle.handle).await;
@@ -3649,7 +3754,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx], 1)).await.unwrap();
+        exec_tx.send(batch_of(output, vec![tx], 1)).await.unwrap();
 
         // Wait for the blocktime tick to process and emit settlements
         let settlements =
@@ -3703,7 +3808,10 @@ mod tests {
         // Buffered well before the first tick, which waits out the start delay,
         // so the tick that finds dedup gone has a batch to commit.
         let (output, transactions) = one_account_batch();
-        exec_tx.send((output, transactions, 1)).await.unwrap();
+        exec_tx
+            .send(batch_of(output, transactions, 1))
+            .await
+            .unwrap();
 
         tokio::time::timeout(Duration::from_secs(10), worker.handle)
             .await
@@ -3791,7 +3899,10 @@ mod tests {
         .await;
 
         let (output, transactions) = one_account_batch();
-        exec_tx.send((output, transactions, 7)).await.unwrap();
+        exec_tx
+            .send(batch_of(output, transactions, 7))
+            .await
+            .unwrap();
 
         let settlements = recv_nonempty_settlements(&mut settled_accounts_rx).await;
         assert_eq!(
@@ -3833,9 +3944,15 @@ mod tests {
         .await;
 
         let (output_a, transactions_a) = one_account_batch();
-        exec_tx.send((output_a, transactions_a, 9)).await.unwrap();
+        exec_tx
+            .send(batch_of(output_a, transactions_a, 9))
+            .await
+            .unwrap();
         let (output_b, transactions_b) = one_account_batch();
-        exec_tx.send((output_b, transactions_b, 7)).await.unwrap();
+        exec_tx
+            .send(batch_of(output_b, transactions_b, 7))
+            .await
+            .unwrap();
 
         let settlements = recv_nonempty_settlements(&mut settled_accounts_rx).await;
         assert_eq!(
@@ -4840,6 +4957,7 @@ mod tests {
                     blockhashes: &blockhashes_tx,
                     accounts: &accounts_tx,
                     address_signatures: &address_signatures_tx,
+                    rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
                 }),
                 0,
                 settle_now(),
@@ -4931,6 +5049,7 @@ mod tests {
                     blockhashes: &blockhashes_tx,
                     accounts: &accounts_tx,
                     address_signatures: &address_signatures_tx,
+                    rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
                 }),
                 generation,
                 settle_now(),
@@ -6064,7 +6183,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx], 1)).await.unwrap();
+        exec_tx.send(batch_of(output, vec![tx], 1)).await.unwrap();
 
         // Poll for perf sample with deadline instead of fixed sleep.
         // Perf tick fires after ~1s; poll every 100ms for up to 5s.
@@ -6131,7 +6250,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx], 1)).await.unwrap();
+        exec_tx.send(batch_of(output, vec![tx], 1)).await.unwrap();
 
         let result = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
         assert!(
@@ -6156,6 +6275,128 @@ mod tests {
         vec![(Ok(processed), tx)]
     }
 
+    /// Rows, not messages, are what the settler waits on. A block whose rows
+    /// exceed the whole budget still passes, taking all of it, and the writer
+    /// hands the rows back by taking the message.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_block_takes_its_rows_from_the_row_budget() {
+        let (db, _pg) = start_test_postgres().await;
+        let mut db = db;
+
+        // One row per account key, so three against a budget of two.
+        let budget = WeightBudget::new(2);
+        let (addr_sig_tx, mut addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(4);
+        let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
+        let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
+
+        let results = single_successful_transfer();
+        let last = LastBlock {
+            slot: 5,
+            blockhash: Hash::new_unique(),
+            block_height: 5,
+        };
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+        let result = settle_transactions(
+            last.slot + 1,
+            Some(last),
+            &mut db,
+            None,
+            &results,
+            &metrics,
+            Some(BlockPublishers {
+                blockhashes: &settled_blockhashes_tx,
+                accounts: &settled_accounts_tx,
+                address_signatures: &addr_sig_tx,
+                rows_budget: &budget,
+            }),
+            0,
+            settle_now(),
+            SETTLE_ATTEMPT_TIMEOUT,
+        )
+        .await;
+
+        assert!(result.is_ok(), "a block over the budget must still pass");
+        assert_eq!(budget.available(), 0, "an oversized block takes all of it");
+
+        let queued = addr_sig_rx.recv().await.expect("rows queued");
+        assert_eq!(queued.rows.len(), 3, "every account key is indexed");
+        drop(queued);
+        assert_eq!(budget.available(), 2, "taking the message returns the rows");
+    }
+
+    /// The row budget parks the settler even with queue slots to spare, and
+    /// only the writer taking a batch lets it go on.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_spent_row_budget_parks_the_settler_until_a_batch_is_taken() {
+        let (db, _pg) = start_test_postgres().await;
+        let mut db = db;
+
+        // Slots to spare: the budget, held by the queued batch, is the limit.
+        let (addr_sig_tx, mut addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(4);
+        let results = single_successful_transfer();
+        let last = LastBlock {
+            slot: 5,
+            blockhash: Hash::new_unique(),
+            block_height: 5,
+        };
+
+        let task = tokio::spawn(async move {
+            let budget = WeightBudget::new(1);
+            let permit = budget.acquire(1, &addr_sig_tx).await.expect("permit");
+            addr_sig_tx
+                .send(AddressSignatureBatch {
+                    rows: Vec::new(),
+                    permit,
+                })
+                .await
+                .unwrap();
+
+            let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
+            let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
+            let metrics: SharedMetrics = Arc::new(NoopMetrics);
+            let r = settle_transactions(
+                last.slot + 1,
+                Some(last),
+                &mut db,
+                None,
+                &results,
+                &metrics,
+                Some(BlockPublishers {
+                    blockhashes: &settled_blockhashes_tx,
+                    accounts: &settled_accounts_tx,
+                    address_signatures: &addr_sig_tx,
+                    rows_budget: &budget,
+                }),
+                0,
+                settle_now(),
+                SETTLE_ATTEMPT_TIMEOUT,
+            )
+            .await;
+            (r, db)
+        });
+
+        // The prefill holds the only permit, so the block cannot hand over.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(
+            !task.is_finished(),
+            "the settler must wait on the row budget"
+        );
+        assert_eq!(addr_sig_rx.len(), 1, "queue depth was never the limit");
+
+        drop(addr_sig_rx.recv().await.expect("prefill"));
+        let rows = tokio::time::timeout(Duration::from_secs(5), addr_sig_rx.recv())
+            .await
+            .expect("the freed rows must unpark the settler")
+            .expect("addr-index channel open");
+        assert_eq!(rows.rows.len(), 3);
+
+        let (result, _db) = tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("settle task completes")
+            .expect("settle task joins");
+        assert!(result.is_ok(), "settle returns Ok once the rows are taken");
+    }
+
     /// The regression test. A blocked-yet-open address-index send must NOT
     /// gate the admission broadcasts: both the settled accounts and the new
     /// blockhash have to reach their consumers while the settler is still parked
@@ -6167,8 +6408,8 @@ mod tests {
         let mut db = db;
 
         // capacity-1 channel pre-filled so the in-function send blocks.
-        let (addr_sig_tx, mut addr_sig_rx) = mpsc::channel::<Vec<AddressSignatureRow>>(1);
-        addr_sig_tx.send(Vec::new()).await.unwrap();
+        let (addr_sig_tx, mut addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(1);
+        addr_sig_tx.send(rows_msg(Vec::new())).await.unwrap();
 
         let (settled_accounts_tx, mut settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, mut settled_blockhashes_rx) = mpsc::unbounded_channel();
@@ -6194,6 +6435,7 @@ mod tests {
                     blockhashes: &settled_blockhashes_tx,
                     accounts: &settled_accounts_tx,
                     address_signatures: &addr_sig_tx,
+                    rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
                 }),
                 0,
                 settle_now(),
@@ -6241,7 +6483,7 @@ mod tests {
     async fn broadcasts_with_empty_address_signatures() {
         let (mut db, _pg) = start_test_postgres().await;
 
-        let (addr_sig_tx, _addr_sig_rx) = mpsc::channel::<Vec<AddressSignatureRow>>(1);
+        let (addr_sig_tx, _addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(1);
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, mut settled_blockhashes_rx) = mpsc::unbounded_channel();
 
@@ -6261,6 +6503,7 @@ mod tests {
                 blockhashes: &settled_blockhashes_tx,
                 accounts: &settled_accounts_tx,
                 address_signatures: &addr_sig_tx,
+                rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
             }),
             0,
             settle_now(),
@@ -6284,7 +6527,7 @@ mod tests {
 
         let (settled_accounts_tx, settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, settled_blockhashes_rx) = mpsc::unbounded_channel();
-        let (addr_sig_tx, _addr_sig_rx) = mpsc::channel::<Vec<AddressSignatureRow>>(1);
+        let (addr_sig_tx, _addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(1);
         // Drop both consumers before calling.
         drop(settled_accounts_rx);
         drop(settled_blockhashes_rx);
@@ -6301,6 +6544,7 @@ mod tests {
                 blockhashes: &settled_blockhashes_tx,
                 accounts: &settled_accounts_tx,
                 address_signatures: &addr_sig_tx,
+                rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
             }),
             0,
             settle_now(),
@@ -6330,7 +6574,7 @@ mod tests {
 
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, mut settled_blockhashes_rx) = mpsc::unbounded_channel();
-        let (addr_sig_tx, _addr_sig_rx) = mpsc::channel::<Vec<AddressSignatureRow>>(1);
+        let (addr_sig_tx, _addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(1);
 
         settle_transactions(
             0,
@@ -6343,6 +6587,7 @@ mod tests {
                 blockhashes: &settled_blockhashes_tx,
                 accounts: &settled_accounts_tx,
                 address_signatures: &addr_sig_tx,
+                rows_budget: &WeightBudget::new(MAX_QUEUED_ADDRESS_ROWS),
             }),
             0,
             settle_now(),
@@ -6366,7 +6611,7 @@ mod tests {
     /// empty blocks (no rows) pass through untouched.
     struct WiredPipeline {
         exec_tx: mpsc::Sender<ExecutedBatch>,
-        addr_sig_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
+        addr_sig_rx: mpsc::Receiver<AddressSignatureBatch>,
         live_blockhashes: Arc<std::sync::RwLock<std::collections::LinkedList<Hash>>>,
         shutdown: CancellationToken,
         _settle: WorkerHandle,
@@ -6387,8 +6632,11 @@ mod tests {
         let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, settled_blockhashes_rx) = mpsc::unbounded_channel();
-        let (address_signatures_tx, addr_sig_rx) = mpsc::channel::<Vec<AddressSignatureRow>>(1);
-        address_signatures_tx.send(Vec::new()).await.unwrap();
+        let (address_signatures_tx, addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(1);
+        address_signatures_tx
+            .send(rows_msg(Vec::new()))
+            .await
+            .unwrap();
 
         let shutdown = CancellationToken::new();
         let _settle = start_settle_worker(SettleArgs {
@@ -6479,7 +6727,7 @@ mod tests {
         let (_exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, mut settled_blockhashes_rx) = mpsc::unbounded_channel();
-        let (address_signatures_tx, _addr_sig_rx) = mpsc::channel::<Vec<AddressSignatureRow>>(64);
+        let (address_signatures_tx, _addr_sig_rx) = mpsc::channel::<AddressSignatureBatch>(64);
 
         let shutdown = CancellationToken::new();
         let _settle = start_settle_worker(SettleArgs {
@@ -6678,7 +6926,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        p.exec_tx.send((output, vec![tx], 1)).await.unwrap();
+        p.exec_tx.send(batch_of(output, vec![tx], 1)).await.unwrap();
 
         wait_for_window(
             &p.live_blockhashes,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -20,7 +20,7 @@ Reference for configuring, tuning, and operating Solana Private Channels service
 | `--sigverify-queue-size` | `PRIVATE_CHANNEL_SIGVERIFY_QUEUE_SIZE` | `1000` | Bounded queue between dedup and sigverify |
 | `--ingress-queue-capacity` | `PRIVATE_CHANNEL_INGRESS_QUEUE_CAPACITY` | `10000` | Bounded RPC→dedup queue; a full queue sheds (`sendTransaction` returns `-32003`, retryable) and increments `rpc_ingress_shed_total` |
 | `--sequencer-queue-capacity` | `PRIVATE_CHANNEL_SEQUENCER_QUEUE_CAPACITY` | `1000` | Bounded sigverify→sequencer queue; a full queue applies upstream backpressure |
-| `--execution-results-capacity` | `PRIVATE_CHANNEL_EXECUTION_RESULTS_CAPACITY` | `1000` | Bounded executor→settler queue; a full queue applies upstream backpressure. The settler also stops draining once a tick's buffered account bytes reach an internal budget, so the queue is bounded by bytes as well as depth |
+| `--execution-results-capacity` | `PRIVATE_CHANNEL_EXECUTION_RESULTS_CAPACITY` | `1000` | Bounded queue from the executor to the settler; a full queue applies upstream backpressure. Also bounded by an internal in-flight byte budget, and the settler stops draining once a tick's buffered account bytes reach a budget of their own |
 | `--max-tx-per-batch` | `PRIVATE_CHANNEL_MAX_TX_PER_BATCH` | `64` | Max transactions per sequencer batch |
 | `--max-connections` | `PRIVATE_CHANNEL_MAX_CONNECTIONS` | `100` | Max concurrent RPC connections |
 | `--blocktime-ms` | `PRIVATE_CHANNEL_BLOCKTIME_MS` | `100` | Tick interval (ms). A block is produced only when the tick carried transactions or the 1s idle heartbeat came due, and the slot it lands on counts every tick since the last block |

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -152,7 +152,9 @@ The mirror is best-effort and covers only what the cache can serve: point lookup
 
 The settler also caps the settled account bytes it buffers between ticks. Once a tick's buffer reaches that budget it stops draining the executor queue, so the executor's bounded send applies backpressure upstream rather than letting one commit grow without limit. Blocks are still produced only on the tick, never early, and the executor splits an oversized batch into byte-bounded messages so a single already-executed batch cannot overshoot the budget. The commit itself binds each column as one array parameter, so bounding the buffer is what bounds the bind; the driver is held at sqlx 0.8 or later, where an oversized bind fails loudly instead of being truncated by the binary protocol's length prefix.
 
-Finally, the settler notifies the executor's in-memory cache (BOB) of settled accounts, completing the feedback loop.
+Both queues either side of the settler are bounded by the account bytes and index rows their messages carry, not only by how many messages are queued. The executor holds a byte budget for the results it has sent but the settler has not yet received, sized at two of its own chunks, and the settler holds a row budget for the address-index rows it has handed to the background writer but the writer has not yet folded into a flush. In each case the budget travels inside the message and comes back when the message is consumed or dropped, so no consumer has to account for it.
+
+Finally, the settler notifies the executor's in-memory cache (BOB) of settled accounts, completing the feedback loop. That acknowledgement is deliberately unbounded: BOB drains it only while the executor runs and the executor runs only while the settler drains, so a blocking send would deadlock the three stages. It shares the account buffers BOB is already pinning rather than copying them, so its depth costs metadata, not account data.
 
 **Location**: [`core/src/stages/settle.rs`](../core/src/stages/settle.rs)
 


### PR DESCRIPTION
Every write-pipeline queue is now limited by both message count and message size. This prevents queues from holding too much data—for example, the results queue could previously hold 1000 × 64 MB messages, and the address-index queue could hold 1024 blocks with unlimited rows.

Each message now carries a weight that represents how much data it retains. A semaphore controls this weight, and the permit is automatically released when the message is dropped. The executor→settler queue is limited to 128 MB of account data, while settler→writer is limited to 512,000 rows.

The existing message-count limits remain as an additional safeguard. Feedback channels to BOB and dedup remain unbounded because limiting them could cause a deadlock.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 22,382 | 24,246 | 92.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34481511923) |
| Indexer | 39,375 | 43,625 | 90.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34481511923) |
| Gateway | 1,662 | 1,957 | 84.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34481511923) |
| Auth | 1,762 | 1,982 | 88.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34481511923) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | 16,585 | 22,052 | 75.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/34481511923) |
| **Total** | **81,766** | **93,862** | **87.1%** | |

> Last updated: 2026-09-10 14:14:25 UTC by E2E Integration