### PR TITLE
fix(monitoring): Attribute alerts to a deployment and apply prometheus config changes

### DIFF
--- a/monitoring/prometheus.yml.j2
+++ b/monitoring/prometheus.yml.j2
@@ -12,6 +12,12 @@ global:
   scrape_interval: 10s
   scrape_timeout: 5s
   evaluation_interval: 15s
+  # Every deployment posts to the same Slack channel, and the job names are
+  # identical across them, so an alert without this is unattributable. Named
+  # `deployment` because the scrape configs below already pin a `stack` target
+  # label, and a target label shadows an external one.
+  external_labels:
+    deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"
 
 scrape_configs:
 
@@ -78,24 +84,28 @@ scrape_configs:
       - targets: ['indexer-solana:9100']
         labels:
           stack: private-channel
+          deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"
 
   - job_name: private-channel-indexer-private-channel
     static_configs:
       - targets: ['indexer-private-channel:9100']
         labels:
           stack: private-channel
+          deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"
 
   - job_name: private-channel-operator-solana
     static_configs:
       - targets: ['operator-solana:9102']
         labels:
           stack: private-channel
+          deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"
 
   - job_name: private-channel-operator-private-channel
     static_configs:
       - targets: ['operator-private-channel:9103']
         labels:
           stack: private-channel
+          deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"
 
   # ── Solana Private Channels write/read node /metrics (only when the node is run
   # with --metrics / PRIVATE_CHANNEL_METRICS=true; otherwise these targets show
@@ -108,6 +118,7 @@ scrape_configs:
           - 'read-node:9090'
         labels:
           stack: private-channel
+          deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"
 
   # ── Gateway /metrics. The gateway always serves metrics (no flag) on
   # METRICS_PORT, default 9101. The RPC dashboard filters on job="gateway".
@@ -117,3 +128,4 @@ scrape_configs:
           - 'gateway:9101'
         labels:
           stack: private-channel
+          deployment: "{{ env | default(group_names | difference(['all']) | first | default('dev')) }}"

--- a/monitoring/provisioning/alerting/alert-rules.yml
+++ b/monitoring/provisioning/alerting/alert-rules.yml
@@ -250,7 +250,7 @@ groups:
         noDataState: OK
         execErrState: Error
         annotations:
-          summary: "Feepayer {{ $labels.job }} ({{ $labels.program_type }}) balance is {{ $values.A }} SOL — schedule a top-up"
+          summary: "[{{ $labels.deployment }}] feepayer {{ $labels.job }} ({{ $labels.program_type }}) balance is {{ $values.A }} SOL — schedule a top-up. The wallet is admin_keypair_path in private-channel-deploy/vars/{{ $labels.deployment }}.yml"
         labels:
           severity: warning
         data:
@@ -284,7 +284,7 @@ groups:
         noDataState: OK
         execErrState: Error
         annotations:
-          summary: "Feepayer {{ $labels.job }} ({{ $labels.program_type }}) balance is {{ $values.A }} SOL — top up immediately"
+          summary: "[{{ $labels.deployment }}] feepayer {{ $labels.job }} ({{ $labels.program_type }}) balance is {{ $values.A }} SOL — top up immediately. The wallet is admin_keypair_path in private-channel-deploy/vars/{{ $labels.deployment }}.yml"
         labels:
           severity: critical
         data:

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -1236,6 +1236,7 @@
         src: "{{ repo_root }}/monitoring/prometheus.yml.j2"
         dest: "{{ monitoring_dir }}/prometheus/prometheus.yml"
         mode: "0644"
+      register: _prom_cfg
 
     - name: Copy blackbox.yml
       ansible.builtin.copy:
@@ -1252,6 +1253,7 @@
         dest: "{{ monitoring_dir }}/grafana/provisioning/"
         mode: "0644"
         directory_mode: "0755"
+      register: _graf_cfg
 
     - name: Copy bundled dashboard JSONs
       ansible.builtin.copy:
@@ -1264,6 +1266,21 @@
       ansible.builtin.shell: "{{ mon_compose_cmd }} up -d --wait"
       changed_when: true
       register: _mon_up
+
+    # prometheus.yml is bind-mounted as a single file, so a running container
+    # holds the inode it started with. `template` writes a temp file and
+    # renames it into place, allocating a new inode, and the container keeps
+    # reading the old one. `up -d --wait` above does not recreate a container
+    # whose spec is unchanged, and /-/reload then returns 200 having reloaded
+    # the stale file, so a scrape-config or label change silently never takes
+    # effect. Grafana reads its provisioning tree only at startup, so alert
+    # rule edits need the same treatment.
+    - name: Restart monitoring services whose config changed
+      ansible.builtin.shell: "{{ mon_compose_cmd }} restart {{ _mon_restart | join(' ') }}"
+      vars:
+        _mon_restart: "{{ (['prometheus'] if _prom_cfg.changed else []) + (['grafana'] if _graf_cfg.changed else []) }}"
+      when: _mon_restart | length > 0
+      changed_when: true
 
     - name: Verify Prometheus is ready
       ansible.builtin.uri:


### PR DESCRIPTION
Two fixes that belong together, because the second is why the first looked like it wasn't working.

## Alerts can't be attributed to a deployment

Every stack posts to the same Slack channel with identical job names, so a feepayer alert named neither the deployment nor the wallet:

> Feepayer private-channel-operator-solana (escrow) balance is 0.99 SOL, schedule a top-up

Adds a `deployment` label, taken from the inventory group, to each scrape job and to `external_labels`, and names it in both feepayer summaries along with where the wallet is configured:

> [spc001] feepayer private-channel-operator-solana (escrow) balance is 0.99 SOL, schedule a top-up. The wallet is admin_keypair_path in private-channel-deploy/vars/spc001.yml

Two things worth knowing about the choices:

- It is `deployment` and not `stack` because the scrape configs already pin `stack: private-channel`, and a target label shadows an external one.
- It is set per target as well as in `external_labels`, because these are Grafana-managed rules evaluated through the query API, which never returns external labels. `external_labels` alone covers only the Prometheus-native alerting path.

## Prometheus config changes silently never applied

`prometheus.yml` is bind-mounted as a single file, so a running container holds the inode it started with. `template` writes a temp file and renames it into place, which allocates a new inode, and the container keeps reading the old one. `up -d --wait` does not recreate a container whose spec is unchanged, and `/-/reload` then returns 200 having faithfully reloaded the stale file.

The result is that a scrape-config or label edit reports success at every step and has no effect. Grafana reads its provisioning tree only at startup and had the same problem for alert rules. Both now restart when their own config changed.

## Reproduction

On a devnet stack running before this change, append a marker to `monitoring/prometheus.yml.j2` and run the monitoring phase:

```
$ ansible-playbook deploy.yml -l <env> --tags monitoring     # reports changed, no failures
$ grep -c MARKER /opt/private-channel/monitoring/prometheus/prometheus.yml
1
$ docker exec private-channel-mon-prometheus grep -c MARKER /etc/prometheus/prometheus.yml
0
```

With the change, the same sequence gives `1` inside the container.

Verified on two devnet stacks. Feepayer series now come back carrying `deployment=spc001` and `deployment=demo`, and the config marker propagates.

## Note for operators

Because config edits have been no-ops, there may be pending changes on existing boxes that have never actually taken effect. The next monitoring deploy will apply them for real.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...