### PR TITLE
chore(deploy): Ignore per-environment secrets, vars and inventories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ indexer/config/devnet/
 # Test coverage
 coverage/
 coverage-*.lcov
+
+# Local audit findings exports (Cantina / OtterSec), not part of the repo.
+cantina_findings*.json
+cantina_severity_downgrade_requests*.csv
+*findings-export-*.json

--- a/private-channel-deploy/.gitignore
+++ b/private-channel-deploy/.gitignore
@@ -6,9 +6,20 @@ ansible.log
 *.retry
 .ansible/
 
-# Plain-text secrets file — must never be committed. See README "Future
+# Plain-text secrets files — must never be committed. See README "Future
 # improvements" for the SOPS upgrade path that lets this go in git encrypted.
+# The glob matters: real deployments use per-environment files (sdp-secrets.yml,
+# spc001-secrets.yml) that the bare `secrets.yml` rule never covered.
 secrets.yml
+*-secrets.yml
+
+# Per-environment vars and inventories carry host IPs, escrow instance ids and
+# keypair paths for stacks that are not the reference ones. common.yml and
+# dev.yml are the tracked references; inventory.ini is the tracked placeholder.
+vars/*.yml
+!vars/common.yml
+!vars/dev.yml
+inventory.*.ini
 
 # Reserved for the SOPS upgrade. Keys must never live in the repo.
 age.key


### PR DESCRIPTION
The ignore rule in `private-channel-deploy/` is the bare filename `secrets.yml`, but real deployments use per-environment files. These have all been sitting untracked and unignored:

```
private-channel-deploy/sdp-secrets.yml
private-channel-deploy/audit-secrets.yml
private-channel-deploy/spc001-secrets.yml
private-channel-deploy/demo-secrets.yml
private-channel-deploy/vars/{sdp,audit,spc001,demo}.yml
private-channel-deploy/inventory.{spc001,demo}.ini
```

A single `git add -A` commits postgres and replication passwords, a JWT signing secret, a Grafana admin password, a GHCR token, the RPC URL with its token in the path, the Yellowstone token and a Slack webhook to a public repo.

**Nothing has leaked.** I verified across every ref: no secrets file, vars file, inventory or keypair has ever been added in any commit, and scanning the pushed branches for the values themselves (`gho_`, `hooks.slack.com/services/…`, tokenised `rpcpool.com` URLs) returns nothing. This closes the gap before something does.

Verified with `git check-ignore` against the real files on a machine that has them:

| Path | Result |
| --- | --- |
| `*-secrets.yml` (four of them) | ignored |
| `vars/spc001.yml`, `vars/demo.yml` | ignored |
| `inventory.spc001.ini` | ignored |
| `vars/common.yml`, `vars/dev.yml` | tracked, still visible |
| `inventory.ini`, `secrets.yml.example` | tracked, still visible |

Also ignores the Cantina and OtterSec findings exports that land at the repo root during audit review. Same reason: local working files that `git add -A` picks up.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...